### PR TITLE
fix: MPIJob worker still running when NotEnoughResources

### DIFF
--- a/pkg/controller.v1/mpi/mpijob_controller.go
+++ b/pkg/controller.v1/mpi/mpijob_controller.go
@@ -638,16 +638,7 @@ func (jc *MPIJobReconciler) UpdateJobStatus(job interface{}, replicas map[common
 			}
 		}
 	}
-
-	// Some workers are still running, leave a running condition.
-	msg := fmt.Sprintf("MPIJob %s is running.", mpiJob.Name)
-	commonutil.LoggerForJob(mpiJob).Infof(msg)
-
-	if err := commonutil.UpdateJobConditions(jobStatus, commonv1.JobRunning, commonutil.JobRunningReason, msg); err != nil {
-		commonutil.LoggerForJob(mpiJob).Error(err, "failed to update MPIJob conditions")
-		return err
-	}
-
+	mpiJob.Status = *jobStatus.DeepCopy()
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
 Before migrate v1 MPI operator to training-operator，only when all the workers of MPIJob are ready and the launcher of MPIJob is running，the state of MPIJob can change from Created to Running. So It is more reasonable to keep the STATE of MPIJob  as created when NotEnoughResources.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #1617

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
