### PR TITLE
fix: Resolve scheme registration issue for defaulters

### DIFF
--- a/pkg/controller.v1/xgboost/xgboostjob_controller.go
+++ b/pkg/controller.v1/xgboost/xgboostjob_controller.go
@@ -44,7 +44,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kubeclientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -163,7 +162,7 @@ func (r *XGBoostJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// Set default priorities for xgboost job
-	scheme.Scheme.Default(xgboostjob)
+	r.Scheme.Default(xgboostjob)
 
 	// Use common to reconcile the job related pod and service
 	err = r.ReconcileJobs(xgboostjob, xgboostjob.Spec.XGBReplicaSpecs, xgboostjob.Status, &xgboostjob.Spec.RunPolicy)
@@ -187,7 +186,7 @@ func (r *XGBoostJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// using onOwnerCreateFunc is easier to set defaults
 	if err = c.Watch(&source.Kind{Type: &xgboostv1.XGBoostJob{}}, &handler.EnqueueRequestForObject{},
-		predicate.Funcs{CreateFunc: onOwnerCreateFunc()},
+		predicate.Funcs{CreateFunc: r.onOwnerCreateFunc()},
 	); err != nil {
 		return err
 	}
@@ -444,15 +443,13 @@ func (r *XGBoostJobReconciler) IsMasterRole(replicas map[commonv1.ReplicaType]*c
 }
 
 // onOwnerCreateFunc modify creation condition.
-func onOwnerCreateFunc() func(event.CreateEvent) bool {
+func (r *XGBoostJobReconciler) onOwnerCreateFunc() func(event.CreateEvent) bool {
 	return func(e event.CreateEvent) bool {
 		xgboostJob, ok := e.Object.(*xgboostv1.XGBoostJob)
 		if !ok {
 			return true
 		}
-		xgboostv1.SetDefaults_XGBoostJob(xgboostJob)
-		// TODO: figure out why default funcs are not registered successfully.
-		scheme.Scheme.Default(xgboostJob)
+		r.Scheme.Default(xgboostJob)
 		msg := fmt.Sprintf("xgboostJob %s is created.", e.Object.GetName())
 		logrus.Info(msg)
 


### PR DESCRIPTION
Resolve #1352 #1359

Since defaulter changes won't be persisted. After the job is done and controller tries to delete pods based on cleanup policy, it can not find `runPolicy` fields. We need to use `scheme.Scheme.Default(job)` in each reconcile loop.
However, follow code snippet doesn't work as expected. 

https://github.com/kubeflow/tf-operator/blob/52cddeceba1e31e54a2e34551f486675fafabda2/pkg/controller.v1/tensorflow/tfjob_controller.go#L149-L150


Because we didn't use scheme we used to register defaulters here. 
https://github.com/kubeflow/tf-operator/blob/52cddeceba1e31e54a2e34551f486675fafabda2/pkg/apis/tensorflow/v1/types.go#L115

This PR fix this issue and also addressed a TODO item left previously.

```
// TODO: figure out why default funcs are not registered successfully.
```

/cc @kubeflow/wg-training-leads 

Thanks @andreyvelich for reporting this issue 