### PR TITLE
Restart job on failure for Always,OnFailure,ExitCode Policy

### DIFF
--- a/pkg/controller.v1/pytorch/hpa.go
+++ b/pkg/controller.v1/pytorch/hpa.go
@@ -33,7 +33,7 @@ func (r *PyTorchJobReconciler) ReconcileHPA(pytorhcjob *pytorchv1.PyTorchJob) er
 
 	if pytorhcjob.Spec.ElasticPolicy == nil || pytorhcjob.Spec.ElasticPolicy.Metrics == nil {
 		logger.V(1).Info(
-			"No ElasicPolicy or Metric is specified, skipping HPA reconciling process")
+			"No ElasticPolicy or Metric is specified, skipping HPA reconciling process")
 		return nil
 	}
 

--- a/pkg/controller.v1/pytorch/pytorchjob_controller.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller.go
@@ -419,7 +419,7 @@ func (r *PyTorchJobReconciler) UpdateJobStatus(job interface{},
 		}
 
 		if failed > 0 {
-			if spec.RestartPolicy == commonv1.RestartPolicyExitCode {
+			if spec.RestartPolicy != commonv1.RestartPolicyNever {
 				msg := fmt.Sprintf("PyTorchJob %s is restarting because %d %s replica(s) failed.", pytorchjob.Name, failed, rtype)
 				r.Recorder.Event(pytorchjob, corev1.EventTypeWarning, commonutil.JobRestartingReason, msg)
 				err := commonutil.UpdateJobConditions(jobStatus, commonv1.JobRestarting, commonutil.JobRestartingReason, msg)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

There can be pod level failures caused by the system, which would previously caused the entire job to fail on all policies except ExitCode. See also https://github.com/kubeflow/training-operator/issues/1570

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

https://github.com/kubeflow/training-operator/issues/1570

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
