### PR TITLE
Fix status lost

### DIFF
--- a/pkg/controller.v1/mpi/mpijob_controller.go
+++ b/pkg/controller.v1/mpi/mpijob_controller.go
@@ -359,9 +359,9 @@ func (jc *MPIJobReconciler) ReconcilePods(
 	}
 
 	// first set StartTime.
-	if mpiJob.Status.StartTime == nil {
+	if jobStatus.StartTime == nil {
 		now := metav1.Now()
-		mpiJob.Status.StartTime = &now
+		jobStatus.StartTime = &now
 	}
 
 	initializeReplicaStatuses(jobStatus, rtype)
@@ -639,9 +639,9 @@ func (jc *MPIJobReconciler) UpdateJobStatus(job interface{}, replicas map[common
 			} else {
 				msg := fmt.Sprintf("MPIJob %s is failed because %d %s replica(s) failed.", mpiJob.Name, failed, rtype)
 				jc.Recorder.Event(mpiJob, corev1.EventTypeNormal, commonutil.JobFailedReason, msg)
-				if mpiJob.Status.CompletionTime == nil {
+				if jobStatus.CompletionTime == nil {
 					now := metav1.Now()
-					mpiJob.Status.CompletionTime = &now
+					jobStatus.CompletionTime = &now
 				}
 				err := commonutil.UpdateJobConditions(jobStatus, commonv1.JobFailed, commonutil.JobFailedReason, msg)
 				if err != nil {


### PR DESCRIPTION
common package uses jobStatus to update job. This
fix makes up the loss of start and completion time of status.

Signed-off-by: Peng Gao <peng.gao.dut@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
