### PR TITLE
add mpi doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ run distributed or non-distributed TensorFlow/PyTorch/Apache MXNet/XGBoost jobs 
   - [PyTorch API Definition](pkg/apis/pytorch/v1/types.go)
   - [Apache MXNet API Definition](pkg/apis/mxnet/v1/types.go)
   - [XGBoost API Definition](pkg/apis/xgboost/v1/types.go)
+  - [MPI API Definition](pkg/apis/mpi/v1/types.go)
 - For details on API design, please refer to the [v1alpha2 design doc](https://github.com/kubeflow/community/blob/master/proposals/tf-operator-design-v1alpha2.md).
 - For details of all-in-one operator design, please refer to the [All-in-one Kubeflow Training Operator](https://docs.google.com/document/d/1x1JPDQfDMIbnoQRftDH1IzGU0qvHGSU4W6Jl4rJLPhI/edit#heading=h.e33ufidnl8z6)
 - For details on its observability, please refer to the [monitoring design doc](docs/monitoring/README.md).
@@ -70,6 +71,7 @@ Please refer to following API Documentation:
 - [PyTorch API Documentation](docs/api/pytorch_generated.asciidoc)
 - [Apache MXNet API Documentation](docs/api/mxnet_generated.asciidoc)
 - [XGBoost API Documentation](docs/api/xgboost_generated.asciidoc)
+- [MPI API Documentation](docs/api/mpi_generated.asciidoc)
 
 ## Community
 

--- a/docs/api/mpi_generated.asciidoc
+++ b/docs/api/mpi_generated.asciidoc
@@ -1,0 +1,87 @@
+// Generated documentation. Please do not edit.
+:anchor_prefix: k8s-api
+
+[id="{p}-api-reference"]
+= API Reference
+
+.Packages
+- xref:{anchor_prefix}-kubeflow-org-v1[$$kubeflow.org/v1$$]
+
+
+[id="{anchor_prefix}-kubeflow-org-v1"]
+== kubeflow.org/v1
+
+Package v1 is the v1 version of the API.
+
+Package v1 contains API Schema definitions for the kubeflow.org v1 API group
+
+.Resource Types
+- xref:{anchor_prefix}-github-com-kubeflow-training-operator-pkg-apis-mpi-v1-mpijob[$$MPIJob$$]
+- xref:{anchor_prefix}-github-com-kubeflow-training-operator-pkg-apis-mpi-v1-mpijoblist[$$MPIJobList$$]
+
+
+=== Definitions
+
+[id="{anchor_prefix}-github-com-kubeflow-training-operator-pkg-apis-mpi-v1-mpijob"]
+==== MPIJob 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-kubeflow-training-operator-pkg-apis-mpi-v1-mpijoblist[$$MPIJobList$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `kubeflow.org/v1`
+| *`kind`* __string__ | `MPIJob`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`spec`* __xref:{anchor_prefix}-github-com-kubeflow-training-operator-pkg-apis-mpi-v1-mpijobspec[$$MPIJobSpec$$]__ | 
+| *`status`* __xref:{anchor_prefix}-github-com-kubeflow-common-pkg-apis-common-v1-jobstatus[$$JobStatus$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-kubeflow-training-operator-pkg-apis-mpi-v1-mpijoblist"]
+==== MPIJobList 
+
+
+
+
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`apiVersion`* __string__ | `kubeflow.org/v1`
+| *`kind`* __string__ | `MPIJobList`
+| *`TypeMeta`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#typemeta-v1-meta[$$TypeMeta$$]__ | 
+| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#listmeta-v1-meta[$$ListMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
+
+| *`items`* __xref:{anchor_prefix}-github-com-kubeflow-training-operator-pkg-apis-mpi-v1-mpijob[$$MPIJob$$]__ | 
+|===
+
+
+[id="{anchor_prefix}-github-com-kubeflow-training-operator-pkg-apis-mpi-v1-mpijobspec"]
+==== MPIJobSpec 
+
+
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-kubeflow-training-operator-pkg-apis-mpi-v1-mpijob[$$MPIJob$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+| *`slotsPerWorker`* __integer__ | Specifies the number of slots per worker used in hostfile. Defaults to 1.
+| *`cleanPodPolicy`* __CleanPodPolicy__ | CleanPodPolicy defines the policy that whether to kill pods after the job completes. Defaults to None.
+| *`mpiReplicaSpecs`* __object (keys:ReplicaType, values:ReplicaSpec)__ | `MPIReplicaSpecs` contains maps from `MPIReplicaType` to `ReplicaSpec` that specify the MPI replicas to run.
+| *`mainContainer`* __string__ | MainContainer specifies name of the main container which executes the MPI code.
+| *`runPolicy`* __xref:{anchor_prefix}-github-com-kubeflow-common-pkg-apis-common-v1-runpolicy[$$RunPolicy$$]__ | `RunPolicy` encapsulates various runtime policies of the distributed training job, for example how to clean up resources and how long the job can stay active.
+|===
+
+

--- a/hack/generate-apidoc.sh
+++ b/hack/generate-apidoc.sh
@@ -53,4 +53,11 @@ crd-ref-docs --log-level DEBUG\
 		--output-path ./docs/api/xgboost_generated.asciidoc \
 		--max-depth 30
 
+crd-ref-docs --log-level DEBUG\
+    --source-path ./pkg/apis/mpi/v1 \
+		--config ./docs/api/autogen/config.yaml \
+		--templates-dir ./docs/api/autogen/templates \
+		--output-path ./docs/api/mpi_generated.asciidoc \
+		--max-depth 30
+
 cd - > /dev/null


### PR DESCRIPTION
While the mpijob api and controller are merged, the document is still missing.

- [x] add auto-generate script for mpijob
- [x] add mpijob doc
- [x] update readme