### PR TITLE
remove ChanYiLin from approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,4 @@
 approvers:
-  - ChanYiLin
   - gaocegege
   - Jeffwan
   - johnugeorge


### PR DESCRIPTION
I am removing myself from training-operator approvers and also wg-training-leads.
Thanks for @kubeflow/wg-training-leads  help during the time, especially thanks to @gaocegege !
