### PR TITLE
Make a generic logger instead of the nil logger on dependent update

### DIFF
--- a/pkg/common/util/reconciler.go
+++ b/pkg/common/util/reconciler.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kubeflow/common/pkg/controller.v1/common"
 	"github.com/kubeflow/common/pkg/controller.v1/expectation"
 	commonutil "github.com/kubeflow/common/pkg/util"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -83,7 +82,9 @@ func OnDependentUpdateFunc(jc *common.JobController) func(updateEvent event.Upda
 			return false
 		}
 
-		var logger *logrus.Entry
+		kind := jc.Controller.GetAPIGroupVersionKind().Kind
+		var logger = LoggerForGenericKind(newObj, kind)
+
 		if _, ok := newObj.(*corev1.Pod); ok {
 			logger = commonutil.LoggerForPod(newObj.(*corev1.Pod), jc.Controller.GetAPIGroupVersionKind().Kind)
 		}

--- a/pkg/common/util/reconciler.go
+++ b/pkg/common/util/reconciler.go
@@ -56,12 +56,13 @@ func OnDependentCreateFunc(exp expectation.ControllerExpectationsInterface) func
 		if controllerRef := metav1.GetControllerOf(e.Object); controllerRef != nil {
 			jobKey := fmt.Sprintf("%s/%s", e.Object.GetNamespace(), controllerRef.Name)
 			var expectKey string
-			if _, ok := e.Object.(*corev1.Pod); ok {
+			switch e.Object.(type) {
+			case *corev1.Pod:
 				expectKey = expectation.GenExpectationPodsKey(jobKey, rtype)
-			}
-
-			if _, ok := e.Object.(*corev1.Service); ok {
+			case *corev1.Service:
 				expectKey = expectation.GenExpectationServicesKey(jobKey, rtype)
+			default:
+				return false
 			}
 			exp.CreationObserved(expectKey)
 			return true
@@ -85,12 +86,13 @@ func OnDependentUpdateFunc(jc *common.JobController) func(updateEvent event.Upda
 		kind := jc.Controller.GetAPIGroupVersionKind().Kind
 		var logger = LoggerForGenericKind(newObj, kind)
 
-		if _, ok := newObj.(*corev1.Pod); ok {
-			logger = commonutil.LoggerForPod(newObj.(*corev1.Pod), jc.Controller.GetAPIGroupVersionKind().Kind)
-		}
-
-		if _, ok := newObj.(*corev1.Service); ok {
+		switch obj := newObj.(type) {
+		case *corev1.Pod:
+			logger = commonutil.LoggerForPod(obj, jc.Controller.GetAPIGroupVersionKind().Kind)
+		case *corev1.Service:
 			logger = commonutil.LoggerForService(newObj.(*corev1.Service), jc.Controller.GetAPIGroupVersionKind().Kind)
+		default:
+			return false
 		}
 
 		newControllerRef := metav1.GetControllerOf(newObj)
@@ -152,14 +154,14 @@ func OnDependentDeleteFunc(exp expectation.ControllerExpectationsInterface) func
 		if controllerRef := metav1.GetControllerOf(e.Object); controllerRef != nil {
 			jobKey := fmt.Sprintf("%s/%s", e.Object.GetNamespace(), controllerRef.Name)
 			var expectKey string
-			if _, ok := e.Object.(*corev1.Pod); ok {
+			switch e.Object.(type) {
+			case *corev1.Pod:
 				expectKey = expectation.GenExpectationPodsKey(jobKey, rtype)
-			}
-
-			if _, ok := e.Object.(*corev1.Service); ok {
+			case *corev1.Service:
 				expectKey = expectation.GenExpectationServicesKey(jobKey, rtype)
+			default:
+				return false
 			}
-
 			exp.DeletionObserved(expectKey)
 			return true
 		}

--- a/pkg/common/util/reconciler_test.go
+++ b/pkg/common/util/reconciler_test.go
@@ -1,0 +1,58 @@
+package util
+
+import (
+	"testing"
+
+	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
+	"github.com/kubeflow/common/pkg/controller.v1/expectation"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestOnDependentXXXFunc(t *testing.T) {
+	createfunc := OnDependentCreateFunc(expectation.NewControllerExpectations())
+	deletefunc := OnDependentDeleteFunc(expectation.NewControllerExpectations())
+
+	for _, testCase := range []struct {
+		object client.Object
+		expect bool
+	}{
+		{
+			// pod object with label is allowed
+			object: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						commonv1.ReplicaTypeLabel: "Worker",
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			// service object without label is not allowed
+			object: &corev1.Service{},
+			expect: false,
+		},
+		{
+			// objects other than pod/service are not allowed
+			object: &corev1.ConfigMap{},
+			expect: false,
+		},
+	} {
+		ret := createfunc(event.CreateEvent{
+			Object: testCase.object,
+		})
+		if ret != testCase.expect {
+			t.Errorf("expect %t, but get %t", testCase.expect, ret)
+		}
+		ret = deletefunc(event.DeleteEvent{
+			Object: testCase.object,
+		})
+		if ret != testCase.expect {
+			t.Errorf("expect %t, but get %t", testCase.expect, ret)
+		}
+
+	}
+}

--- a/pkg/controller.v1/mxnet/mxjob_controller.go
+++ b/pkg/controller.v1/mxnet/mxjob_controller.go
@@ -226,9 +226,9 @@ func (r *MXJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			IsController: true,
 			OwnerType:    &kubeflowv1.MXJob{},
 		}, predicate.Funcs{
-			CreateFunc: util.OnDependentCreateFunc(r.Expectations),
-			UpdateFunc: util.OnDependentUpdateFunc(&r.JobController),
-			DeleteFunc: util.OnDependentDeleteFunc(r.Expectations),
+			CreateFunc: util.OnDependentCreateFuncGeneric(r.Expectations),
+			UpdateFunc: util.OnDependentUpdateFuncGeneric(&r.JobController),
+			DeleteFunc: util.OnDependentDeleteFuncGeneric(r.Expectations),
 		}); err != nil {
 			return err
 		}

--- a/pkg/controller.v1/pytorch/pytorchjob_controller.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller.go
@@ -224,9 +224,9 @@ func (r *PyTorchJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			IsController: true,
 			OwnerType:    &kubeflowv1.PyTorchJob{},
 		}, predicate.Funcs{
-			CreateFunc: util.OnDependentCreateFunc(r.Expectations),
-			UpdateFunc: util.OnDependentUpdateFunc(&r.JobController),
-			DeleteFunc: util.OnDependentDeleteFunc(r.Expectations),
+			CreateFunc: util.OnDependentCreateFuncGeneric(r.Expectations),
+			UpdateFunc: util.OnDependentUpdateFuncGeneric(&r.JobController),
+			DeleteFunc: util.OnDependentDeleteFuncGeneric(r.Expectations),
 		}); err != nil {
 			return err
 		}

--- a/pkg/controller.v1/tensorflow/tfjob_controller.go
+++ b/pkg/controller.v1/tensorflow/tfjob_controller.go
@@ -245,9 +245,9 @@ func (r *TFJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			IsController: true,
 			OwnerType:    &kubeflowv1.TFJob{},
 		}, predicate.Funcs{
-			CreateFunc: util.OnDependentCreateFunc(r.Expectations),
-			UpdateFunc: util.OnDependentUpdateFunc(&r.JobController),
-			DeleteFunc: util.OnDependentDeleteFunc(r.Expectations),
+			CreateFunc: util.OnDependentCreateFuncGeneric(r.Expectations),
+			UpdateFunc: util.OnDependentUpdateFuncGeneric(&r.JobController),
+			DeleteFunc: util.OnDependentDeleteFuncGeneric(r.Expectations),
 		}); err != nil {
 			return err
 		}

--- a/pkg/controller.v1/xgboost/xgboostjob_controller.go
+++ b/pkg/controller.v1/xgboost/xgboostjob_controller.go
@@ -231,9 +231,9 @@ func (r *XGBoostJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			IsController: true,
 			OwnerType:    &kubeflowv1.XGBoostJob{},
 		}, predicate.Funcs{
-			CreateFunc: util.OnDependentCreateFunc(r.Expectations),
-			UpdateFunc: util.OnDependentUpdateFunc(&r.JobController),
-			DeleteFunc: util.OnDependentDeleteFunc(r.Expectations),
+			CreateFunc: util.OnDependentCreateFuncGeneric(r.Expectations),
+			UpdateFunc: util.OnDependentUpdateFuncGeneric(&r.JobController),
+			DeleteFunc: util.OnDependentDeleteFuncGeneric(r.Expectations),
 		}); err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Peng Gao <peng.gao.dut@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Make a temporary logger for generic object instead of being nil.
 
**Which issue(s) this PR fixes**

Fixes  #1679 #1678

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
