### PR TITLE
fix: Mac M1 compatible Dockerfile and bump TF version

### DIFF
--- a/examples/tensorflow/distribution_strategy/keras-API/Dockerfile
+++ b/examples/tensorflow/distribution_strategy/keras-API/Dockerfile
@@ -1,6 +1,6 @@
-FROM tensorflow/tensorflow:2.1.0-gpu-py3
+FROM python:3.9
 
-RUN pip install tensorflow_datasets==2.1.0
+RUN pip install tensorflow==2.11.0 tensorflow_datasets==4.7.0
 
 COPY multi_worker_strategy-with-keras.py /
 ENTRYPOINT ["python", "/multi_worker_strategy-with-keras.py", "--saved_model_dir", "/train/saved_model/", "--checkpoint_dir", "/train/checkpoint"]


### PR DESCRIPTION
The TF image does not work on Mac M1. Switching to use Python base image and install TF from there. Also bumped TF versions.

Verified that the example works.