### PR TITLE
fix: MPIJob problems that running workers for completed MPIJob cannot be deleted

### DIFF
--- a/pkg/controller.v1/mpi/mpijob.go
+++ b/pkg/controller.v1/mpi/mpijob.go
@@ -42,7 +42,6 @@ const (
 	workerSuffix            = "-worker"
 	gpuResourceNameSuffix   = ".com/gpu"
 	gpuResourceNamePattern  = "gpu"
-	labelGroupName          = "group-name"
 	labelMPIJobName         = "mpi-job-name"
 	labelMPIRoleType        = "mpi-job-role"
 	initContainerCpu        = "100m"
@@ -228,9 +227,12 @@ func isGPULauncher(mpiJob *mpiv1.MPIJob) bool {
 
 func defaultWorkerLabels(mpiJobName string) map[string]string {
 	return map[string]string{
-		labelGroupName:   "kubeflow.org",
-		labelMPIJobName:  mpiJobName,
-		labelMPIRoleType: worker,
+		labelMPIJobName:                   mpiJobName,
+		labelMPIRoleType:                  worker,
+		commonv1.OperatorNameLabel:        controllerName,
+		commonv1.GroupNameLabelDeprecated: "kubeflow.org",
+		commonv1.JobNameLabel:             mpiJobName,
+		commonv1.JobNameLabelDeprecated:   mpiJobName,
 	}
 }
 

--- a/pkg/controller.v1/mpi/mpijob_controller.go
+++ b/pkg/controller.v1/mpi/mpijob_controller.go
@@ -242,7 +242,7 @@ func (jc *MPIJobReconciler) DeletePodsAndServices(runPolicy *commonv1.RunPolicy,
 	}
 
 	// Delete nothing when the cleanPodPolicy is None.
-	if *runPolicy.CleanPodPolicy == commonv1.CleanPodPolicyNone {
+	if runPolicy == nil || *runPolicy.CleanPodPolicy == commonv1.CleanPodPolicyNone {
 		return nil
 	}
 

--- a/pkg/controller.v1/mpi/mpijob_controller.go
+++ b/pkg/controller.v1/mpi/mpijob_controller.go
@@ -1053,9 +1053,12 @@ func (jc *MPIJobReconciler) newWorker(mpiJob *mpiv1.MPIJob, name string) *corev1
 func (jc *MPIJobReconciler) newLauncher(mpiJob *mpiv1.MPIJob, kubectlDeliveryImage string, isGPULauncher bool) *corev1.Pod {
 	launcherName := mpiJob.Name + launcherSuffix
 	labels := map[string]string{
-		labelGroupName:   "kubeflow.org",
-		labelMPIJobName:  mpiJob.Name,
-		labelMPIRoleType: launcher,
+		labelMPIJobName:                   mpiJob.Name,
+		labelMPIRoleType:                  launcher,
+		commonv1.OperatorNameLabel:        controllerName,
+		commonv1.GroupNameLabelDeprecated: "kubeflow.org",
+		commonv1.JobNameLabel:             mpiJob.Name,
+		commonv1.JobNameLabelDeprecated:   mpiJob.Name,
 	}
 
 	podSpec := mpiJob.Spec.MPIReplicaSpecs[mpiv1.MPIReplicaTypeLauncher].Template.DeepCopy()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
The current training-operator for MPIJob has the following bug:
![image](https://user-images.githubusercontent.com/13050415/158203128-e5c6c2ec-20a3-4de1-95bb-d1e8d85433c4.png)
Although cleanPodPolicy is set, when launcher completed, pod would continue run infinitely so that gpu resources couldn't be returned for incoming jobs.

The bug in short is that mpi-operator give both worker/launcher labels: `mpi-job-name`, while the when needs to delete pods, the operator lists pods using labels: `job-name`,  `training.kubeflow.org/operator-name`,  and `training.kubeflow.org/job-name`, so they are mismatched and running worker cannot be recycled.

In detailed: 
1. MPIJob has default labels: `labelGroupName:   "kubeflow.org"`, `labelMPIJobName:  mpiJobName` and `labelMPIRoleType: worker`
2. However, the labels for MPIJob don't match the labels when `DeletePodsAndServices()` (github.com./kubeflow/training-operator/pkg/controller.v1/mpi/mpijob_controller.go#239), so mpi-operator lists no pods for deletion at `pods, err := jc.Controller.GetPodsForJob(job)` (github.com/kubeflow/common@v0.4.1/pkg/controller.v1/common/job.go#85), which will call ` MatchLabels: jc.GenLabels(job.GetName())` (github.com/kubeflow/common@v0.4.1/pkg/controller.v1/common/job_controller.go#209)
<img width="720" alt="image" src="https://user-images.githubusercontent.com/13050415/158204079-85ed4e5f-11de-4cea-8830-14f7e40076e8.png">

<img width="961" alt="wecom-temp-8ac1ef2260eeaeee623383bf18f7ce2d" src="https://user-images.githubusercontent.com/13050415/158203786-c71cc583-4214-4f4c-b47d-8fbcbd7c2ec4.png">


**Which issue(s) this PR fixes** :
Fixes #1546

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
