### PR TITLE
Increase success threshold

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -40,13 +40,14 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
-            timeoutSeconds: 5
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: /readyz
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
+            timeoutSeconds: 3
           resources:
             limits:
               cpu: 100m

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -45,8 +45,8 @@ spec:
             httpGet:
               path: /readyz
               port: 8081
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            initialDelaySeconds: 10
+            periodSeconds: 15
             timeoutSeconds: 3
           resources:
             limits:

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -40,6 +40,7 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /readyz


### PR DESCRIPTION
**What this PR does / why we need it**:

This should be related to https://github.com/kubeflow/training-operator/issues/1559

In my cluster, the default `timeoutSeconds: 1` is not enough and change to `3` is fine.
My cluster is `1.21` with training-operator `1.4.0`

