### PR TITLE
Set Go version of base image to 1.17

### DIFF
--- a/build/images/training-operator/Dockerfile
+++ b/build/images/training-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.14.9 as builder
+FROM golang:1.17 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, Go version is unmatched between gomod and base image of Dockerfile for training operator. So, this PR upgrade Go version of base image.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
