### PR TITLE
To fix scaledown error, upgrade PyTorch version to v1.13.1 in echo example

### DIFF
--- a/examples/pytorch/elastic/echo/Dockerfile
+++ b/examples/pytorch/elastic/echo/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-buster
 WORKDIR /workspace
-RUN pip install torch==1.10.0 numpy
+RUN pip install torch==1.13.1 numpy
 # TODO Replace this with the PIP version when available
 ADD examples/pytorch/elastic/echo/echo.py echo.py
 ENV PYTHONPATH /workspace


### PR DESCRIPTION
Signed-off-by: Yuki Iwai <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I upgraded PyTorch version to v1.13.1 to fix the scaledown error in echo example.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #1504 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
