### PR TITLE
Fix the default LeaderElectionID and make it an argument

### DIFF
--- a/cmd/training-operator.v1/main.go
+++ b/cmd/training-operator.v1/main.go
@@ -51,6 +51,7 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var leaderElectionID string
 	var probeAddr string
 	var enabledSchemes controllerv1.EnabledSchemes
 	var enableGangScheduling bool
@@ -62,6 +63,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&leaderElectionID, "leader-election-id", "1ca428e5.training-operator.kubeflow.org", "The ID for leader election.")
 	flag.Var(&enabledSchemes, "enable-scheme", "Enable scheme(s) as --enable-scheme=tfjob --enable-scheme=pytorchjob, case insensitive."+
 		" Now supporting TFJob, PyTorchJob, MXNetJob, XGBoostJob. By default, all supported schemes will be enabled.")
 	flag.BoolVar(&enableGangScheduling, "enable-gang-scheduling", false, "Set true to enable gang scheduling")
@@ -96,7 +98,7 @@ func main() {
 		Port:                   monitoringPort,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "1ca428e5.",
+		LeaderElectionID:       leaderElectionID,
 		Namespace:              namespace,
 	})
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the default leader election ID which has an invalid format. If one enables leader election through `leader-elect=true`, the operator fails to start with the following error:

**Before:**
```
> go run ./cmd/training-operator.v1/main.go -leader-elect=true --namespace kubeflow
1.6589798403535447e+09  INFO    controller-runtime.metrics      Metrics server is starting to listen    {"addr": ":8080"}
1.6589798403555276e+09  INFO    setup   starting manager
1.6589798403558226e+09  INFO    Starting server {"path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
1.6589798403558557e+09  INFO    Starting server {"kind": "health probe", "addr": "[::]:8081"}
I0727 20:44:00.356108 1889297 leaderelection.go:248] attempting to acquire leader lease kubeflow/1ca428e5....
E0727 20:44:00.360526 1889297 leaderelection.go:334] error initially creating leader election record: Lease.coordination.k8s.io "1ca428e5." is invalid: metadata.name: Invalid value: "1ca428e5.": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
E0727 20:44:04.107669 1889297 leaderelection.go:334] error initially creating leader election record: Lease.coordination.k8s.io "1ca428e5." is invalid: metadata.name: Invalid value: "1ca428e5.": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

Fails to acquire lease:

`
E0727 20:44:04.107669 1889297 leaderelection.go:334] error initially creating leader election record: Lease.coordination.k8s.io "1ca428e5." is invalid: metadata.name: Invalid value: "1ca428e5.": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
`

**After:**
```
> go run ./cmd/training-operator.v1/main.go -leader-elect=true --namespace kubeflow
1.6589798807258694e+09  INFO    controller-runtime.metrics      Metrics server is starting to listen    {"addr": ":8080"}
1.6589798807272537e+09  INFO    setup   starting manager
1.6589798807275426e+09  INFO    Starting server {"path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
1.6589798807275436e+09  INFO    Starting server {"kind": "health probe", "addr": "[::]:8081"}
I0727 20:44:40.727719 1890098 leaderelection.go:248] attempting to acquire leader lease kubeflow/1ca428e5.training-operator.kubeflow.org...
I0727 20:44:57.469968 1890098 leaderelection.go:258] successfully acquired lease kubeflow/1ca428e5.training-operator.kubeflow.org
1.6589798974700997e+09  DEBUG   events  Normal  {"object": {"kind":"Lease","namespace":"kubeflow","name":"1ca428e5.training-operator.kubeflow.org","uid":"bea108c0-01ba-4759-bdd4-d55accfa7596","apiVersion":"coordination.k8s.io/v1","resourceVersion":"16304"}, "reason": "LeaderElection", "message": "angoyal-ld5.linkedin.biz_a24fbed3-c23d-4d3d-922b-407b342e23d8 became leader"}
1.6589798974702497e+09  INFO    Starting EventSource    {"controller": "mxjob-controller", "source": "kind source: *v1.MXJob"}
1.6589798974702735e+
```
Successfully acquires lease:

`
I0727 20:44:40.727719 1890098 leaderelection.go:248] attempting to acquire leader lease kubeflow/1ca428e5.training-operator.kubeflow.org...
I0727 20:44:57.469968 1890098 leaderelection.go:258] successfully acquired lease kubeflow/1ca428e5.training-operator.kubeflow.org
`

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #1640

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
