### PR TITLE
manifests/base/cluster-role.yaml: add CRUD rights on CR finalizers

### DIFF
--- a/manifests/base/cluster-role.yaml
+++ b/manifests/base/cluster-role.yaml
@@ -19,6 +19,11 @@ rules:
       - pytorchjobs/status
       - mxjobs/status
       - xgboostjobs/status
+      - tfjobs/finalizers
+      - pytorchjobs/finalizers
+      - mxjobs/finalizers
+      - xgboostjobs/finalizers
+      - mpijobs/finalizers
     verbs:
       - create
       - delete


### PR DESCRIPTION
Solves this issue on OpenShift:

```
2022-03-18T12:16:02.296Z        ERROR   controller-runtime.manager.controller.tfjob-controller  Reconciler error        {"name": "run-transformer-xl-2nodes", "namespace": "matrix-benchmarking", "error": "pods \"run-transformer-xl-2nodes-ps-0\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}
```

See [this Operator SDK FAQ entry](https://sdk.operatorframework.io/docs/faqs/#after-deploying-my-operator-why-do-i-see-errors-like-is-forbidden-cannot-set-blockownerdeletion-if-an-ownerreference-refers-to-a-resource-you-cant-set-finalizers-on-).

The 

Fixes: #1552
