### PR TITLE
Update MPIJob unit tests to use spec.runPolicy.cleanPodPolicy

### DIFF
--- a/pkg/apis/mpi/v1/default.go
+++ b/pkg/apis/mpi/v1/default.go
@@ -50,6 +50,11 @@ func SetDefaults_MPIJob(mpiJob *MPIJob) {
 		mpiJob.Spec.CleanPodPolicy = &none
 	}
 
+	if mpiJob.Spec.RunPolicy.CleanPodPolicy == nil {
+		none := common.CleanPodPolicyNone
+		mpiJob.Spec.RunPolicy.CleanPodPolicy = &none
+	}
+
 	// set default to Launcher
 	setDefaultsTypeLauncher(mpiJob.Spec.MPIReplicaSpecs[MPIReplicaTypeLauncher])
 

--- a/pkg/controller.v1/mpi/mpijob_controller_test.go
+++ b/pkg/controller.v1/mpi/mpijob_controller_test.go
@@ -47,7 +47,10 @@ func newMPIJobCommon(name string, startTime, completionTime *metav1.Time) *kubef
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: kubeflow.MPIJobSpec{
-			CleanPodPolicy: &cleanPodPolicyAll,
+			//CleanPodPolicy: &cleanPodPolicyAll,
+			RunPolicy: common.RunPolicy{
+				CleanPodPolicy: &cleanPodPolicyAll,
+			},
 			MPIReplicaSpecs: map[common.ReplicaType]*common.ReplicaSpec{
 				kubeflow.MPIReplicaTypeWorker: {
 					Template: corev1.PodTemplateSpec{

--- a/pkg/controller.v1/mpi/mpijob_controller_test.go
+++ b/pkg/controller.v1/mpi/mpijob_controller_test.go
@@ -47,7 +47,6 @@ func newMPIJobCommon(name string, startTime, completionTime *metav1.Time) *kubef
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: kubeflow.MPIJobSpec{
-			//CleanPodPolicy: &cleanPodPolicyAll,
 			RunPolicy: common.RunPolicy{
 				CleanPodPolicy: &cleanPodPolicyAll,
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This pr update mpijob unit tests: in the past, unit tests uses spec.cleanPodPolicy to test gc logic, but now in training-operator framework, spec.runPolicy.CleanPodPolicy is the standard, so it is more suit to use this field in unit tests as well.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #1555

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
