### PR TITLE
Use low-level controller and handlers in SetupWithManager

### DIFF
--- a/cmd/tf-operator.v1/app/options/options.go
+++ b/cmd/tf-operator.v1/app/options/options.go
@@ -51,7 +51,7 @@ func NewServerOption() *ServerOption {
 
 // AddFlags adds flags for a specific CMServer to the specified FlagSet.
 func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
-	fs.StringVar(&s.Kubeconfig, "kubeconfig", "", "The path of kubeconfig file")
+	//fs.StringVar(&s.Kubeconfig, "kubeconfig", "", "The path of kubeconfig file")
 
 	fs.StringVar(&s.MasterURL, "master", "",
 		`The url of the Kubernetes API server,

--- a/pkg/apis/xgboost/validation/validation.go
+++ b/pkg/apis/xgboost/validation/validation.go
@@ -1,0 +1,81 @@
+// Copyright 2021 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"fmt"
+
+	xgboostv1 "github.com/kubeflow/tf-operator/pkg/apis/xgboost/v1"
+
+	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
+
+	torchv1 "github.com/kubeflow/tf-operator/pkg/apis/pytorch/v1"
+)
+
+func ValidateV1XGBoostJobSpec(c *xgboostv1.XGBoostJobSpec) error {
+	if c.XGBReplicaSpecs == nil {
+		return fmt.Errorf("XGBoostJobSpec is not valid")
+	}
+	masterExists := false
+	for rType, value := range c.XGBReplicaSpecs {
+		if value == nil || len(value.Template.Spec.Containers) == 0 {
+			return fmt.Errorf("XGBoostJobSpec is not valid: containers definition expected in %v", rType)
+		}
+		// Make sure the replica type is valid.
+		validReplicaTypes := []commonv1.ReplicaType{xgboostv1.XGBoostReplicaTypeMaster, xgboostv1.XGBoostReplicaTypeWorker}
+
+		isValidReplicaType := false
+		for _, t := range validReplicaTypes {
+			if t == rType {
+				isValidReplicaType = true
+				break
+			}
+		}
+
+		if !isValidReplicaType {
+			return fmt.Errorf("XGBoostReplicaType is %v but must be one of %v", rType, validReplicaTypes)
+		}
+
+		//Make sure the image is defined in the container
+		defaultContainerPresent := false
+		for _, container := range value.Template.Spec.Containers {
+			if container.Image == "" {
+				msg := fmt.Sprintf("XGBoostReplicaType is not valid: Image is undefined in the container of %v", rType)
+				return fmt.Errorf(msg)
+			}
+			if container.Name == xgboostv1.DefaultContainerName {
+				defaultContainerPresent = true
+			}
+		}
+		//Make sure there has at least one container named "pytorch"
+		if !defaultContainerPresent {
+			msg := fmt.Sprintf("XGBoostReplicaType is not valid: There is no container named %s in %v", torchv1.DefaultContainerName, rType)
+			return fmt.Errorf(msg)
+		}
+		if rType == xgboostv1.XGBoostReplicaTypeMaster {
+			masterExists = true
+			if value.Replicas != nil && int(*value.Replicas) != 1 {
+				return fmt.Errorf("XGBoostReplicaType is not valid: There must be only 1 master replica")
+			}
+		}
+
+	}
+
+	if !masterExists {
+		return fmt.Errorf("XGBoostReplicaType is not valid: Master ReplicaSpec must be present")
+	}
+	return nil
+
+}

--- a/pkg/apis/xgboost/validation/validation_test.go
+++ b/pkg/apis/xgboost/validation/validation_test.go
@@ -1,0 +1,114 @@
+// Copyright 2021 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"testing"
+
+	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
+	xgboostv1 "github.com/kubeflow/tf-operator/pkg/apis/xgboost/v1"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestValidateV1XGBoostJobSpec(t *testing.T) {
+	testCases := []xgboostv1.XGBoostJobSpec{
+		{
+			XGBReplicaSpecs: nil,
+		},
+		{
+			XGBReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+				xgboostv1.XGBoostReplicaTypeWorker: &commonv1.ReplicaSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{},
+						},
+					},
+				},
+			},
+		},
+		{
+			XGBReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+				xgboostv1.XGBoostReplicaTypeWorker: &commonv1.ReplicaSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								v1.Container{
+									Image: "",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			XGBReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+				xgboostv1.XGBoostReplicaTypeWorker: &commonv1.ReplicaSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								v1.Container{
+									Name:  "",
+									Image: "gcr.io/kubeflow-ci/xgboost-dist-mnist_test:1.0",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			XGBReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+				xgboostv1.XGBoostReplicaTypeMaster: &commonv1.ReplicaSpec{
+					Replicas: xgboostv1.Int32(2),
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								v1.Container{
+									Name:  "xgboost",
+									Image: "gcr.io/kubeflow-ci/xgboost-dist-mnist_test:1.0",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			XGBReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+				xgboostv1.XGBoostReplicaTypeWorker: &commonv1.ReplicaSpec{
+					Replicas: xgboostv1.Int32(1),
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								v1.Container{
+									Name:  "xgboost",
+									Image: "gcr.io/kubeflow-ci/xgboost-dist-mnist_test:1.0",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, c := range testCases {
+		err := ValidateV1XGBoostJobSpec(&c)
+		if err == nil {
+			t.Error("Failed validate the v1.XGBoostJobSpec")
+		}
+	}
+}

--- a/pkg/common/util/reconciler.go
+++ b/pkg/common/util/reconciler.go
@@ -2,6 +2,13 @@ package util
 
 import (
 	"fmt"
+	"reflect"
+
+	"github.com/sirupsen/logrus"
+
+	commonutil "github.com/kubeflow/common/pkg/util"
+
+	"github.com/kubeflow/common/pkg/controller.v1/common"
 
 	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 	"github.com/kubeflow/common/pkg/controller.v1/expectation"
@@ -52,6 +59,72 @@ func OnDependentCreateFunc(exp expectation.ControllerExpectationsInterface) func
 
 		return true
 	}
+}
+
+// OnDependentUpdateFunc modify expectations when dependent (pod/service) update observed.
+func OnDependentUpdateFunc(jc *common.JobController) func(updateEvent event.UpdateEvent) bool {
+	return func(e event.UpdateEvent) bool {
+		newObj := e.ObjectNew
+		oldObj := e.ObjectOld
+		if newObj.GetResourceVersion() == oldObj.GetResourceVersion() {
+			// Periodic resync will send update events for all known pods.
+			// Two different versions of the same pod will always have different RVs.
+			return false
+		}
+
+		var logger *logrus.Entry
+		if _, ok := newObj.(*corev1.Pod); ok {
+			logger = commonutil.LoggerForPod(newObj.(*corev1.Pod), jc.Controller.GetAPIGroupVersionKind().Kind)
+		}
+
+		if _, ok := newObj.(*corev1.Service); ok {
+			logger = commonutil.LoggerForService(newObj.(*corev1.Service), jc.Controller.GetAPIGroupVersionKind().Kind)
+		}
+
+		newControllerRef := metav1.GetControllerOf(newObj)
+		oldControllerRef := metav1.GetControllerOf(oldObj)
+		controllerRefChanged := !reflect.DeepEqual(newControllerRef, oldControllerRef)
+
+		if controllerRefChanged && oldControllerRef != nil {
+			// The ControllerRef was changed. Sync the old controller, if any.
+			if job := resolveControllerRef(jc, oldObj.GetName(), oldControllerRef); job != nil {
+				logger.Infof("pod/service controller ref updated: %v, %v", newObj, oldObj)
+				return true
+			}
+		}
+
+		// If it has a controller ref, that's all that matters.
+		if newControllerRef != nil {
+			job := resolveControllerRef(jc, newObj.GetNamespace(), newControllerRef)
+			if job == nil {
+				return false
+			}
+			logger.Debugf("pod/service has a controller ref: %v, %v", newObj, oldObj)
+			return true
+		}
+		return false
+	}
+}
+
+// resolveControllerRef returns the job referenced by a ControllerRef,
+// or nil if the ControllerRef could not be resolved to a matching job
+// of the correct Kind.
+func resolveControllerRef(jc *common.JobController, namespace string, controllerRef *metav1.OwnerReference) metav1.Object {
+	// We can't look up by UID, so look up by Name and then verify UID.
+	// Don't even try to look up by Name if it's the wrong Kind.
+	if controllerRef.Kind != jc.Controller.GetAPIGroupVersionKind().Kind {
+		return nil
+	}
+	job, err := jc.Controller.GetJobFromInformerCache(namespace, controllerRef.Name)
+	if err != nil {
+		return nil
+	}
+	if job.GetUID() != controllerRef.UID {
+		// The controller we found with this Name is not the same one that the
+		// ControllerRef points to.
+		return nil
+	}
+	return job
 }
 
 // OnDependentDeleteFunc modify expectations when dependent (pod/service) deletion observed.

--- a/pkg/controller.v1/mxnet/mxjob_controller.go
+++ b/pkg/controller.v1/mxnet/mxjob_controller.go
@@ -19,6 +19,11 @@ import (
 	"fmt"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
 	"reflect"
 
 	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
@@ -127,7 +132,7 @@ func (r *MXJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	mxjob := &mxjobv1.MXJob{}
 	err := r.Get(ctx, req.NamespacedName, mxjob)
 	if err != nil {
-		logger.Info(err.Error(), "unable to fetch PyTorchJob", req.NamespacedName.String())
+		logger.Info(err.Error(), "unable to fetch MXJob", req.NamespacedName.String())
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -178,46 +183,46 @@ func (r *MXJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *MXJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// setup FieldIndexer to inform the manager that this controller owns pods and services,
-	// so that it will automatically call Reconcile on the underlying MXJob when a Pod or Service changes, is deleted, etc.
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, jobOwnerKey, func(rawObj client.Object) []string {
-		pod := rawObj.(*corev1.Pod)
-		owner := metav1.GetControllerOf(pod)
-		if owner == nil {
-			return nil
-		}
+	c, err := controller.New(r.ControllerName(), mgr, controller.Options{
+		Reconciler: r,
+	})
 
-		// Make sure owner is XGBoostJob Controller.
-		if owner.APIVersion != r.GetAPIGroupVersion().Version || owner.Kind != r.GetAPIGroupVersionKind().Kind {
-			return nil
-		}
+	if err != nil {
+		return err
+	}
 
-		return []string{owner.Name}
+	// using onOwnerCreateFunc is easier to set defaults
+	if err = c.Watch(&source.Kind{Type: &mxjobv1.MXJob{}}, &handler.EnqueueRequestForObject{},
+		predicate.Funcs{CreateFunc: onOwnerCreateFunc()},
+	); err != nil {
+		return err
+	}
+
+	// inject watching for job related pod
+	if err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &mxjobv1.MXJob{},
+	}, predicate.Funcs{
+		CreateFunc: util.OnDependentCreateFunc(r.Expectations),
+		UpdateFunc: util.OnDependentUpdateFunc(&r.JobController),
+		DeleteFunc: util.OnDependentDeleteFunc(r.Expectations),
 	}); err != nil {
 		return err
 	}
 
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Service{}, jobOwnerKey, func(rawObj client.Object) []string {
-		svc := rawObj.(*corev1.Service)
-		owner := metav1.GetControllerOf(svc)
-		if owner == nil {
-			return nil
-		}
-
-		if owner.APIVersion != r.GetAPIGroupVersion().Version || owner.Kind != r.GetAPIGroupVersionKind().Kind {
-			return nil
-		}
-
-		return []string{owner.Name}
+	// inject watching for job related service
+	if err = c.Watch(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &mxjobv1.MXJob{},
+	}, predicate.Funcs{
+		CreateFunc: util.OnDependentCreateFunc(r.Expectations),
+		UpdateFunc: util.OnDependentUpdateFunc(&r.JobController),
+		DeleteFunc: util.OnDependentDeleteFunc(r.Expectations),
 	}); err != nil {
 		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&mxjobv1.MXJob{}).
-		Owns(&corev1.Pod{}).
-		Owns(&corev1.Service{}).
-		Complete(r)
+	return nil
 }
 
 // Below is ControllerInterface's implementation

--- a/pkg/controller.v1/mxnet/mxjob_controller.go
+++ b/pkg/controller.v1/mxnet/mxjob_controller.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/kubeflow/tf-operator/pkg/apis/mxnet/validation"
+
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -136,7 +138,10 @@ func (r *MXJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	//mxjobv1.SetDefaults_MXJob(mxjob)
+	mxjobv1.SetDefaults_MXJob(mxjob)
+	if err = validation.ValidateV1MXJobSpec(&mxjob.Spec); err != nil {
+		logger.Info(err.Error(), "MXJob failed validation", req.NamespacedName.String())
+	}
 
 	// Check if reconciliation is needed
 	jobKey, err := common.KeyFunc(mxjob)

--- a/pkg/controller.v1/mxnet/mxjob_controller.go
+++ b/pkg/controller.v1/mxnet/mxjob_controller.go
@@ -422,7 +422,7 @@ func (r *MXJobReconciler) UpdateJobStatusInApiServer(job interface{}, jobStatus 
 		mxJob.Status = *jobStatus.DeepCopy()
 	}
 
-	if err := r.Update(context.Background(), mxJob); err != nil {
+	if err := r.Status().Update(context.Background(), mxJob); err != nil {
 		logrus.Error(err, " failed to update MxJob conditions in the API server")
 		return err
 	}

--- a/pkg/controller.v1/pytorch/pytorchjob_controller.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller.go
@@ -127,7 +127,6 @@ func (r *PyTorchJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		logger.Info(err.Error(), "unable to fetch PyTorchJob", req.NamespacedName.String())
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	pytorchv1.SetDefaults_PyTorchJob(pytorchjob)
 
 	if err = validation.ValidateV1PyTorchJobSpec(&pytorchjob.Spec); err != nil {
 		logger.Info(err.Error(), "PyTorchJob failed validation", req.NamespacedName.String())
@@ -445,16 +444,10 @@ func onOwnerCreateFunc() func(event.CreateEvent) bool {
 		if !ok {
 			return true
 		}
+		pytorchv1.SetDefaults_PyTorchJob(pytorchjob)
 		scheme.Scheme.Default(pytorchjob)
 		msg := fmt.Sprintf("PyTorchJob %s is created.", e.Object.GetName())
 		logrus.Info(msg)
-		//specific the run policy
-
-		if pytorchjob.Spec.CleanPodPolicy == nil {
-			pytorchjob.Spec.CleanPodPolicy = new(commonv1.CleanPodPolicy)
-			pytorchjob.Spec.CleanPodPolicy = &defaultCleanPodPolicy
-		}
-
 		if err := commonutil.UpdateJobConditions(&pytorchjob.Status, commonv1.JobCreated, "PyTorchJobCreated", msg); err != nil {
 			logrus.Error(err, "append job condition error")
 			return false

--- a/pkg/controller.v1/pytorch/pytorchjob_controller.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller.go
@@ -406,7 +406,7 @@ func (r *PyTorchJobReconciler) UpdateJobStatusInApiServer(job interface{}, jobSt
 		pytorchjob.Status = *jobStatus.DeepCopy()
 	}
 
-	result := r.Update(context.Background(), pytorchjob)
+	result := r.Status().Update(context.Background(), pytorchjob)
 
 	if result != nil {
 		r.Log.WithValues("pytorchjob", types.NamespacedName{

--- a/pkg/controller.v1/pytorch/pytorchjob_controller.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/kubeflow/tf-operator/pkg/apis/pytorch/validation"
+
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -126,6 +128,10 @@ func (r *PyTorchJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	pytorchv1.SetDefaults_PyTorchJob(pytorchjob)
+
+	if err = validation.ValidateV1PyTorchJobSpec(&pytorchjob.Spec); err != nil {
+		logger.Info(err.Error(), "PyTorchJob failed validation", req.NamespacedName.String())
+	}
 
 	// Check if reconciliation is needed
 	jobKey, err := common.KeyFunc(pytorchjob)

--- a/pkg/controller.v1/tensorflow/job.go
+++ b/pkg/controller.v1/tensorflow/job.go
@@ -112,6 +112,8 @@ func (tc *TFController) addTFJob(obj interface{}) {
 	}
 
 	// Set default for the new tfjob.
+	// TODO(Jeffwan): Consider to change to scheme https://github.com/kubeflow/tf-operator/issues/1317#issuecomment-890397705
+	tfv1.SetDefaults_TFJob(tfJob)
 	scheme.Scheme.Default(tfJob)
 
 	msg := fmt.Sprintf("TFJob %s is created.", tfJob.Name)

--- a/pkg/controller.v1/tensorflow/tfjob_controller.go
+++ b/pkg/controller.v1/tensorflow/tfjob_controller.go
@@ -126,7 +126,7 @@ func (r *TFJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		logger.Info(err.Error(), "unable to fetch TFJob", req.NamespacedName.String())
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	tensorflowv1.SetDefaults_TFJob(tfjob)
+
 	if err = validation.ValidateV1TFJobSpec(&tfjob.Spec); err != nil {
 		logger.Info(err.Error(), "TFJob failed validation", req.NamespacedName.String())
 	}
@@ -841,15 +841,11 @@ func onOwnerCreateFunc() func(event.CreateEvent) bool {
 		if !ok {
 			return true
 		}
+
+		tensorflowv1.SetDefaults_TFJob(tfJob)
 		scheme.Scheme.Default(tfJob)
 		msg := fmt.Sprintf("TFJob %s is created.", e.Object.GetName())
 		logrus.Info(msg)
-		//specific the run policy
-
-		if tfJob.Spec.RunPolicy.CleanPodPolicy == nil {
-			tfJob.Spec.RunPolicy.CleanPodPolicy = new(commonv1.CleanPodPolicy)
-			tfJob.Spec.RunPolicy.CleanPodPolicy = &defaultCleanPodPolicy
-		}
 
 		if err := commonutil.UpdateJobConditions(&tfJob.Status, commonv1.JobCreated, "TFJobCreated", msg); err != nil {
 			log.Log.Error(err, "append job condition error")

--- a/pkg/controller.v1/tensorflow/tfjob_controller.go
+++ b/pkg/controller.v1/tensorflow/tfjob_controller.go
@@ -21,6 +21,13 @@ import (
 	"strings"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
 	train_util "github.com/kubeflow/common/pkg/util/train"
 
 	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
@@ -59,8 +66,8 @@ import (
 	"github.com/kubeflow/tf-operator/pkg/common/util"
 )
 
-const (
-	jobOwnerKey = ".metadata.controller"
+var (
+	defaultCleanPodPolicy = commonv1.CleanPodPolicyNone
 )
 
 func NewReconciler(mgr manager.Manager) *TFJobReconciler {
@@ -149,11 +156,46 @@ func (r *TFJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *TFJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&tensorflowv1.TFJob{}).
-		Owns(&corev1.Pod{}).
-		Owns(&corev1.Service{}).
-		Complete(r)
+	c, err := controller.New(r.ControllerName(), mgr, controller.Options{
+		Reconciler: r,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	// using onOwnerCreateFunc is easier to set defaults
+	if err = c.Watch(&source.Kind{Type: &tfv1.TFJob{}}, &handler.EnqueueRequestForObject{},
+		predicate.Funcs{CreateFunc: onOwnerCreateFunc()},
+	); err != nil {
+		return err
+	}
+
+	// inject watching for job related pod
+	if err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &tfv1.TFJob{},
+	}, predicate.Funcs{
+		CreateFunc: util.OnDependentCreateFunc(r.Expectations),
+		UpdateFunc: util.OnDependentUpdateFunc(&r.JobController),
+		DeleteFunc: util.OnDependentDeleteFunc(r.Expectations),
+	}); err != nil {
+		return err
+	}
+
+	// inject watching for job related service
+	if err = c.Watch(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &tfv1.TFJob{},
+	}, predicate.Funcs{
+		CreateFunc: util.OnDependentCreateFunc(r.Expectations),
+		UpdateFunc: util.OnDependentUpdateFunc(&r.JobController),
+		DeleteFunc: util.OnDependentDeleteFunc(r.Expectations),
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (r *TFJobReconciler) ControllerName() string {
@@ -785,4 +827,29 @@ func (r *TFJobReconciler) createNewPod(tfjob *tfv1.TFJob, rt, index string, spec
 		return err
 	}
 	return nil
+}
+
+// onOwnerCreateFunc modify creation condition.
+func onOwnerCreateFunc() func(event.CreateEvent) bool {
+	return func(e event.CreateEvent) bool {
+		tfJob, ok := e.Object.(*tensorflowv1.TFJob)
+		if !ok {
+			return true
+		}
+		scheme.Scheme.Default(tfJob)
+		msg := fmt.Sprintf("TFJob %s is created.", e.Object.GetName())
+		logrus.Info(msg)
+		//specific the run policy
+
+		if tfJob.Spec.RunPolicy.CleanPodPolicy == nil {
+			tfJob.Spec.RunPolicy.CleanPodPolicy = new(commonv1.CleanPodPolicy)
+			tfJob.Spec.RunPolicy.CleanPodPolicy = &defaultCleanPodPolicy
+		}
+
+		if err := commonutil.UpdateJobConditions(&tfJob.Status, commonv1.JobCreated, "TFJobCreated", msg); err != nil {
+			log.Log.Error(err, "append job condition error")
+			return false
+		}
+		return true
+	}
 }

--- a/pkg/controller.v1/tensorflow/tfjob_controller.go
+++ b/pkg/controller.v1/tensorflow/tfjob_controller.go
@@ -524,7 +524,7 @@ func (r *TFJobReconciler) UpdateJobStatusInApiServer(job interface{}, jobStatus 
 	tfJob = tfJob.DeepCopy()
 	tfJob.Status = *jobStatus.DeepCopy()
 
-	result := r.Update(context.Background(), tfJob)
+	result := r.Status().Update(context.Background(), tfJob)
 
 	if result != nil {
 		r.Log.WithValues("tfjob", types.NamespacedName{

--- a/pkg/controller.v1/tensorflow/tfjob_controller.go
+++ b/pkg/controller.v1/tensorflow/tfjob_controller.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kubeflow/tf-operator/pkg/apis/tensorflow/validation"
+
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -125,6 +127,9 @@ func (r *TFJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	tensorflowv1.SetDefaults_TFJob(tfjob)
+	if err = validation.ValidateV1TFJobSpec(&tfjob.Spec); err != nil {
+		logger.Info(err.Error(), "TFJob failed validation", req.NamespacedName.String())
+	}
 
 	// Check if reconciliation is needed
 	jobKey, err := common.KeyFunc(tfjob)

--- a/pkg/controller.v1/xgboost/xgboostjob_controller.go
+++ b/pkg/controller.v1/xgboost/xgboostjob_controller.go
@@ -143,7 +143,6 @@ func (r *XGBoostJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	xgboostv1.SetDefaults_XGBoostJob(xgboostjob)
 	if err = validation.ValidateV1XGBoostJobSpec(&xgboostjob.Spec); err != nil {
 		logger.Info(err.Error(), "XGBoostJob failed validation", req.NamespacedName.String())
 	}
@@ -451,15 +450,11 @@ func onOwnerCreateFunc() func(event.CreateEvent) bool {
 		if !ok {
 			return true
 		}
+
+		xgboostv1.SetDefaults_XGBoostJob(xgboostJob)
 		scheme.Scheme.Default(xgboostJob)
 		msg := fmt.Sprintf("xgboostJob %s is created.", e.Object.GetName())
 		logrus.Info(msg)
-		//specific the run policy
-
-		if xgboostJob.Spec.RunPolicy.CleanPodPolicy == nil {
-			xgboostJob.Spec.RunPolicy.CleanPodPolicy = new(commonv1.CleanPodPolicy)
-			xgboostJob.Spec.RunPolicy.CleanPodPolicy = &defaultCleanPodPolicy
-		}
 
 		if err := commonutil.UpdateJobConditions(&xgboostJob.Status.JobStatus, commonv1.JobCreated, xgboostJobCreatedReason, msg); err != nil {
 			log.Log.Error(err, "append job condition error")

--- a/pkg/controller.v1/xgboost/xgboostjob_controller.go
+++ b/pkg/controller.v1/xgboost/xgboostjob_controller.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kubeflow/tf-operator/pkg/apis/xgboost/validation"
+
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -139,6 +141,11 @@ func (r *XGBoostJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// Object not found, return.  Created objects are automatically garbage collected.
 		// For additional cleanup logic use finalizers.
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	xgboostv1.SetDefaults_XGBoostJob(xgboostjob)
+	if err = validation.ValidateV1XGBoostJobSpec(&xgboostjob.Spec); err != nil {
+		logger.Info(err.Error(), "XGBoostJob failed validation", req.NamespacedName.String())
 	}
 
 	// Check reconcile is required.

--- a/pkg/controller.v1/xgboost/xgboostjob_controller.go
+++ b/pkg/controller.v1/xgboost/xgboostjob_controller.go
@@ -415,7 +415,7 @@ func (r *XGBoostJobReconciler) UpdateJobStatusInApiServer(job interface{}, jobSt
 		xgboostjob.Status.JobStatus = *jobStatus.DeepCopy()
 	}
 
-	result := r.Update(context.Background(), xgboostjob)
+	result := r.Status().Update(context.Background(), xgboostjob)
 
 	if result != nil {
 		logger.LoggerForJob(xgboostjob).Error(result, "failed to update XGBoost Job conditions in the API server")


### PR DESCRIPTION
Resolve https://github.com/kubeflow/tf-operator/issues/1312 https://github.com/kubeflow/tf-operator/issues/1314 https://github.com/kubeflow/tf-operator/issues/1316 https://github.com/kubeflow/tf-operator/issues/1317

1. Since we use kubeflow/common to observe expections, current (kubebuilder v3) way is kind of hard to be compatible with kubeflow/common pattern. The expectation calculation is not accurate. I determine to change back to kubebuilder v1 pattern to use low level controller in SetupWithManager. Rest of the logics and programming model is still same as Kubebuilder v3.0 which is compatible
   - example: https://book-v1.book.kubebuilder.io/basics/simple_controller.html

2. Add validation back to reconciler. 
3. Set defaults in onOwnerCreateFunc
4. Fix job status update issue. 
5. Make CI work in this dev branch
