### PR TITLE
Look for fully-qualified job role label in Python sdk

### DIFF
--- a/sdk/python/kubeflow/training/constants/constants.py
+++ b/sdk/python/kubeflow/training/constants/constants.py
@@ -31,7 +31,7 @@ JOB_GROUP_LABEL = 'group-name'
 JOB_NAME_LABEL = 'job-name'
 JOB_TYPE_LABEL = 'replica-type'
 JOB_INDEX_LABEL = 'replica-index'
-JOB_ROLE_LABEL = 'job-role'
+JOB_ROLE_LABEL = 'training.kubeflow.org/job-role'
 
 JOB_STATUS_SUCCEEDED = 'Succeeded'
 JOB_STATUS_FAILED = 'Failed'


### PR DESCRIPTION
**What this PR does / why we need it**: Currently certain operations like tailing logs from the Python sdk fail against the latest version of the training operator due to a label mismatch; fix that. With this patch I can now tail the logs of a TFJob with the training operator deployed from 1.4 and from master.

**Which issue(s) this PR fixes:**
Fixes #1587.

**Checklist:**
- [x] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
