### PR TITLE
chore: stop action on first fail

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -27,23 +27,23 @@ jobs:
 
       - name: Check Go modules
         run: |
-          go mod tidy && git add go.*
+          go mod tidy && git add go.* &&
           git diff --cached --exit-code || (echo 'Please run "go mod tidy" to sync Go modules' && exit 1);
       - name: Check manifests
         run: |
-          make manifests && git add manifests
+          make manifests && git add manifests &&
           git diff --cached --exit-code || (echo 'Please run "make manifests" to generate manifests' && exit 1);
       - name: Check auto-generated codes
         run: |
-          make generate && git add pkg/apis
+          make generate && git add pkg/apis &&
           git diff --cached --exit-code || (echo 'Please run "make generate" to generate Go codes' && exit 1);
       - name: Verify gofmt
         run: |
-          make fmt && git add pkg cmd
+          make fmt && git add pkg cmd &&
           git diff --cached --exit-code || (echo 'Please run "make fmt" to verify gofmt' && exit 1);
       - name: Verify govet
         run: |
-          make vet && git add pkg cmd
+          make vet && git add pkg cmd &&
           git diff --cached --exit-code || (echo 'Please run "make vet" to verify govet' && exit 1);
       - name: Run Go test
         run: make test


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Currently, github action won't stop even though there is an error during make step. Adding a `&&` to make sure github action abort on first fail.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
