### PR TITLE
chore: Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - Jeffwan
   - johnugeorge
   - terrytangyuan
+  - zw0610
 reviewers:
   - jinchihe


### PR DESCRIPTION
Add @zw0610 as the approver.

- https://github.com/kubeflow/training-operator/commits?author=zw0610
- https://github.com/kubeflow/common/commits?author=zw0610

Lucas helped to improve the kubeflow common and migrated mpi and pytorch to the training operator. I suggest adding him as an approver in training operator.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
