### PR TITLE
Remove `table-logger` dependency

### DIFF
--- a/sdk/python/kubeflow/training/api/py_torch_job_watch.py
+++ b/sdk/python/kubeflow/training/api/py_torch_job_watch.py
@@ -15,15 +15,13 @@
 import retrying
 from kubernetes import client
 from kubernetes import watch as k8s_watch
-from table_logger import TableLogger
 
 from kubeflow.training.constants import constants
 from kubeflow.training.utils import utils
 
-tbl = TableLogger(
-    columns='NAME,STATE,TIME',
-    colwidth={'NAME': 30, 'STATE': 20, 'TIME': 30},
-    border=False)
+tbl = utils.TableLogger(
+    header="{:<30.30} {:<20.20} {:<30.30}".format('NAME', 'STATE', 'TIME'),
+    column_format="{:<30.30} {:<20.20} {:<30.30}")
 
 
 @retrying.retry(wait_fixed=1000, stop_max_attempt_number=20)

--- a/sdk/python/kubeflow/training/api/tf_job_watch.py
+++ b/sdk/python/kubeflow/training/api/tf_job_watch.py
@@ -15,15 +15,13 @@
 import retrying
 from kubernetes import client
 from kubernetes import watch as k8s_watch
-from table_logger import TableLogger
 
 from kubeflow.training.constants import constants
 from kubeflow.training.utils import utils
 
-tbl = TableLogger(
-    columns='NAME,STATE,TIME',
-    colwidth={'NAME': 30, 'STATE': 20, 'TIME': 30},
-    border=False)
+tbl = utils.TableLogger(
+    header="{:<30.30} {:<20.20} {:<30.30}".format('NAME', 'STATE', 'TIME'),
+    column_format="{:<30.30} {:<20.20} {:<30.30}")
 
 
 @retrying.retry(wait_fixed=1000, stop_max_attempt_number=20)

--- a/sdk/python/kubeflow/training/utils/utils.py
+++ b/sdk/python/kubeflow/training/utils/utils.py
@@ -79,3 +79,16 @@ def to_selector(labels):
         parts.append("{0}={1}".format(key, labels[key]))
 
     return ",".join(parts)
+
+
+class TableLogger:
+    def __init__(self, header, column_format):
+        self.header = header
+        self.column_format = column_format
+        self.first_call = True
+
+    def __call__(self, *values):
+        if self.first_call:
+            print(self.header)
+            self.first_call = False
+        print(self.column_format.format(*values))

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -4,5 +4,4 @@ python_dateutil>=2.5.3
 setuptools>=21.0.0
 urllib3>=1.15.1
 kubernetes>=12.0.0
-table_logger>=0.3.5
 retrying>=1.3.3


### PR DESCRIPTION
**What this PR does / why we need it**: This removes the dependency on `table-logger`. None of the various alternatives mentioned in that issues were drop-in replacements, so given the simplicity of the use case here the dependency is replaced with a small class utilizing `str.format`. Note that the class was written without referring to the `table-logger` source at all, which would be a license violation.

I confirmed that you can now run the sample notebook

https://github.com/kubeflow/training-operator/blob/6523d8d2b7a27f1140a05971843cc4da7523694f/sdk/python/examples/kubeflow-tfjob-sdk.ipynb

in modern IPython.

Fixes #1446 

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
