### PR TITLE
Add PR template with doc checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!--  Thanks for sending a pull request! Here are some tips for you:
+1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
+2. To know more about Training Operator, check the developer guide:
+    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
+3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
+Fixes #
+
+**Checklist:**
+
+- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing


### PR DESCRIPTION
As we discussed on the WG meeting, it is better to add the doc checklist to our PR template.

Once our contributors submit the new PR with feature request, they have to update the [Kubeflow docs](https://www.kubeflow.org/docs/components/training/).

/assign @kubeflow/wg-training-leads 