### PR TITLE
update label for tf-controller

### DIFF
--- a/pkg/controller.v1/tensorflow/tfjob_controller.go
+++ b/pkg/controller.v1/tensorflow/tfjob_controller.go
@@ -794,6 +794,8 @@ func (r *TFJobReconciler) createNewPod(tfjob *tfv1.TFJob, rt, index string, spec
 	labels := r.GenLabels(tfjob.Name)
 	labels[tfReplicaTypeLabel] = rt
 	labels[tfReplicaIndexLabel] = index
+	labels[commonv1.ReplicaTypeLabel] = rt
+	labels[commonv1.ReplicaIndexLabel] = index
 
 	if masterRole {
 		labels[commonv1.JobRoleLabel] = "master"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Because the tf-controller overrides the `ReconcilePods` function, the updated labels with `training.kubeflow.org` prefix are not added to the metainfo of tf pod generated. However, for the selector in tf service, because tf-controller does not overrides the `ReconcilePods`, labels with `training.kubeflow.org` prefix are included.

**Checklist:**

- [x] adding `"training.kubeflow.org/replica-type"` and `"training.kubeflow.org/replica-index"` to tf-controller when generating labels
