### PR TITLE
Remove uncalled mpi-controller DeletePodsAndServices()

### DIFF
--- a/pkg/controller.v1/mpi/mpijob_controller.go
+++ b/pkg/controller.v1/mpi/mpijob_controller.go
@@ -237,31 +237,6 @@ func (jc *MPIJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return nil
 }
 
-// DeletePodsAndServices is overridden because mpi-reconciler.v1 needs not deleting services
-func (jc *MPIJobReconciler) DeletePodsAndServices(runPolicy *commonv1.RunPolicy, job interface{}, pods []*corev1.Pod) error {
-	if len(pods) == 0 {
-		return nil
-	}
-
-	// Delete nothing when the cleanPodPolicy is None.
-	if *runPolicy.CleanPodPolicy == commonv1.CleanPodPolicyNone {
-		return nil
-	}
-
-	for _, pod := range pods {
-		// Note that pending pod will turn into running once schedulable,
-		// not cleaning it may leave orphan running pod in the future,
-		// we should treat it equivalent to running phase here.
-		if *runPolicy.CleanPodPolicy == commonv1.CleanPodPolicyRunning && pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != corev1.PodPending {
-			continue
-		}
-		if err := jc.PodControl.DeletePod(pod.Namespace, pod.Name, job.(runtime.Object)); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // ReconcileServices is overridden because mpi-reconciler.v1 does not need to reconcile services
 func (jc *MPIJobReconciler) ReconcileServices(
 	job metav1.Object,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
mpi-controller's `DeletePodsAndServices()` is a dead code which is never called, very confusing and very misleading. All of controllers use the base job-controller to reconcile and the base will call `jc.DeletePodsAndServices()` without using subclass's(such as mpijob, pytorchjob, .etc). It is better to remove it.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
