### PR TITLE
fix label and CleanPodPolicy for mpi-controller

### DIFF
--- a/examples/mpi/tensorflow-mnist.yaml
+++ b/examples/mpi/tensorflow-mnist.yaml
@@ -2,7 +2,6 @@ apiVersion: kubeflow.org/v1
 kind: MPIJob
 metadata:
   name: tensorflow-mnist
-  namespace: kubeflow
 spec:
   slotsPerWorker: 1
   runPolicy:

--- a/pkg/apis/mpi/v1/default.go
+++ b/pkg/apis/mpi/v1/default.go
@@ -44,14 +44,10 @@ func setDefaultsTypeWorker(spec *common.ReplicaSpec) {
 }
 
 func SetDefaults_MPIJob(mpiJob *MPIJob) {
-	// Set default cleanpod policy to None.
-	if mpiJob.Spec.CleanPodPolicy == nil {
+	// Set default CleanPodPolicy to None when neither fields specified.
+	if mpiJob.Spec.CleanPodPolicy == nil && mpiJob.Spec.RunPolicy.CleanPodPolicy == nil {
 		none := common.CleanPodPolicyNone
 		mpiJob.Spec.CleanPodPolicy = &none
-	}
-
-	if mpiJob.Spec.RunPolicy.CleanPodPolicy == nil {
-		none := common.CleanPodPolicyNone
 		mpiJob.Spec.RunPolicy.CleanPodPolicy = &none
 	}
 

--- a/pkg/common/util/util.go
+++ b/pkg/common/util/util.go
@@ -17,7 +17,10 @@ package util
 import (
 	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+type ObjectFilterFunction func(obj metav1.Object) bool
 
 // ConvertServiceList convert service list to service point list
 func ConvertServiceList(list []corev1.Service) []*corev1.Service {
@@ -39,6 +42,25 @@ func ConvertPodList(list []corev1.Pod) []*corev1.Pod {
 	ret := make([]*corev1.Pod, 0, len(list))
 	for i := range list {
 		ret = append(ret, &list[i])
+	}
+	return ret
+}
+
+// ConvertPodListWithFilter converts pod list to pod pointer list with ObjectFilterFunction
+func ConvertPodListWithFilter(list []corev1.Pod, pass ObjectFilterFunction) []*corev1.Pod {
+	if list == nil {
+		return nil
+	}
+	ret := make([]*corev1.Pod, 0, len(list))
+	for i := range list {
+		obj := &list[i]
+		if pass != nil {
+			if pass(obj) {
+				ret = append(ret, obj)
+			}
+		} else {
+			ret = append(ret, obj)
+		}
 	}
 	return ret
 }

--- a/pkg/controller.v1/mpi/mpijob.go
+++ b/pkg/controller.v1/mpi/mpijob.go
@@ -42,9 +42,6 @@ const (
 	workerSuffix            = "-worker"
 	gpuResourceNameSuffix   = ".com/gpu"
 	gpuResourceNamePattern  = "gpu"
-	labelGroupName          = "group-name"
-	labelMPIJobName         = "mpi-job-name"
-	labelMPIRoleType        = "mpi-job-role"
 	initContainerCpu        = "100m"
 	initContainerEphStorage = "5Gi"
 	initContainerMem        = "512Mi"
@@ -226,16 +223,26 @@ func isGPULauncher(mpiJob *mpiv1.MPIJob) bool {
 	return false
 }
 
-func defaultWorkerLabels(mpiJobName string) map[string]string {
-	return map[string]string{
-		labelGroupName:   "kubeflow.org",
-		labelMPIJobName:  mpiJobName,
-		labelMPIRoleType: worker,
+func defaultReplicaLabels(genericLabels map[string]string, roleLabelVal string) map[string]string {
+	replicaLabels := map[string]string{}
+	for k, v := range genericLabels {
+		replicaLabels[k] = v
 	}
+
+	replicaLabels[commonv1.ReplicaTypeLabel] = roleLabelVal
+	return replicaLabels
 }
 
-func workerSelector(mpiJobName string) (labels.Selector, error) {
-	labels := defaultWorkerLabels(mpiJobName)
+func defaultWorkerLabels(genericLabels map[string]string) map[string]string {
+	return defaultReplicaLabels(genericLabels, worker)
+}
+
+func defaultLauncherLabels(genericLabels map[string]string) map[string]string {
+	return defaultReplicaLabels(genericLabels, launcher)
+}
+
+func workerSelector(genericLabels map[string]string) (labels.Selector, error) {
+	labels := defaultWorkerLabels(genericLabels)
 
 	labelSelector := metav1.LabelSelector{
 		MatchLabels: labels,


### PR DESCRIPTION
**What this PR does / why we need it**:

Multiple issues are fixed in this pull request because simply fixing one of them fails the tests.

-----

**1. Duplicated CleanPodPolicy in MPIJob**

There exists two field for CleanPolicy in MPIJob:
- `Spec.CleanPodPolicy`
- `Spec.RunPolicy.CleanPodPolicy`

It is a legacy issue and exists before mpi-controller is migrated to training-operator: https://github.com/kubeflow/mpi-operator/blob/master/pkg/apis/kubeflow/v1/types.go#L49

To keep API compatibility, we did not change the API (by removing `Spec.CleanPodPolicy`) during the migration phase.

 **Solution**
> 1. Update `Validate` function to rule out the case when both fields of `CleanPodPolicy` are specified but the values are not identical
> 2. Update `Default` function to fill both fields of `CleanPodPolicy` if neither specified
> 3. Sync the value of `CleanPodPolicy` if only one field is specified

------

**2. Pod label conflicts after update from kubeflow/common**

While the migration of MPIJob succeeds at first place, label generation for Pod from MPIJob is kept in training-operator code as mpi-operator does but the selector is changed to kubeflow/common. This harmony breaks after label generation in kubeflow/common is updated for some reason.

 **Solution**
*Generally transform to kubeflow/common but keep job-level label for backward compatibility*
> 1. For *Job Name*, use kubeflow/common and the legacy label `mpi-job-name` but not deprecated `job-name` as MPIJob never uses it
> 2. For role and index, since they are mostly used by the controller itself, replace legacy labels with updated kubeflow/common, no backward compatibility is kept for these two labels.

-----

**3. Claim Pods without owner reference**

`ClaimPod` function adopts Pods without owner reference. This conflicts with test case in mpi-controller where error messages are expected when reconciling an Pod, Role, ServiceAccount and other native resources without owner reference (or as suggested *Not Controlled by us*).
The user case for resource adoption is merely seen with controller-runtime. However, it is necessary to filter out Pods belongs to last MPIJob shares the same name (and namespace but not UID) with the current MPIJob.

 **Solution**
 Add a filter to `ConvertPodList` to rule out Pods that belong to other MPIJob.

-----

**Checklist:**

- [x] fix `CleanPodPolicy` issue
- [x] fix label issue
- [x] fix claim Pods issue