### PR TITLE
fix: requeue when expire time is not up yet

### DIFF
--- a/pkg/common/util/util_test.go
+++ b/pkg/common/util/util_test.go
@@ -1,0 +1,124 @@
+// Copyright 2022 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
+)
+
+func TestDurationUntilExpireTime(t *testing.T) {
+	tests := []struct {
+		name      string
+		runPolicy *commonv1.RunPolicy
+		jobStatus commonv1.JobStatus
+		want      time.Duration
+		wantErr   bool
+	}{
+		{
+			name:      "running job",
+			runPolicy: &commonv1.RunPolicy{},
+			jobStatus: commonv1.JobStatus{
+				Conditions: []commonv1.JobCondition{newJobCondition(commonv1.JobRunning)},
+			},
+			want:    -1,
+			wantErr: false,
+		},
+		{
+			name: "succeeded job with remaining time 1s",
+			runPolicy: &commonv1.RunPolicy{
+				TTLSecondsAfterFinished: pointer.Int32(5),
+			},
+			jobStatus: commonv1.JobStatus{
+				Conditions:     []commonv1.JobCondition{newJobCondition(commonv1.JobSucceeded)},
+				CompletionTime: &metav1.Time{Time: time.Now().Add(4 * time.Second)},
+			},
+			want:    1,
+			wantErr: false,
+		},
+		{
+			name: "failed job with remaining time 1s",
+			runPolicy: &commonv1.RunPolicy{
+				TTLSecondsAfterFinished: pointer.Int32(5),
+			},
+			jobStatus: commonv1.JobStatus{
+				Conditions:     []commonv1.JobCondition{newJobCondition(commonv1.JobFailed)},
+				CompletionTime: &metav1.Time{Time: time.Now().Add(4 * time.Second)},
+			},
+			want:    1,
+			wantErr: false,
+		},
+		{
+			name:      "succeeded job with infinite TTL",
+			runPolicy: &commonv1.RunPolicy{},
+			jobStatus: commonv1.JobStatus{
+				Conditions:     []commonv1.JobCondition{newJobCondition(commonv1.JobSucceeded)},
+				CompletionTime: &metav1.Time{Time: time.Now().Add(4 * time.Second)},
+			},
+			want:    -1,
+			wantErr: false,
+		},
+		{
+			name: "succeeded job without remaining time",
+			runPolicy: &commonv1.RunPolicy{
+				TTLSecondsAfterFinished: pointer.Int32(5),
+			},
+			jobStatus: commonv1.JobStatus{
+				Conditions:     []commonv1.JobCondition{newJobCondition(commonv1.JobSucceeded)},
+				CompletionTime: &metav1.Time{Time: time.Now().Add(6 * time.Second)},
+			},
+			want:    0,
+			wantErr: false,
+		},
+		{
+			name: "succeeded job with nil completion time error",
+			runPolicy: &commonv1.RunPolicy{
+				TTLSecondsAfterFinished: pointer.Int32(5),
+			},
+			jobStatus: commonv1.JobStatus{
+				Conditions: []commonv1.JobCondition{newJobCondition(commonv1.JobSucceeded)},
+			},
+			want:    -1,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DurationUntilExpireTime(tt.runPolicy, tt.jobStatus)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DurationUntilExpireTime() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				if tt.want < 0 || tt.want >= 0 && tt.want > got {
+					t.Errorf("DurationUntilExpireTime() got = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func newJobCondition(t commonv1.JobConditionType) commonv1.JobCondition {
+	return commonv1.JobCondition{
+		Type:   t,
+		Status: corev1.ConditionTrue,
+	}
+}

--- a/pkg/controller.v1/mpi/mpijob_controller.go
+++ b/pkg/controller.v1/mpi/mpijob_controller.go
@@ -162,6 +162,15 @@ func (jc *MPIJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
+	t, err := util.DurationUntilExpireTime(&mpijob.Spec.RunPolicy, mpijob.Status)
+	if err != nil {
+		logrus.Warnf("Reconcile MPIJob Job error %v", err)
+		return ctrl.Result{}, err
+	}
+	if t >= 0 {
+		return ctrl.Result{Requeue: true, RequeueAfter: t}, nil
+	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/controller.v1/mxnet/mxjob_controller.go
+++ b/pkg/controller.v1/mxnet/mxjob_controller.go
@@ -163,6 +163,15 @@ func (r *MXJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
+	t, err := util.DurationUntilExpireTime(&mxjob.Spec.RunPolicy, mxjob.Status)
+	if err != nil {
+		logrus.Warnf("Reconcile MX Job error %v", err)
+		return ctrl.Result{}, err
+	}
+	if t >= 0 {
+		return ctrl.Result{Requeue: true, RequeueAfter: t}, nil
+	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/controller.v1/pytorch/pytorchjob_controller.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller.go
@@ -162,6 +162,15 @@ func (r *PyTorchJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	t, err := util.DurationUntilExpireTime(&pytorchjob.Spec.RunPolicy, pytorchjob.Status)
+	if err != nil {
+		logrus.Warnf("Reconcile PyTorchJob error %v", err)
+		return ctrl.Result{}, err
+	}
+	if t >= 0 {
+		return ctrl.Result{Requeue: true, RequeueAfter: t}, nil
+	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/controller.v1/tensorflow/job_test.go
+++ b/pkg/controller.v1/tensorflow/job_test.go
@@ -25,9 +25,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kubeflowv1 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
@@ -518,6 +520,75 @@ var _ = Describe("TFJob controller", func() {
 				Expect(testK8sClient.List(ctx, svcList, listOpt)).Should(Succeed())
 				svcRemainingCount := len(svcList.Items)
 				Expect(svcRemainingCount).To(Equal(tc.expectedPodRemaining))
+			}
+		})
+	})
+
+	Context("Test TTL Seconds After Finished", func() {
+		It("should delete job when expired time is up", func() {
+			type testCase struct {
+				description string
+				tfJob       *kubeflowv1.TFJob
+				phase       corev1.PodPhase
+			}
+			testCases := []testCase{
+				{
+					description: "succeeded job with TTL 3s",
+					tfJob:       testutil.NewTFJobWithCleanupJobDelay(0, 1, 0, pointer.Int32(3)),
+					phase:       corev1.PodSucceeded,
+				},
+				{
+					description: "failed job with TTL 3s",
+					tfJob:       testutil.NewTFJobWithCleanupJobDelay(0, 1, 0, pointer.Int32(3)),
+					phase:       corev1.PodFailed,
+				},
+			}
+			jobNameTemplate := "test-bof-%d"
+			for idx, tc := range testCases {
+				By(fmt.Sprintf("preparing cases %s", tc.description))
+				ctx := context.Background()
+				name := fmt.Sprintf(jobNameTemplate, idx)
+				tc.tfJob.SetName(name)
+
+				By("creating a TFJob")
+				Expect(reconciler.Create(ctx, tc.tfJob)).Should(Succeed())
+
+				initializeReplicaStatuses(&tc.tfJob.Status, kubeflowv1.TFJobReplicaTypeWorker)
+
+				By("prepare pod")
+				refs := []metav1.OwnerReference{
+					*reconciler.GenOwnerReference(tc.tfJob),
+				}
+				pod := testutil.NewBasePod("pod", tc.tfJob, refs)
+				pod.Status.Phase = tc.phase
+
+				By("update job replica statuses")
+				updateJobReplicaStatuses(&tc.tfJob.Status, kubeflowv1.TFJobReplicaTypeWorker, pod)
+
+				By("update job status")
+				Expect(reconciler.UpdateJobStatus(tc.tfJob, tc.tfJob.Spec.TFReplicaSpecs, &tc.tfJob.Status)).To(Succeed())
+				Expect(reconciler.Status().Update(ctx, tc.tfJob)).Should(Succeed())
+
+				ttl := tc.tfJob.Spec.RunPolicy.TTLSecondsAfterFinished
+				if ttl != nil {
+					dur := time.Second * time.Duration(*ttl)
+					time.Sleep(dur)
+				}
+
+				Eventually(func() error {
+					tfJob := &kubeflowv1.TFJob{}
+					key := types.NamespacedName{
+						Namespace: metav1.NamespaceDefault,
+						Name:      name,
+					}
+					if err := reconciler.Get(ctx, key, tfJob); err != nil {
+						if errors.IsNotFound(err) {
+							return nil
+						}
+						return err
+					}
+					return fmt.Errorf("job %s still remains", name)
+				}, timeout, interval).Should(BeNil())
 			}
 		})
 	})

--- a/pkg/controller.v1/tensorflow/tfjob_controller.go
+++ b/pkg/controller.v1/tensorflow/tfjob_controller.go
@@ -183,6 +183,15 @@ func (r *TFJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
+	t, err := util.DurationUntilExpireTime(&tfjob.Spec.RunPolicy, tfjob.Status)
+	if err != nil {
+		logrus.Warnf("Reconcile Tensorflow Job error %v", err)
+		return ctrl.Result{}, err
+	}
+	if t >= 0 {
+		return ctrl.Result{Requeue: true, RequeueAfter: t}, nil
+	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/controller.v1/xgboost/xgboostjob_controller.go
+++ b/pkg/controller.v1/xgboost/xgboostjob_controller.go
@@ -169,6 +169,15 @@ func (r *XGBoostJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	t, err := util.DurationUntilExpireTime(&xgboostjob.Spec.RunPolicy, xgboostjob.Status)
+	if err != nil {
+		logrus.Warnf("Reconcile XGBoost Job error %v", err)
+		return ctrl.Result{}, err
+	}
+	if t >= 0 {
+		return ctrl.Result{Requeue: true, RequeueAfter: t}, nil
+	}
+
 	return reconcile.Result{}, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Garrybest <garrybest@foxmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
When reconciling jobs, if expire time is not up yet, the `common.JobController` would [requeue](https://github.com/kubeflow/common/blob/21f5ba8833a2e21df17601497a08396c9bae9ab2/pkg/controller.v1/common/job.go#L346-L352) the object into a `FakeWorkQueue`, which does not work in Reconcilers.

I would like to check TTL after finished and requeue the object until expire time is up if necessary.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #1533

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
