### PR TITLE
style: Refine name and signature of 2 replicaName functions

### DIFF
--- a/pkg/controller.v1/pytorch/envvar.go
+++ b/pkg/controller.v1/pytorch/envvar.go
@@ -103,8 +103,8 @@ func getTotalReplicas(job *kubeflowv1.PyTorchJob) int32 {
 	return jobReplicas
 }
 
-func genGeneralName(jobName, rtype, index string) string {
-	n := jobName + "-" + rtype + "-" + index
+func replicaName(jobName string, rtype commonv1.ReplicaType, index int) string {
+	n := jobName + "-" + strings.ToLower(string(rtype)) + "-" + strconv.Itoa(index)
 	return strings.Replace(n, "/", "-", -1)
 }
 

--- a/pkg/controller.v1/pytorch/initcontainer.go
+++ b/pkg/controller.v1/pytorch/initcontainer.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"html/template"
 	"io/ioutil"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -120,8 +119,8 @@ func setInitContainer(obj interface{}, podTemplate *corev1.PodTemplateSpec,
 	// rtype is worker.
 	if rtype == strings.ToLower(string(kubeflowv1.PyTorchJobReplicaTypeWorker)) {
 		g := getInitContainerGenerator()
-		initContainers, err := g.GetInitContainer(genGeneralName(pytorchJob.Name,
-			strings.ToLower(string(kubeflowv1.PyTorchJobReplicaTypeMaster)), strconv.Itoa(0)))
+		initContainers, err := g.GetInitContainer(replicaName(pytorchJob.Name,
+			kubeflowv1.PyTorchJobReplicaTypeMaster, 0))
 		if err != nil {
 			return err
 		}

--- a/pkg/controller.v1/pytorch/master.go
+++ b/pkg/controller.v1/pytorch/master.go
@@ -2,7 +2,6 @@ package pytorch
 
 import (
 	"strconv"
-	"strings"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
@@ -37,7 +36,7 @@ func (e MasterEnvVarGenerator) Generate(
 			return nil, err
 		}
 
-		masterAddr := genGeneralName(job.Name, strings.ToLower(string(kubeflowv1.PyTorchJobReplicaTypeMaster)), strconv.Itoa(0))
+		masterAddr := replicaName(job.Name, kubeflowv1.PyTorchJobReplicaTypeMaster, 0)
 
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  EnvMasterPort,

--- a/pkg/controller.v1/xgboost/xgboost.go
+++ b/pkg/controller.v1/xgboost/xgboost.go
@@ -47,7 +47,7 @@ func SetPodEnv(job interface{}, podTemplate *corev1.PodTemplateSpec, rtype, inde
 		rank += masterReplicas
 	}
 
-	masterAddr := computeMasterAddr(xgboostjob.Name, strings.ToLower(string(kubeflowv1.XGBoostJobReplicaTypeMaster)), strconv.Itoa(0))
+	masterAddr := replicaName(xgboostjob.Name, kubeflowv1.XGBoostJobReplicaTypeMaster, 0)
 
 	masterPort, err := getPortFromXGBoostJob(xgboostjob, kubeflowv1.XGBoostJobReplicaTypeMaster)
 	if err != nil {
@@ -67,7 +67,7 @@ func SetPodEnv(job interface{}, podTemplate *corev1.PodTemplateSpec, rtype, inde
 		workerPort = workerPortTemp
 		workerAddrs = make([]string, totalReplicas-1)
 		for i := range workerAddrs {
-			workerAddrs[i] = computeMasterAddr(xgboostjob.Name, strings.ToLower(string(kubeflowv1.XGBoostJobReplicaTypeWorker)), strconv.Itoa(i))
+			workerAddrs[i] = replicaName(xgboostjob.Name, kubeflowv1.XGBoostJobReplicaTypeWorker, i)
 		}
 	}
 
@@ -111,8 +111,8 @@ func SetPodEnv(job interface{}, podTemplate *corev1.PodTemplateSpec, rtype, inde
 	return nil
 }
 
-func computeMasterAddr(jobName, rtype, index string) string {
-	n := jobName + "-" + rtype + "-" + index
+func replicaName(jobName string, rtype commonv1.ReplicaType, index int) string {
+	n := jobName + "-" + strings.ToLower(string(rtype)) + "-" + strconv.Itoa(index)
 	return strings.Replace(n, "/", "-", -1)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

2 tiny functions in pytorch and xgboost controllers are renamed and redesigned. They both
1. do the same thing: generating names for each replica of a job
2. share same parameters: the job name, the type of the replica, an index number

So, they are renamed to `replicaName`, and redesigned to use proper types for parameters

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
