### PR TITLE
Override eks kubernetes version to 1.19 in CI

### DIFF
--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -360,7 +360,15 @@
             ]),  // py lint
             $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTemplate("setup-cluster", testWorkerImage, [
               "/usr/local/bin/create-eks-cluster.sh",
-            ]),  // setup cluster
+            ],
+            # need to specify kubernetes version to be created in AWS EKS
+            env_vars=[
+              {
+                name: "EKS_CLUSTER_VERSION",
+                value: "1.19",
+              },
+            ]
+            ),  // setup cluster
             $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTemplate("setup-training-operator", testWorkerImage, [
               "scripts/setup-training-operator.sh",
             ]),  // setup training-operator


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix CI and unblock pending PRs.

/cc @zw0610 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes https://github.com/kubeflow/training-operator/issues/1581

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
