### PR TITLE
Adding support for linux/ppc64le in github actions for training-operator

### DIFF
--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -13,6 +13,11 @@ runs:
   steps:
     - name: Set Up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: amd64,ppc64le,arm64
 
     - name: Docker Login
       uses: docker/login-action@v2
@@ -32,6 +37,7 @@ runs:
     - name: Build and Push
       uses: docker/build-push-action@v3
       with:
+        platforms: linux/amd64,linux/ppc64le,linux/arm64
         context: .
         file: ${{ inputs.dockerfile }}
         push: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

I have added support for Linux/ppc64le architecture in GitHub actions. using QEMU. It enables the CI for Linux/ppc64le. Please review and merge.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #1664 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing

