### PR TITLE
support monitor podgroup

### DIFF
--- a/cmd/training-operator.v1/main.go
+++ b/cmd/training-operator.v1/main.go
@@ -64,6 +64,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Var(&enabledSchemes, "enable-scheme", "Enable scheme(s) as --enable-scheme=tfjob --enable-scheme=pytorchjob, case insensitive."+
 		" Now supporting TFJob, PyTorchJob, MXNetJob, XGBoostJob. By default, all supported schemes will be enabled.")
+	flag.Var(&config.Config.WatchedResources, "enable-watch-resources", "The list of resources that need be watched to trigger reconcile, in the form: Kind.version.group (e.g. TFJob.v1.kubeflow.org)")
 	flag.BoolVar(&enableGangScheduling, "enable-gang-scheduling", false, "Set true to enable gang scheduling")
 	flag.StringVar(&gangSchedulerName, "gang-scheduler-name", "volcano", "The scheduler to gang-schedule kubeflow jobs, defaults to volcano")
 	flag.StringVar(&namespace, "namespace", os.Getenv(commonutil.EnvKubeflowNamespace), "The namespace to monitor kubeflow jobs. If unset, it monitors all namespaces cluster-wide."+

--- a/pkg/common/util/flag_util.go
+++ b/pkg/common/util/flag_util.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// GvkListFlag is the custom flag to parse GroupVersionKind list for trial resources.
+type GvkListFlag []schema.GroupVersionKind
+
+// Set is the method to convert gvk to string value
+func (flag *GvkListFlag) String() string {
+	gvkStrings := []string{}
+	for _, x := range []schema.GroupVersionKind(*flag) {
+		gvkStrings = append(gvkStrings, x.String())
+	}
+	return strings.Join(gvkStrings, ",")
+}
+
+// Set is the method to set gvk from string flag value
+func (flag *GvkListFlag) Set(value string) error {
+	gvk, _ := schema.ParseKindArg(value)
+	if gvk == nil {
+		return fmt.Errorf("Invalid GroupVersionKind: %v", value)
+	}
+	*flag = append(*flag, *gvk)
+	return nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,11 +14,15 @@
 
 package config
 
+import "github.com/kubeflow/training-operator/pkg/common/util"
+
 // Config is the global configuration for the training operator.
 var Config struct {
 	PyTorchInitContainerTemplateFile string
 	PyTorchInitContainerImage        string
 	MPIKubectlDeliveryImage          string
+
+	WatchedResources util.GvkListFlag
 }
 
 const (


### PR DESCRIPTION
if we create a pytorchjob, operator will create a podgroup later (we use volcano as scheduler),if there is no enough resources in cluster at the moment, the status of podgroup will be pending, and the reconcile function will break.

after a while, if there are enough resources available, the status of podgroup will be inqueue. then the reconcile function should continue to run. but the operator have not listening the podgroup, so the status pytorchjob will always be created, and no pod will be created.

so we may need to watch the change of podgroup's status, so that the reconcile function can continue to create pods and services.


```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    control-plane: kubeflow-training-operator
  name: training-operator
  namespace: kubeflow
spec:
  replicas: 1
  selector:
    matchLabels:
      control-plane: kubeflow-training-operator
  template:
    spec:
      containers:
      - command:
        - /manager
        args:
        - --enable-gang-scheduling=true
        - --enable-watch-resources=PodGroup.v1beta1.scheduling.volcano.sh
```

I add  an argument  `enable-watch-resources`,  you can add any resources you want to monitor, controller will watch its change to trigger the reconcile.

related pr #1677 