### PR TITLE
[SDK] Remove Final Keyword from constants

### DIFF
--- a/sdk/python/kubeflow/training/constants/constants.py
+++ b/sdk/python/kubeflow/training/constants/constants.py
@@ -13,63 +13,60 @@
 # limitations under the License.
 
 import os
-from typing import Final
 
 # General constants
 # How long to wait in seconds for requests to the ApiServer
-APISERVER_TIMEOUT: Final[int] = 120
-KUBEFLOW_GROUP: Final[str] = "kubeflow.org"
+APISERVER_TIMEOUT = 120
+KUBEFLOW_GROUP = "kubeflow.org"
 
 # TFJob K8S constants
-TFJOB_KIND: Final[str] = "TFJob"
-TFJOB_PLURAL: Final[str] = "tfjobs"
-TFJOB_VERSION: Final[str] = os.environ.get("TFJOB_VERSION", "v1")
+TFJOB_KIND = "TFJob"
+TFJOB_PLURAL = "tfjobs"
+TFJOB_VERSION = os.environ.get("TFJOB_VERSION", "v1")
 
-TFJOB_LOGLEVEL: Final[str] = os.environ.get("TFJOB_LOGLEVEL", "INFO").upper()
+TFJOB_LOGLEVEL = os.environ.get("TFJOB_LOGLEVEL", "INFO").upper()
 
-TFJOB_BASE_IMAGE: Final[str] = "docker.io/tensorflow/tensorflow:2.9.1"
-TFJOB_BASE_IMAGE_GPU: Final[str] = "docker.io/tensorflow/tensorflow:2.9.1-gpu"
+TFJOB_BASE_IMAGE = "docker.io/tensorflow/tensorflow:2.9.1"
+TFJOB_BASE_IMAGE_GPU = "docker.io/tensorflow/tensorflow:2.9.1-gpu"
 
 # Job Label Names
-JOB_GROUP_LABEL: Final[str] = "group-name"
-JOB_NAME_LABEL: Final[str] = "training.kubeflow.org/job-name"
-JOB_TYPE_LABEL: Final[str] = "training.kubeflow.org/replica-type"
-JOB_INDEX_LABEL: Final[str] = "training.kubeflow.org/replica-index"
-JOB_ROLE_LABEL: Final[str] = "training.kubeflow.org/job-role"
-JOB_ROLE_MASTER: Final[str] = "master"
+JOB_GROUP_LABEL = "group-name"
+JOB_NAME_LABEL = "training.kubeflow.org/job-name"
+JOB_TYPE_LABEL = "training.kubeflow.org/replica-type"
+JOB_INDEX_LABEL = "training.kubeflow.org/replica-index"
+JOB_ROLE_LABEL = "training.kubeflow.org/job-role"
+JOB_ROLE_MASTER = "master"
 
-JOB_STATUS_SUCCEEDED: Final[str] = "Succeeded"
-JOB_STATUS_FAILED: Final[str] = "Failed"
-JOB_STATUS_RUNNING: Final[str] = "Running"
+JOB_STATUS_SUCCEEDED = "Succeeded"
+JOB_STATUS_FAILED = "Failed"
+JOB_STATUS_RUNNING = "Running"
 
 # PyTorchJob K8S constants
-PYTORCHJOB_KIND: Final[str] = "PyTorchJob"
-PYTORCHJOB_PLURAL: Final[str] = "pytorchjobs"
-PYTORCHJOB_VERSION: Final[str] = os.environ.get("PYTORCHJOB_VERSION", "v1")
+PYTORCHJOB_KIND = "PyTorchJob"
+PYTORCHJOB_PLURAL = "pytorchjobs"
+PYTORCHJOB_VERSION = os.environ.get("PYTORCHJOB_VERSION", "v1")
 
-PYTORCH_LOGLEVEL: Final[str] = os.environ.get("PYTORCHJOB_LOGLEVEL", "INFO").upper()
+PYTORCH_LOGLEVEL = os.environ.get("PYTORCHJOB_LOGLEVEL", "INFO").upper()
 
-PYTORCHJOB_BASE_IMAGE: Final[
-    str
-] = "docker.io/pytorch/pytorch:1.12.1-cuda11.3-cudnn8-runtime"
+PYTORCHJOB_BASE_IMAGE = "docker.io/pytorch/pytorch:1.12.1-cuda11.3-cudnn8-runtime"
 
 # XGBoostJob K8S constants
-XGBOOSTJOB_KIND: Final[str] = "XGBoostJob"
-XGBOOSTJOB_PLURAL: Final[str] = "xgboostjobs"
-XGBOOSTJOB_VERSION: Final[str] = os.environ.get("XGBOOSTJOB_VERSION", "v1")
+XGBOOSTJOB_KIND = "XGBoostJob"
+XGBOOSTJOB_PLURAL = "xgboostjobs"
+XGBOOSTJOB_VERSION = os.environ.get("XGBOOSTJOB_VERSION", "v1")
 
-XGBOOST_LOGLEVEL: Final[str] = os.environ.get("XGBOOSTJOB_LOGLEVEL", "INFO").upper()
+XGBOOST_LOGLEVEL = os.environ.get("XGBOOSTJOB_LOGLEVEL", "INFO").upper()
 
 # MPIJob K8S constants
-MPIJOB_KIND: Final[str] = "MPIJob"
-MPIJOB_PLURAL: Final[str] = "mpijobs"
-MPIJOB_VERSION: Final[str] = os.environ.get("MPIJOB_VERSION", "v1")
+MPIJOB_KIND = "MPIJob"
+MPIJOB_PLURAL = "mpijobs"
+MPIJOB_VERSION = os.environ.get("MPIJOB_VERSION", "v1")
 
-MPI_LOGLEVEL: Final[str] = os.environ.get("MPIJOB_LOGLEVEL", "INFO").upper()
+MPI_LOGLEVEL = os.environ.get("MPIJOB_LOGLEVEL", "INFO").upper()
 
 # MXNETJob K8S constants
-MXJOB_KIND: Final[str] = "MXJob"
-MXJOB_PLURAL: Final[str] = "mxjobs"
-MXJOB_VERSION: Final[str] = os.environ.get("MXJOB_VERSION", "v1")
+MXJOB_KIND = "MXJob"
+MXJOB_PLURAL = "mxjobs"
+MXJOB_VERSION = os.environ.get("MXJOB_VERSION", "v1")
 
-MX_LOGLEVEL: Final[str] = os.environ.get("MXJOB_LOGLEVEL", "INFO").upper()
+MX_LOGLEVEL = os.environ.get("MXJOB_LOGLEVEL", "INFO").upper()


### PR DESCRIPTION
I think, we should remove Final keyword from our constants in Python SDK.
Final is available only in >= Python 3.8 version: https://peps.python.org/pep-0591/
Currently, we say that [Training Operator SDK is supported in Python 3 and 3.7](https://github.com/kubeflow/training-operator/blob/master/sdk/python/setup.py#L45-L47).
Also, it's better to be compatible with other Kubeflow components SDKs, [e.g. with Kubeflow Pipelines](https://github.com/kubeflow/pipelines/blob/master/sdk/python/setup.py#L85-L87).

We can think about Python upgrade in the future releases/versions across various Kubeflow components.

cc @johnugeorge @tenzen-y @anencore94 