### PR TITLE
fix UpdateJobStatusInApiServer when gang-scheduling is enabled

### DIFF
--- a/pkg/controller.v1/mpi/mpijob_controller.go
+++ b/pkg/controller.v1/mpi/mpijob_controller.go
@@ -668,6 +668,10 @@ func (jc *MPIJobReconciler) UpdateJobStatus(job interface{}, replicas map[common
 }
 
 func (jc *MPIJobReconciler) UpdateJobStatusInApiServer(job interface{}, jobStatus *commonv1.JobStatus) error {
+	if jobStatus.ReplicaStatuses == nil {
+		jobStatus.ReplicaStatuses = map[commonv1.ReplicaType]*commonv1.ReplicaStatus{}
+	}
+
 	mpiJob, ok := job.(*mpiv1.MPIJob)
 	if !ok {
 		return fmt.Errorf("%v is not a type of MpiJob", mpiJob)

--- a/pkg/controller.v1/mxnet/mxjob_controller.go
+++ b/pkg/controller.v1/mxnet/mxjob_controller.go
@@ -400,6 +400,10 @@ func (r *MXJobReconciler) UpdateJobStatus(job interface{}, replicas map[commonv1
 
 // UpdateJobStatusInApiServer updates the status of the given MXJob.
 func (r *MXJobReconciler) UpdateJobStatusInApiServer(job interface{}, jobStatus *commonv1.JobStatus) error {
+	if jobStatus.ReplicaStatuses == nil {
+		jobStatus.ReplicaStatuses = map[commonv1.ReplicaType]*commonv1.ReplicaStatus{}
+	}
+
 	mxJob, ok := job.(*mxjobv1.MXJob)
 	if !ok {
 		return fmt.Errorf("%v is not a type of MXJob", mxJob)

--- a/pkg/controller.v1/pytorch/pytorchjob_controller.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller.go
@@ -440,6 +440,10 @@ func ContainsMasterSpec(replicas map[commonv1.ReplicaType]*commonv1.ReplicaSpec)
 
 // UpdateJobStatusInApiServer updates the job status in to cluster.
 func (r *PyTorchJobReconciler) UpdateJobStatusInApiServer(job interface{}, jobStatus *commonv1.JobStatus) error {
+	if jobStatus.ReplicaStatuses == nil {
+		jobStatus.ReplicaStatuses = map[commonv1.ReplicaType]*commonv1.ReplicaStatus{}
+	}
+
 	pytorchjob, ok := job.(*pytorchv1.PyTorchJob)
 	trainingoperatorcommon.ClearGeneratedFields(&pytorchjob.ObjectMeta)
 	if !ok {

--- a/pkg/controller.v1/tensorflow/tfjob_controller.go
+++ b/pkg/controller.v1/tensorflow/tfjob_controller.go
@@ -545,6 +545,10 @@ func (r *TFJobReconciler) UpdateJobStatus(job interface{}, replicas map[commonv1
 }
 
 func (r *TFJobReconciler) UpdateJobStatusInApiServer(job interface{}, jobStatus *commonv1.JobStatus) error {
+	if jobStatus.ReplicaStatuses == nil {
+		jobStatus.ReplicaStatuses = map[commonv1.ReplicaType]*commonv1.ReplicaStatus{}
+	}
+
 	tfJob, ok := job.(*tensorflowv1.TFJob)
 	if !ok {
 		return fmt.Errorf("%v is not a type of TFJob", tfJob)

--- a/pkg/controller.v1/xgboost/xgboostjob_controller.go
+++ b/pkg/controller.v1/xgboost/xgboostjob_controller.go
@@ -412,6 +412,10 @@ func (r *XGBoostJobReconciler) UpdateJobStatus(job interface{}, replicas map[com
 
 // UpdateJobStatusInApiServer updates the job status in to cluster.
 func (r *XGBoostJobReconciler) UpdateJobStatusInApiServer(job interface{}, jobStatus *commonv1.JobStatus) error {
+	if jobStatus.ReplicaStatuses == nil {
+		jobStatus.ReplicaStatuses = map[commonv1.ReplicaType]*commonv1.ReplicaStatus{}
+	}
+
 	xgboostjob, ok := job.(*xgboostv1.XGBoostJob)
 	if !ok {
 		return fmt.Errorf("%+v is not a type of XGBoostJob", xgboostjob)


### PR DESCRIPTION
When [`--enable-gang-scheduling` is enabled](https://github.com/kubeflow/common/blob/master/pkg/controller.v1/common/job.go#L214), for jobs with PodGroup in pending phase, the operator will update the JobStatus with [only its `LastReconcileTime` being changed](https://github.com/kubeflow/common/blob/master/pkg/controller.v1/common/job.go#L267). That means the `jobStatus.replicaStatues` could be nil when being pushed to the APIServer, triggering an error message.
![bf662adb42f5f52efacb01cb4e00ce3a](https://user-images.githubusercontent.com/46096162/158730285-499ec8de-e274-4b4f-99bd-3cafa84f2275.jpg)

This PR add a fix procedure for all controllers to give an empty value for `jobStatus.replicaStatues` if nil.
