### PR TITLE
fix： allow predicate checkout of podgroup UpdateFunc

### DIFF
--- a/pkg/common/util/reconciler.go
+++ b/pkg/common/util/reconciler.go
@@ -17,6 +17,7 @@ package util
 import (
 	"fmt"
 	"reflect"
+	"volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 
 	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 	"github.com/kubeflow/common/pkg/controller.v1/common"
@@ -91,6 +92,8 @@ func OnDependentUpdateFunc(jc *common.JobController) func(updateEvent event.Upda
 			logger = commonutil.LoggerForPod(obj, jc.Controller.GetAPIGroupVersionKind().Kind)
 		case *corev1.Service:
 			logger = commonutil.LoggerForService(newObj.(*corev1.Service), jc.Controller.GetAPIGroupVersionKind().Kind)
+		case *v1beta1.PodGroup:
+			logger = commonutil.LoggerForPodGroup(newObj.(*v1beta1.PodGroup), jc.Controller.GetAPIGroupVersionKind().Kind)
 		default:
 			return false
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
when apply paddlepaddleJob with  enable gang schedule, that the operator  SyncPodGroup and delay pods creation until podgroup status is inqueue, the operator update LastReconcileTime of jobStatus in each reconcile that can trigger next Reconcile. 
when the last two LastReconcileTime is same in second, then canot tigger next reconcile in watch loop. and this paddlepaddleJob is always in pendding, unless reboot training-operator pod or modify paddlepaddleJob.
for the above bug, it can tigger by podgroup status change, but OnDependentUpdateFunc in reconciler.go only allow pod/service, my pr is fix to allow tigger event loop by podgroup update

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
