### PR TITLE
fix torch env typo

### DIFF
--- a/pkg/controller.v1/pytorch/elastic.go
+++ b/pkg/controller.v1/pytorch/elastic.go
@@ -50,7 +50,7 @@ const (
 	// Worker/node size related arguments.
 
 	// EnvNProcPerNode is the environment variable name for the number of processes per node.
-	EnvNProcPerNode = "PET_N_PROC_PER_NODE"
+	EnvNProcPerNode = "PET_NPROC_PER_NODE"
 	// EnvNNodes is the environment variable name for the number of nodes.
 	EnvNNodes = "PET_NNODES"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
There is a wrong env set for pytorch.

**PET_N_PROC_PER_NODE** should be **PET_NPROC_PER_NODE** according to 
https://github.com/pytorch/pytorch/blob/master/torch/distributed/argparse_util.py#L12-L57

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [*] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
