### PR TITLE
fix: set mpijob runPolicy.cleanPodPolicy to default none

### DIFF
--- a/pkg/apis/mpi/v1/default.go
+++ b/pkg/apis/mpi/v1/default.go
@@ -50,6 +50,11 @@ func SetDefaults_MPIJob(mpiJob *MPIJob) {
 		mpiJob.Spec.CleanPodPolicy = &none
 	}
 
+	if mpiJob.Spec.RunPolicy.CleanPodPolicy == nil {
+		none := common.CleanPodPolicyNone
+		mpiJob.Spec.RunPolicy.CleanPodPolicy = &none
+	}
+
 	// set default to Launcher
 	setDefaultsTypeLauncher(mpiJob.Spec.MPIReplicaSpecs[MPIReplicaTypeLauncher])
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Current mpiController only give spec.CleanPodPolicy a default value none. However, all xjobs in training-operator use spec.RunPolicy.CleanPodPolicy when jobContoller does DeletePodsAndServices in kubeflow common package. If this field is not set by default so do users, it will trigger a nil pointer when jobController deference RunPolicy at DeletePodAndServices(). https://github.com/kubeflow/common/blob/master/pkg/controller.v1/common/job.go#L28. So we have to give MPIJob runPolicy field a default value.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
