### PR TITLE
Removed GOARCH dependency for multiarch support

### DIFF
--- a/build/images/training-operator/Dockerfile
+++ b/build/images/training-operator/Dockerfile
@@ -13,7 +13,7 @@ RUN go mod download
 COPY . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager cmd/training-operator.v1/main.go
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager cmd/training-operator.v1/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
These changes are targeted to remove the arch-specific dependency.
Also, these changes are verified for Intel and ppc64le.