### PR TITLE
chore: Add .gitattributes to ignore Jsonnet test code for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/** linguist-generated


### PR DESCRIPTION
Jsonnet is recognized as the main language of this repo but it's only for testing and shouldn't be included as part of the classification.

Reference: https://github.com/github/linguist/blob/master/docs/overrides.md#generated-code

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>