### PR TITLE
fix: Fix Python SDK installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ kubectl apply -k "github.com/kubeflow/tf-operator/manifests/overlays/standalone?
 
 Training Operator provides Python SDK for the custom resources. More docs are available in [sdk/python](sdk/python) folder.
 
-Use `pip install` command to install the latest release of the SDK:
+Use the following command to install the Python SDK:
 ```
-pip install kubeflow-training
+python -m pip install git+https://github.com/kubeflow/training-operator#subdirectory=sdk/python
 ```
 
 ## Quick Start

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -9,7 +9,8 @@ Python 2.7 and 3.5+
 ### pip install
 
 ```sh
-pip install kubeflow-training
+python -m pip install git+https://github.com/kubeflow/training-operator#subdirectory=sdk/python
+```
 ```
 
 Then import the package:


### PR DESCRIPTION
The package is not in PyPI so `pip install kubeflow-training` won't work and the best way to install is from Git with `subdirectory=sdk/python`.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>