### PR TITLE
Trim down CRD descriptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= kubeflow/training-operator:latest
 # CRD generation options
-CRD_OPTIONS ?= "crd:generateEmbeddedObjectMeta=true,maxDescLen=300"
+CRD_OPTIONS ?= "crd:generateEmbeddedObjectMeta=true,maxDescLen=400"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= kubeflow/training-operator:latest
 # CRD generation options
-CRD_OPTIONS ?= "crd:generateEmbeddedObjectMeta=true"
+CRD_OPTIONS ?= "crd:generateEmbeddedObjectMeta=true,maxDescLen=300"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/manifests/base/crds/kubeflow.org_mpijobs.yaml
+++ b/manifests/base/crds/kubeflow.org_mpijobs.yaml
@@ -111,15 +111,7 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node matches the corresponding matchExpressions;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                        with the greatest sum of weights, i.e.
                                       items:
                                         description: An empty preferred scheduling
                                           term matches all objects with implicit weight
@@ -162,8 +154,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -203,8 +193,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -232,9 +220,7 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g. due to an update), the
-                                        system may or may not try to eventually evict
-                                        the pod from its node.
+                                        pod execution (e.g.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
@@ -276,8 +262,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -317,8 +301,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -346,15 +328,7 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node has pods which matches the corresponding
-                                        podAffinityTerm; the node(s) with the highest
-                                        sum are the most preferred.
+                                        with the greatest sum of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -435,9 +409,7 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                  means "this pod's namespace".
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -519,8 +491,7 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                  selected pods i
                                                 type: string
                                             required:
                                             - topologyKey
@@ -542,12 +513,7 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g. due to a pod label update),
-                                        the system may or may not try to eventually
-                                        evict the pod from its node. When there are
-                                        multiple elements, the lists of nodes corresponding
-                                        to each podAffinityTerm are intersected, i.e.
-                                        all terms must be satisfied.
+                                        pod execution (e.g.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -556,8 +522,7 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                          that of an
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -625,7 +590,6 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -701,8 +665,7 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                              of the selected pods i
                                             type: string
                                         required:
                                         - topologyKey
@@ -721,15 +684,7 @@ spec:
                                         may choose a node that violates one or more
                                         of the expressions. The node that is most
                                         preferred is the one with the greatest sum
-                                        of weights, i.e. for each node that meets
-                                        all of the scheduling requirements (resource
-                                        request, requiredDuringScheduling anti-affinity
-                                        expressions, etc.), compute a sum by iterating
-                                        through the elements of this field and adding
-                                        "weight" to the sum if the node has pods which
-                                        matches the corresponding podAffinityTerm;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                        of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -810,9 +765,7 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                  means "this pod's namespace".
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -894,8 +847,7 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                  selected pods i
                                                 type: string
                                             required:
                                             - topologyKey
@@ -917,12 +869,7 @@ spec:
                                         time, the pod will not be scheduled onto the
                                         node. If the anti-affinity requirements specified
                                         by this field cease to be met at some point
-                                        during pod execution (e.g. due to a pod label
-                                        update), the system may or may not try to
-                                        eventually evict the pod from its node. When
-                                        there are multiple elements, the lists of
-                                        nodes corresponding to each podAffinityTerm
-                                        are intersected, i.e. all terms must be satisfied.
+                                        during pod execution (e.g.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -931,8 +878,7 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                          that of an
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -1000,7 +946,6 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1076,8 +1021,7 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                              of the selected pods i
                                             type: string
                                         required:
                                         - topologyKey
@@ -1100,34 +1044,22 @@ spec:
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
+                                    description: Arguments to the entrypoint. The
+                                      container image's CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
+                                      expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The container image's ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
+                                      $(VAR_NAME) are expanded using the container's
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -1143,19 +1075,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1265,11 +1191,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1336,7 +1258,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1350,10 +1272,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1437,21 +1356,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1465,10 +1375,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1569,10 +1476,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -1698,19 +1602,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -1731,10 +1623,7 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
-                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                      Cannot be updated.
+                                      from the network.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -1795,10 +1684,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -1924,19 +1810,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -1984,15 +1858,11 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -2031,7 +1901,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -2046,7 +1916,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -2056,10 +1926,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -2068,8 +1935,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -2077,11 +1943,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2138,8 +2000,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -2161,13 +2022,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -2182,16 +2037,11 @@ spec:
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the
-                                      Pod has successfully initialized. If specified,
+                                    description: StartupProbe indicates that the Pod
+                                      has successfully initialized. If specified,
                                       no other probes are executed until this completes
                                       successfully. If this probe fails, the Pod will
                                       be restarted, just as if the livenessProbe failed.
-                                      This can be used to provide different probe
-                                      parameters at the beginning of a Pod''s lifecycle,
-                                      when it might take a long time to load data
-                                      or warm a cache, than during steady-state operation.
-                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
@@ -2205,10 +2055,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -2334,19 +2181,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2368,15 +2203,7 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -2385,21 +2212,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -2528,9 +2347,7 @@ spec:
                                 "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
                                 'ClusterFirst', 'Default' or 'None'. DNS parameters
                                 given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy. To have DNS options set along
-                                with hostNetwork, you have to specify DNS policy explicitly
-                                to 'ClusterFirstWithHostNet'.
+                                selected with DNSPolicy.
                               type: string
                             enableServiceLinks:
                               description: 'EnableServiceLinks indicates whether information
@@ -2544,50 +2361,31 @@ spec:
                                 pod to perform user-initiated actions such as debugging.
                                 This list cannot be specified when creating a pod,
                                 and it cannot be modified by updating the pod spec.
-                                In order to add an ephemeral container to an existing
-                                pod, use the pod's ephemeralcontainers subresource.
                               items:
-                                description: "An EphemeralContainer is a temporary
+                                description: An EphemeralContainer is a temporary
                                   container that you may add to an existing Pod for
                                   user-initiated activities such as debugging. Ephemeral
                                   containers have no resource or scheduling guarantees,
                                   and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted. The kubelet
-                                  may evict a Pod if an ephemeral container causes
-                                  the Pod to exceed its resource allocation. \n To
-                                  add an ephemeral container, use the ephemeralcontainers
-                                  subresource of an existing Pod. Ephemeral containers
-                                  may not be removed or restarted."
+                                  when a Pod is removed or restarted.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      image''s CMD is used if this is not provided.
+                                    description: Arguments to the entrypoint. The
+                                      image's CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
+                                      using the container's environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the
-                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                      produce the string literal "$(VAR_NAME)". Escaped
-                                      references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The image''s ENTRYPOINT is used if
-                                      this is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container''s environment.
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The image's ENTRYPOINT is used if this
+                                      is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
@@ -2603,19 +2401,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -2725,11 +2517,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -2791,7 +2579,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2805,10 +2593,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2892,21 +2677,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2920,10 +2696,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3023,10 +2796,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -3152,19 +2922,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3241,10 +2999,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -3370,19 +3125,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3430,15 +3173,11 @@ spec:
                                       override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -3477,7 +3216,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -3492,7 +3231,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -3502,10 +3241,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -3514,8 +3250,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -3523,11 +3258,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3584,8 +3315,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -3607,13 +3337,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -3643,10 +3367,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -3772,19 +3493,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3806,26 +3515,15 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: "If set, the name of the container
+                                    description: If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
                                       then the ephemeral container uses the namespaces
-                                      configured in the Pod spec. \n The container
-                                      runtime must implement support for this feature.
-                                      If the runtime does not support namespace targeting
-                                      then the result of setting this field is undefined."
+                                      configured in the Pod spec.
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -3834,21 +3532,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -3974,13 +3664,7 @@ spec:
                                 pod will be run in the host user namespace, useful
                                 for when the pod needs a feature only available to
                                 the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE. When set to false, a new
-                                userns is created for the pod. Setting false is useful
-                                for mitigating container breakout vulnerabilities
-                                even allowing users to run their containers as root
-                                without actually having root privileges on the host.
-                                This field is alpha-level and is only honored by servers
-                                that enable the UserNamespacesSupport feature.'
+                                module with CAP_SYS_MODULE.'
                               type: boolean
                             hostname:
                               description: Specifies the hostname of the Pod If not
@@ -3993,7 +3677,7 @@ spec:
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
                                 puller implementations for them to use. More info:
-                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                https://kubernetes.'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -4009,55 +3693,32 @@ spec:
                                 x-kubernetes-map-type: atomic
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging
+                              description: List of initialization containers belonging
                                 to the pod. Init containers are executed in order
                                 prior to containers being started. If any init container
                                 fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy. The name for
-                                an init container or normal container must be unique
-                                among all containers. Init containers may not have
-                                Lifecycle actions, Readiness probes, Liveness probes,
-                                or Startup probes. The resourceRequirements of an
-                                init container are taken into account during scheduling
-                                by finding the highest request/limit for each resource
-                                type, and then using the max of of that value or the
-                                sum of the normal containers. Limits are applied to
-                                init containers in a similar fashion. Init containers
-                                cannot currently be added or removed. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                                handled according to its restartPolicy.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
+                                    description: Arguments to the entrypoint. The
+                                      container image's CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
+                                      expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The container image's ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
+                                      $(VAR_NAME) are expanded using the container's
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -4073,19 +3734,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -4195,11 +3850,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -4266,7 +3917,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4280,10 +3931,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4367,21 +4015,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4395,10 +4034,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4499,10 +4135,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -4628,19 +4261,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4661,10 +4282,7 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
-                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                      Cannot be updated.
+                                      from the network.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -4725,10 +4343,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -4854,19 +4469,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4914,15 +4517,11 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -4961,7 +4560,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -4976,7 +4575,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -4986,10 +4585,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -4998,8 +4594,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -5007,11 +4602,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -5068,8 +4659,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -5091,13 +4681,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -5112,16 +4696,11 @@ spec:
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the
-                                      Pod has successfully initialized. If specified,
+                                    description: StartupProbe indicates that the Pod
+                                      has successfully initialized. If specified,
                                       no other probes are executed until this completes
                                       successfully. If this probe fails, the Pod will
                                       be restarted, just as if the livenessProbe failed.
-                                      This can be used to provide different probe
-                                      parameters at the beginning of a Pod''s lifecycle,
-                                      when it might take a long time to load data
-                                      or warm a cache, than during steady-state operation.
-                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
@@ -5135,10 +4714,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -5264,19 +4840,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -5298,15 +4862,7 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -5315,21 +4871,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -5435,28 +4983,13 @@ spec:
                                 if this is set. \n If the OS field is set to linux,
                                 the following fields must be unset: -securityContext.windowsOptions
                                 \n If the OS field is set to windows, following fields
-                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
-                                - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
-                                - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
-                                - spec.securityContext.sysctls - spec.shareProcessNamespace
-                                - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
-                                - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions
-                                - spec.containers[*].securityContext.seccompProfile
-                                - spec.containers[*].securityContext.capabilities
-                                - spec.containers[*].securityContext.readOnlyRootFilesystem
-                                - spec.containers[*].securityContext.privileged -
-                                spec.containers[*].securityContext.allowPrivilegeEscalation
-                                - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                                - spec.containers[*].securityContext.runAsGroup"
+                                must be unset: - spec."
                               properties:
                                 name:
                                   description: 'Name is the name of the operating
                                     system. The currently supported values are linux
                                     and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                    Clients should expect to handle additional values
-                                    and treat unrecognized values in this field as
-                                    os: null'
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.'
                                   type: string
                               required:
                               - name
@@ -5468,18 +5001,12 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Overhead represents the resource overhead
+                              description: Overhead represents the resource overhead
                                 associated with running a pod for a given RuntimeClass.
                                 This field will be autopopulated at admission time
                                 by the RuntimeClass admission controller. If the RuntimeClass
                                 admission controller is enabled, overhead must not
-                                be set in Pod create requests. The RuntimeClass admission
-                                controller will reject Pod create requests which have
-                                the overhead already set. If RuntimeClass is configured
-                                and selected in the PodSpec, Overhead will be set
-                                to the value defined in the corresponding RuntimeClass,
-                                otherwise it will remain unset and treated as zero.
-                                More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                                be set in Pod create requests.
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
@@ -5501,8 +5028,7 @@ spec:
                                 are two special keywords which indicate the highest
                                 priorities with the former being the highest priority.
                                 Any other name must be defined by creating a PriorityClass
-                                object with that name. If not specified, the pod priority
-                                will be default or zero if there is no default.
+                                object with that name.
                               type: string
                             readinessGates:
                               description: 'If specified, all readiness gates will
@@ -5528,14 +5054,10 @@ spec:
                                 to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass
+                              description: RuntimeClassName refers to a RuntimeClass
                                 object in the node.k8s.io group, which should be used
                                 to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run. If unset
-                                or empty, the "legacy" RuntimeClass will be used,
-                                which is an implicit class with an empty definition
-                                that uses the default runtime handler. More info:
-                                https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                                the named class, the pod will not be run.
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -5555,24 +5077,15 @@ spec:
                                     of that volume to be owned by the pod: \n 1. The
                                     owning GID will be the FSGroup 2. The setgid bit
                                     is set (new files created in the volume will be
-                                    owned by FSGroup) 3. The permission bits are OR'd
-                                    with rw-rw---- \n If unset, the Kubelet will not
-                                    modify the ownership and permissions of any volume.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows."
+                                    owned by FSGroup) 3."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior
+                                  description: fsGroupChangePolicy defines behavior
                                     of changing ownership and permission of the volume
                                     before being exposed inside Pod. This field will
                                     only apply to volume types which support fsGroup
-                                    based ownership(and permissions). It will have
-                                    no effect on ephemeral volume types such as: secret,
-                                    configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified, "Always" is used.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.'
+                                    based ownership(and permissions).
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -5581,7 +5094,7 @@ spec:
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
                                     for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                    be set when spec.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -5591,9 +5104,7 @@ spec:
                                     does not run as UID 0 (root) and fail to start
                                     the container if it does. If unset or false, no
                                     such validation will be performed. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                    set in SecurityContext.
                                   type: boolean
                                 runAsUser:
                                   description: The UID to run the entrypoint of the
@@ -5602,19 +5113,13 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
                                   description: The SELinux context to be applied to
                                     all containers. If unspecified, the container
                                     runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                    for each container.  May also be set in SecurityContext.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5696,8 +5201,7 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                    Note that this field cannot be set when spec.os.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -5716,12 +5220,7 @@ spec:
                                         honored by components that enable the WindowsHostProcessContainers
                                         feature flag. Setting this field without the
                                         feature flag will result in errors when validating
-                                        the Pod. All of a Pod's containers must have
-                                        the same effective HostProcess value (it is
-                                        not allowed to have a mix of HostProcess containers
-                                        and non-HostProcess containers).  In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                        the Pod.
                                       type: boolean
                                     runAsUserName:
                                       description: The UserName in Windows to run
@@ -5749,20 +5248,14 @@ spec:
                                 as the pod's FQDN, rather than the leaf name (the
                                 default). In Linux containers, this means setting
                                 the FQDN in the hostname field of the kernel (the
-                                nodename field of struct utsname). In Windows containers,
-                                this means setting the registry value of hostname
-                                for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
-                                to FQDN. If a pod does not have FQDN, this has no
-                                effect. Default to false.
+                                nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between
+                              description: Share a single process namespace between
                                 all of the containers in a pod. When this is set containers
                                 will be able to view and signal processes from other
                                 containers in the same pod, and the first process
-                                in each container will not be assigned PID 1. HostPID
-                                and ShareProcessNamespace cannot both be set. Optional:
-                                Default to false.'
+                                in each container will not be assigned PID 1.
                               type: boolean
                             subdomain:
                               description: If specified, the fully qualified Pod hostname
@@ -5775,14 +5268,7 @@ spec:
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
                                 zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down). If this value is nil,
-                                the default grace period will be used instead. The
-                                grace period is the duration in seconds after the
-                                processes running in the pod are sent a termination
-                                signal and the time when the processes are forcibly
-                                halted with a kill signal. Set this value longer than
-                                the expected cleanup time for your process. Defaults
-                                to 30 seconds.
+                                (no opportunity to shut down).
                               format: int64
                               type: integer
                             tolerations:
@@ -5818,8 +5304,7 @@ spec:
                                       of effect NoExecute, otherwise this field is
                                       ignored) tolerates the taint. By default, it
                                       is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
+                                      (do not evict).
                                     format: int64
                                     type: integer
                                   value:
@@ -5896,98 +5381,44 @@ spec:
                                   matchLabelKeys:
                                     description: MatchLabelKeys is a set of pod label
                                       keys to select the pods over which spreading
-                                      will be calculated. The keys are used to lookup
-                                      values from the incoming pod labels, those key-value
-                                      labels are ANDed with labelSelector to select
-                                      the group of existing pods over which spreading
-                                      will be calculated for the incoming pod. Keys
-                                      that don't exist in the incoming pod labels
-                                      will be ignored. A null or empty list means
-                                      only match against labelSelector.
+                                      will be calculated.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   maxSkew:
-                                    description: 'MaxSkew describes the degree to
-                                      which pods may be unevenly distributed. When
-                                      `whenUnsatisfiable=DoNotSchedule`, it is the
-                                      maximum permitted difference between the number
-                                      of matching pods in the target topology and
-                                      the global minimum. The global minimum is the
-                                      minimum number of matching pods in an eligible
-                                      domain or zero if the number of eligible domains
-                                      is less than MinDomains. For example, in a 3-zone
-                                      cluster, MaxSkew is set to 1, and pods with
-                                      the same labelSelector spread as 2/2/1: In this
-                                      case, the global minimum is 1. | zone1 | zone2
-                                      | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
-                                      is 1, incoming pod can only be scheduled to
-                                      zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                                      would make the ActualSkew(3-1) on zone1(zone2)
-                                      violate MaxSkew(1). - if MaxSkew is 2, incoming
-                                      pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                                      it is used to give higher precedence to topologies
-                                      that satisfy it. It''s a required field. Default
-                                      value is 1 and 0 is not allowed.'
+                                    description: MaxSkew describes the degree to which
+                                      pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                      it is the maximum permitted difference between
+                                      the number of matching pods in the target topology
+                                      and the global minimum.
                                     format: int32
                                     type: integer
                                   minDomains:
-                                    description: "MinDomains indicates a minimum number
+                                    description: MinDomains indicates a minimum number
                                       of eligible domains. When the number of eligible
                                       domains with matching topology keys is less
                                       than minDomains, Pod Topology Spread treats
-                                      \"global minimum\" as 0, and then the calculation
-                                      of Skew is performed. And when the number of
-                                      eligible domains with matching topology keys
-                                      equals or greater than minDomains, this value
-                                      has no effect on scheduling. As a result, when
-                                      the number of eligible domains is less than
-                                      minDomains, scheduler won't schedule more than
-                                      maxSkew Pods to those domains. If value is nil,
-                                      the constraint behaves as if MinDomains is equal
-                                      to 1. Valid values are integers greater than
-                                      0. When value is not nil, WhenUnsatisfiable
-                                      must be DoNotSchedule. \n For example, in a
-                                      3-zone cluster, MaxSkew is set to 2, MinDomains
-                                      is set to 5 and pods with the same labelSelector
-                                      spread as 2/2/2: | zone1 | zone2 | zone3 | |
-                                      \ P P  |  P P  |  P P  | The number of domains
-                                      is less than 5(MinDomains), so \"global minimum\"
-                                      is treated as 0. In this situation, new pod
-                                      with the same labelSelector cannot be scheduled,
-                                      because computed skew will be 3(3 - 0) if new
-                                      Pod is scheduled to any of the three zones,
-                                      it will violate MaxSkew. \n This is a beta field
-                                      and requires the MinDomainsInPodTopologySpread
-                                      feature gate to be enabled (enabled by default)."
+                                      "global minimum" as 0, and then the calculation
+                                      of Skew is performed.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: "NodeAffinityPolicy indicates how
-                                      we will treat Pod's nodeAffinity/nodeSelector
+                                    description: 'NodeAffinityPolicy indicates how
+                                      we will treat Pod''s nodeAffinity/nodeSelector
                                       when calculating pod topology spread skew. Options
                                       are: - Honor: only nodes matching nodeAffinity/nodeSelector
                                       are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored. All nodes
-                                      are included in the calculations. \n If this
-                                      value is nil, the behavior is equivalent to
-                                      the Honor policy. This is a alpha-level feature
-                                      enabled by the NodeInclusionPolicyInPodTopologySpread
-                                      feature flag."
+                                      nodeAffinity/nodeSelector are ignored.'
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: "NodeTaintsPolicy indicates how we
+                                    description: 'NodeTaintsPolicy indicates how we
                                       will treat node taints when calculating pod
                                       topology spread skew. Options are: - Honor:
                                       nodes without taints, along with tainted nodes
                                       for which the incoming pod has a toleration,
                                       are included. - Ignore: node taints are ignored.
-                                      All nodes are included. \n If this value is
-                                      nil, the behavior is equivalent to the Ignore
-                                      policy. This is a alpha-level feature enabled
-                                      by the NodeInclusionPolicyInPodTopologySpread
-                                      feature flag."
+                                      All nodes are included.'
                                     type: string
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
@@ -5995,37 +5426,13 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket. We define a domain as a particular
-                                      instance of a topology. Also, we define an eligible
-                                      domain as a domain whose nodes meet the requirements
-                                      of nodeAffinityPolicy and nodeTaintsPolicy.
-                                      e.g. If TopologyKey is "kubernetes.io/hostname",
-                                      each Node is a domain of that topology. And,
-                                      if TopologyKey is "topology.kubernetes.io/zone",
-                                      each zone is a domain of that topology. It's
-                                      a required field.
+                                      each bucket.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: 'WhenUnsatisfiable indicates how
-                                      to deal with a pod if it doesn''t satisfy the
-                                      spread constraint. - DoNotSchedule (default)
-                                      tells the scheduler not to schedule it. - ScheduleAnyway
-                                      tells the scheduler to schedule the pod in any
-                                      location, but giving higher precedence to topologies
-                                      that would help reduce the skew. A constraint
-                                      is considered "Unsatisfiable" for an incoming
-                                      pod if and only if every possible node assignment
-                                      for that pod would violate "MaxSkew" on some
-                                      topology. For example, in a 3-zone cluster,
-                                      MaxSkew is set to 1, and pods with the same
-                                      labelSelector spread as 3/1/1: | zone1 | zone2
-                                      | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
-                                      is set to DoNotSchedule, incoming pod can only
-                                      be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
-                                      as ActualSkew(2-1) on zone2(zone3) satisfies
-                                      MaxSkew(1). In other words, the cluster can
-                                      still be imbalanced, but scheduler won''t make
-                                      it *more* imbalanced. It''s a required field.'
+                                    description: WhenUnsatisfiable indicates how to
+                                      deal with a pod if it doesn't satisfy the spread
+                                      constraint. - DoNotSchedule (default) tells
+                                      the scheduler not to schedule it.
                                     type: string
                                 required:
                                 - maxSkew
@@ -6058,9 +5465,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6245,12 +5650,7 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          values for mode bits. Defaults to 0644.'
                                         format: int32
                                         type: integer
                                       items:
@@ -6260,12 +5660,7 @@ spec:
                                           as a file whose name is the key and content
                                           is the value. If specified, the listed keys
                                           will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the ConfigMap, the volume setup will
-                                          error unless it is marked optional. Paths
-                                          must be relative and may not contain the
-                                          '..' path or start with '..'.
+                                          and unlisted keys will not be present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -6282,10 +5677,7 @@ spec:
                                                 and decimal values, JSON requires
                                                 decimal values for mode bits. If not
                                                 specified, the volume defaultMode
-                                                will be used. This might be in conflict
-                                                with other options that affect the
-                                                file mode, like fsGroup, and the result
-                                                can be other mode bits set.'
+                                                will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -6336,9 +5728,7 @@ spec:
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
                                           calls. This field is optional, and  may
-                                          be empty if no secret is required. If the
-                                          secret object contains more than one secret,
-                                          all secret references are passed.
+                                          be empty if no secret is required.
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -6374,14 +5764,7 @@ spec:
                                           mode bits used to set permissions on created
                                           files by default. Must be an octal value
                                           between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          between 0 and 511.'
                                         format: int32
                                         type: integer
                                       items:
@@ -6418,11 +5801,7 @@ spec:
                                                 and 511. YAML accepts both octal and
                                                 decimal values, JSON requires decimal
                                                 values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                                the volume defaultMode will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -6483,70 +5862,30 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'sizeLimit is the total amount
+                                        description: sizeLimit is the total amount
                                           of local storage required for this EmptyDir
                                           volume. The size limit is also applicable
                                           for memory medium. The maximum usage on
                                           memory medium EmptyDir would be the minimum
                                           value between the SizeLimit specified here
                                           and the sum of memory limits of all containers
-                                          in a pod. The default is nil which means
-                                          that the limit is undefined. More info:
-                                          http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                          in a pod.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: "ephemeral represents a volume that
+                                    description: ephemeral represents a volume that
                                       is handled by a cluster storage driver. The
                                       volume's lifecycle is tied to the pod that defines
                                       it - it will be created before the pod starts,
-                                      and deleted when the pod is removed. \n Use
-                                      this if: a) the volume is only needed while
-                                      the pod runs, b) features of normal volumes
-                                      like restoring from snapshot or capacity tracking
-                                      are needed, c) the storage driver is specified
-                                      through a storage class, and d) the storage
-                                      driver supports dynamic volume provisioning
-                                      through a PersistentVolumeClaim (see EphemeralVolumeSource
-                                      for more information on the connection between
-                                      this volume type and PersistentVolumeClaim).
-                                      \n Use PersistentVolumeClaim or one of the vendor-specific
-                                      APIs for volumes that persist for longer than
-                                      the lifecycle of an individual pod. \n Use CSI
-                                      for light-weight local ephemeral volumes if
-                                      the CSI driver is meant to be used that way
-                                      - see the documentation of the driver for more
-                                      information. \n A pod can use both types of
-                                      ephemeral volumes and persistent volumes at
-                                      the same time."
+                                      and deleted when the pod is removed.
                                     properties:
                                       volumeClaimTemplate:
-                                        description: "Will be used to create a stand-alone
+                                        description: Will be used to create a stand-alone
                                           PVC to provision the volume. The pod in
                                           which this EphemeralVolumeSource is embedded
                                           will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.  The
-                                          name of the PVC will be `<pod name>-<volume
-                                          name>` where `<volume name>` is the name
-                                          from the `PodSpec.Volumes` array entry.
-                                          Pod validation will reject the pod if the
-                                          concatenated name is not valid for a PVC
-                                          (for example, too long). \n An existing
-                                          PVC with that name that is not owned by
-                                          the pod will *not* be used for the pod to
-                                          avoid using an unrelated volume by mistake.
-                                          Starting the pod is then blocked until the
-                                          unrelated PVC is removed. If such a pre-created
-                                          PVC is meant to be used by the pod, the
-                                          PVC has to updated with an owner reference
-                                          to the pod once the pod exists. Normally
-                                          this should not be necessary, but it may
-                                          be useful when manually reconstructing a
-                                          broken cluster. \n This field is read-only
-                                          and no changes will be made by Kubernetes
-                                          to the PVC after it has been created. \n
-                                          Required, must not be nil."
+                                          will be deleted together with the pod.
                                         properties:
                                           metadata:
                                             description: May contain labels and annotations
@@ -6589,17 +5928,7 @@ spec:
                                               dataSource:
                                                 description: 'dataSource field can
                                                   be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                  * An existing PVC (PersistentVolumeClaim)
-                                                  If the provisioner or an external
-                                                  controller can support the specified
-                                                  data source, it will create a new
-                                                  volume based on the contents of
-                                                  the specified data source. If the
-                                                  AnyVolumeDataSource feature gate
-                                                  is enabled, this field will always
-                                                  have the same contents as the DataSourceRef
-                                                  field.'
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6624,38 +5953,13 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               dataSourceRef:
-                                                description: 'dataSourceRef specifies
+                                                description: dataSourceRef specifies
                                                   the object from which to populate
                                                   the volume with data, if a non-empty
                                                   volume is desired. This may be any
                                                   local object from a non-empty API
                                                   group (non core object) or a PersistentVolumeClaim
-                                                  object. When this field is specified,
-                                                  volume binding will only succeed
-                                                  if the type of the specified object
-                                                  matches some installed volume populator
-                                                  or dynamic provisioner. This field
-                                                  will replace the functionality of
-                                                  the DataSource field and as such
-                                                  if both fields are non-empty, they
-                                                  must have the same value. For backwards
-                                                  compatibility, both fields (DataSource
-                                                  and DataSourceRef) will be set to
-                                                  the same value automatically if
-                                                  one of them is empty and the other
-                                                  is non-empty. There are two important
-                                                  differences between DataSource and
-                                                  DataSourceRef: * While DataSource
-                                                  only allows two specific types of
-                                                  objects, DataSourceRef allows any
-                                                  non-core object, as well as PersistentVolumeClaim
-                                                  objects. * While DataSource ignores
-                                                  disallowed values (dropping them),
-                                                  DataSourceRef preserves all values,
-                                                  and generates an error if a disallowed
-                                                  value is specified. (Beta) Using
-                                                  this field requires the AnyVolumeDataSource
-                                                  feature gate to be enabled.'
+                                                  object.
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6680,7 +5984,7 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resources:
-                                                description: 'resources represents
+                                                description: resources represents
                                                   the minimum resources the volume
                                                   should have. If RecoverVolumeExpansionFailure
                                                   feature is enabled users are allowed
@@ -6688,7 +5992,7 @@ spec:
                                                   that are lower than previous value
                                                   but must still be higher than capacity
                                                   recorded in the status field of
-                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  the claim.
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -6917,9 +6221,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6928,7 +6230,7 @@ spec:
                                           Examples: For volume /dev/sda1, you specify
                                           the partition as "1". Similarly, the volume
                                           partition for /dev/sda is "0" (or you can
-                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          leave the property empty).'
                                         format: int32
                                         type: integer
                                       pdName:
@@ -7000,10 +6302,7 @@ spec:
                                       directly exposed to the container. This is generally
                                       used for system agents or other privileged things
                                       that are allowed to see the host machine. Most
-                                      containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                      --- TODO(jonesdl) We need to restrict who can
-                                      use host directory mounts and who can/can not
-                                      mount host directories as read/write.'
+                                      containers will NOT need this. More info: https://kubernetes.'
                                     properties:
                                       path:
                                         description: 'path of the directory on the
@@ -7038,9 +6337,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       initiatorName:
                                         description: initiatorName is the custom iSCSI
@@ -7197,11 +6494,7 @@ spec:
                                           0000 and 0777 or a decimal value between
                                           0 and 511. YAML accepts both octal and decimal
                                           values, JSON requires decimal values for
-                                          mode bits. Directories within the path are
-                                          not affected by this setting. This might
-                                          be in conflict with other options that affect
-                                          the file mode, like fsGroup, and the result
-                                          can be other mode bits set.
+                                          mode bits.
                                         format: int32
                                         type: integer
                                       sources:
@@ -7225,12 +6518,6 @@ spec:
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
-                                                    If a key is specified which is
-                                                    not present in the ConfigMap,
-                                                    the volume setup will error unless
-                                                    it is marked optional. Paths must
-                                                    be relative and may not contain
-                                                    the '..' path or start with '..'.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7250,12 +6537,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7330,12 +6612,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7399,12 +6676,6 @@ spec:
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
-                                                    If a key is specified which is
-                                                    not present in the Secret, the
-                                                    volume setup will error unless
-                                                    it is marked optional. Paths must
-                                                    be relative and may not contain
-                                                    the '..' path or start with '..'.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7424,12 +6695,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7481,13 +6747,7 @@ spec:
                                                     As the token approaches expiration,
                                                     the kubelet volume plugin will
                                                     proactively rotate the service
-                                                    account token. The kubelet will
-                                                    start trying to rotate the token
-                                                    if the token is older than 80
-                                                    percent of its time to live or
-                                                    if the token is older than 24
-                                                    hours.Defaults to 1 hour and must
-                                                    be at least 10 minutes.
+                                                    account token.
                                                   format: int64
                                                   type: integer
                                                 path:
@@ -7551,9 +6811,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       image:
                                         description: 'image is the rados image name.
@@ -7677,12 +6935,7 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          values for mode bits. Defaults to 0644.'
                                         format: int32
                                         type: integer
                                       items:
@@ -7692,12 +6945,7 @@ spec:
                                           as a file whose name is the key and content
                                           is the value. If specified, the listed keys
                                           will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the Secret, the volume setup will error
-                                          unless it is marked optional. Paths must
-                                          be relative and may not contain the '..'
-                                          path or start with '..'.
+                                          and unlisted keys will not be present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -7714,10 +6962,7 @@ spec:
                                                 and decimal values, JSON requires
                                                 decimal values for mode bits. If not
                                                 specified, the volume defaultMode
-                                                will be used. This might be in conflict
-                                                with other options that affect the
-                                                file mode, like fsGroup, and the result
-                                                can be other mode bits set.'
+                                                will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -7784,9 +7029,6 @@ spec:
                                           Kubernetes name scoping to be mirrored within
                                           StorageOS for tighter integration. Set VolumeName
                                           to any name to override the default behaviour.
-                                          Set to "default" if you are not using namespaces
-                                          within StorageOS. Namespaces that do not
-                                          pre-exist within StorageOS will be created.
                                         type: string
                                     type: object
                                   vsphereVolume:

--- a/manifests/base/crds/kubeflow.org_mpijobs.yaml
+++ b/manifests/base/crds/kubeflow.org_mpijobs.yaml
@@ -111,7 +111,10 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e.
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.
                                       items:
                                         description: An empty preferred scheduling
                                           term matches all objects with implicit weight
@@ -154,6 +157,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -193,6 +198,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -220,7 +227,9 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g.
+                                        pod execution (e.g. due to an update), the
+                                        system may or may not try to eventually evict
+                                        the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
@@ -262,6 +271,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -301,6 +312,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -328,7 +341,10 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e.
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -409,7 +425,9 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace".
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -491,7 +509,8 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods i
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
@@ -513,7 +532,9 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g.
+                                        pod execution (e.g. due to a pod label update),
+                                        the system may or may not try to eventually
+                                        evict the pod from its node.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -522,7 +543,8 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of an
+                                          that of any node on which a pod of the set
+                                          of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -590,6 +612,7 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -665,7 +688,8 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods i
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -765,7 +789,9 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace".
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -847,7 +873,8 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods i
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
@@ -869,7 +896,9 @@ spec:
                                         time, the pod will not be scheduled onto the
                                         node. If the anti-affinity requirements specified
                                         by this field cease to be met at some point
-                                        during pod execution (e.g.
+                                        during pod execution (e.g. due to a pod label
+                                        update), the system may or may not try to
+                                        eventually evict the pod from its node.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -878,7 +907,8 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of an
+                                          that of any node on which a pod of the set
+                                          of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -946,6 +976,7 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1021,7 +1052,8 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods i
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1044,22 +1076,26 @@ spec:
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      container image's CMD is used if this is not
+                                    description: 'Arguments to the entrypoint. The
+                                      container image''s CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container's environment.
+                                      expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The container image's ENTRYPOINT is
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The container image''s ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container's
+                                      $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -1075,13 +1111,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1191,7 +1230,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1258,7 +1301,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1272,7 +1315,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1362,6 +1408,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1375,7 +1423,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1476,7 +1527,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -1602,7 +1656,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -1623,7 +1679,9 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network.
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -1684,7 +1742,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -1810,7 +1871,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -1858,11 +1921,15 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -1901,7 +1968,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -1916,7 +1983,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -1935,7 +2002,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -1943,7 +2011,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2000,7 +2072,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -2055,7 +2128,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -2181,7 +2257,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2212,13 +2290,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -2347,7 +2431,9 @@ spec:
                                 "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
                                 'ClusterFirst', 'Default' or 'None'. DNS parameters
                                 given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy.
+                                selected with DNSPolicy. To have DNS options set along
+                                with hostNetwork, you have to specify DNS policy explicitly
+                                to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
                               description: 'EnableServiceLinks indicates whether information
@@ -2361,31 +2447,40 @@ spec:
                                 pod to perform user-initiated actions such as debugging.
                                 This list cannot be specified when creating a pod,
                                 and it cannot be modified by updating the pod spec.
+                                In order to add an ephemeral container to an existing
+                                pod, use the pod's ephemeralcontainers subresource.
                               items:
                                 description: An EphemeralContainer is a temporary
                                   container that you may add to an existing Pod for
                                   user-initiated activities such as debugging. Ephemeral
                                   containers have no resource or scheduling guarantees,
                                   and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted.
+                                  when a Pod is removed or restarted. The kubelet
+                                  may evict a Pod if an ephemeral container causes
+                                  the Pod to exceed its resource allocation.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      image's CMD is used if this is not provided.
+                                    description: 'Arguments to the entrypoint. The
+                                      image''s CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
-                                      using the container's environment. If a variable
+                                      using the container''s environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged.
+                                      string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the
+                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)".'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The image's ENTRYPOINT is used if this
-                                      is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container's environment.
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The image''s ENTRYPOINT is used if
+                                      this is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -2401,13 +2496,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -2517,7 +2615,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -2579,7 +2681,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2593,7 +2695,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2683,6 +2788,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2696,7 +2803,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2796,7 +2906,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -2922,7 +3035,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2999,7 +3114,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -3125,7 +3243,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3173,11 +3293,15 @@ spec:
                                       override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -3216,7 +3340,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -3231,7 +3355,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -3250,7 +3374,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -3258,7 +3383,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3315,7 +3444,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -3367,7 +3497,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -3493,7 +3626,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3518,12 +3653,13 @@ spec:
                                       sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container
+                                    description: "If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
                                       then the ephemeral container uses the namespaces
-                                      configured in the Pod spec.
+                                      configured in the Pod spec. \n The container
+                                      runtime must implement support for this feature."
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -3532,13 +3668,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -3664,7 +3806,8 @@ spec:
                                 pod will be run in the host user namespace, useful
                                 for when the pod needs a feature only available to
                                 the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE.'
+                                module with CAP_SYS_MODULE. When set to false, a new
+                                userns is created for the pod.'
                               type: boolean
                             hostname:
                               description: Specifies the hostname of the Pod If not
@@ -3677,7 +3820,7 @@ spec:
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
                                 puller implementations for them to use. More info:
-                                https://kubernetes.'
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -3697,28 +3840,34 @@ spec:
                                 to the pod. Init containers are executed in order
                                 prior to containers being started. If any init container
                                 fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy.
+                                handled according to its restartPolicy. The name for
+                                an init container or normal container must be unique
+                                among all containers.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      container image's CMD is used if this is not
+                                    description: 'Arguments to the entrypoint. The
+                                      container image''s CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container's environment.
+                                      expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The container image's ENTRYPOINT is
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The container image''s ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container's
+                                      $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -3734,13 +3883,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -3850,7 +4002,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -3917,7 +4073,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -3931,7 +4087,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4021,6 +4180,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4034,7 +4195,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4135,7 +4299,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4261,7 +4428,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4282,7 +4451,9 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network.
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -4343,7 +4514,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4469,7 +4643,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4517,11 +4693,15 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -4560,7 +4740,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -4575,7 +4755,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -4594,7 +4774,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -4602,7 +4783,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -4659,7 +4844,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -4714,7 +4900,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4840,7 +5029,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4871,13 +5062,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -4983,13 +5180,17 @@ spec:
                                 if this is set. \n If the OS field is set to linux,
                                 the following fields must be unset: -securityContext.windowsOptions
                                 \n If the OS field is set to windows, following fields
-                                must be unset: - spec."
+                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
+                                - spec.securityContext.seLinuxOptions - spec.securityContext."
                               properties:
                                 name:
                                   description: 'Name is the name of the operating
                                     system. The currently supported values are linux
                                     and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.'
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values
+                                    and treat unrecognized values in this field as
+                                    os: null'
                                   type: string
                               required:
                               - name
@@ -5006,7 +5207,9 @@ spec:
                                 This field will be autopopulated at admission time
                                 by the RuntimeClass admission controller. If the RuntimeClass
                                 admission controller is enabled, overhead must not
-                                be set in Pod create requests.
+                                be set in Pod create requests. The RuntimeClass admission
+                                controller will reject Pod create requests which have
+                                the overhead already set.
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
@@ -5028,7 +5231,8 @@ spec:
                                 are two special keywords which indicate the highest
                                 priorities with the former being the highest priority.
                                 Any other name must be defined by creating a PriorityClass
-                                object with that name.
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
                               type: string
                             readinessGates:
                               description: 'If specified, all readiness gates will
@@ -5054,10 +5258,14 @@ spec:
                                 to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: RuntimeClassName refers to a RuntimeClass
+                              description: 'RuntimeClassName refers to a RuntimeClass
                                 object in the node.k8s.io group, which should be used
                                 to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run.
+                                the named class, the pod will not be run. If unset
+                                or empty, the "legacy" RuntimeClass will be used,
+                                which is an implicit class with an empty definition
+                                that uses the default runtime handler. More info:
+                                https://git.k8s.'
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -5081,11 +5289,14 @@ spec:
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: fsGroupChangePolicy defines behavior
+                                  description: 'fsGroupChangePolicy defines behavior
                                     of changing ownership and permission of the volume
                                     before being exposed inside Pod. This field will
                                     only apply to volume types which support fsGroup
-                                    based ownership(and permissions).
+                                    based ownership(and permissions). It will have
+                                    no effect on ephemeral volume types such as: secret,
+                                    configmaps and emptydir. Valid values are "OnRootMismatch"
+                                    and "Always". If not specified, "Always" is used.'
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -5094,7 +5305,7 @@ spec:
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
                                     for that container. Note that this field cannot
-                                    be set when spec.
+                                    be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -5113,13 +5324,19 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
                                   description: The SELinux context to be applied to
                                     all containers. If unspecified, the container
                                     runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.
+                                    for each container.  May also be set in SecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5201,7 +5418,8 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -5251,11 +5469,13 @@ spec:
                                 nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: Share a single process namespace between
+                              description: 'Share a single process namespace between
                                 all of the containers in a pod. When this is set containers
                                 will be able to view and signal processes from other
                                 containers in the same pod, and the first process
-                                in each container will not be assigned PID 1.
+                                in each container will not be assigned PID 1. HostPID
+                                and ShareProcessNamespace cannot both be set. Optional:
+                                Default to false.'
                               type: boolean
                             subdomain:
                               description: If specified, the fully qualified Pod hostname
@@ -5268,7 +5488,8 @@ spec:
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
                                 zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down).
+                                (no opportunity to shut down). If this value is nil,
+                                the default grace period will be used instead.
                               format: int64
                               type: integer
                             tolerations:
@@ -5304,7 +5525,8 @@ spec:
                                       of effect NoExecute, otherwise this field is
                                       ignored) tolerates the taint. By default, it
                                       is not set, which means tolerate the taint forever
-                                      (do not evict).
+                                      (do not evict). Zero and negative values will
+                                      be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
@@ -5381,7 +5603,13 @@ spec:
                                   matchLabelKeys:
                                     description: MatchLabelKeys is a set of pod label
                                       keys to select the pods over which spreading
-                                      will be calculated.
+                                      will be calculated. The keys are used to lookup
+                                      values from the incoming pod labels, those key-value
+                                      labels are ANDed with labelSelector to select
+                                      the group of existing pods over which spreading
+                                      will be calculated for the incoming pod. Keys
+                                      that don't exist in the incoming pod labels
+                                      will be ignored.
                                     items:
                                       type: string
                                     type: array
@@ -5391,7 +5619,10 @@ spec:
                                       pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                                       it is the maximum permitted difference between
                                       the number of matching pods in the target topology
-                                      and the global minimum.
+                                      and the global minimum. The global minimum is
+                                      the minimum number of matching pods in an eligible
+                                      domain or zero if the number of eligible domains
+                                      is less than MinDomains.
                                     format: int32
                                     type: integer
                                   minDomains:
@@ -5400,25 +5631,33 @@ spec:
                                       domains with matching topology keys is less
                                       than minDomains, Pod Topology Spread treats
                                       "global minimum" as 0, and then the calculation
-                                      of Skew is performed.
+                                      of Skew is performed. And when the number of
+                                      eligible domains with matching topology keys
+                                      equals or greater than minDomains, this value
+                                      has no effect on scheduling.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: 'NodeAffinityPolicy indicates how
-                                      we will treat Pod''s nodeAffinity/nodeSelector
+                                    description: "NodeAffinityPolicy indicates how
+                                      we will treat Pod's nodeAffinity/nodeSelector
                                       when calculating pod topology spread skew. Options
                                       are: - Honor: only nodes matching nodeAffinity/nodeSelector
                                       are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored.'
+                                      nodeAffinity/nodeSelector are ignored. All nodes
+                                      are included in the calculations. \n If this
+                                      value is nil, the behavior is equivalent to
+                                      the Honor policy."
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: 'NodeTaintsPolicy indicates how we
+                                    description: "NodeTaintsPolicy indicates how we
                                       will treat node taints when calculating pod
                                       topology spread skew. Options are: - Honor:
                                       nodes without taints, along with tainted nodes
                                       for which the incoming pod has a toleration,
                                       are included. - Ignore: node taints are ignored.
-                                      All nodes are included.'
+                                      All nodes are included. \n If this value is
+                                      nil, the behavior is equivalent to the Ignore
+                                      policy."
                                     type: string
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
@@ -5426,13 +5665,17 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket.
+                                      each bucket. We define a domain as a particular
+                                      instance of a topology.
                                     type: string
                                   whenUnsatisfiable:
                                     description: WhenUnsatisfiable indicates how to
                                       deal with a pod if it doesn't satisfy the spread
                                       constraint. - DoNotSchedule (default) tells
-                                      the scheduler not to schedule it.
+                                      the scheduler not to schedule it. - ScheduleAnyway
+                                      tells the scheduler to schedule the pod in any
+                                      location, but giving higher precedence to topologies
+                                      that would help reduce the skew.
                                     type: string
                                 required:
                                 - maxSkew
@@ -5465,7 +5708,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -5650,7 +5895,9 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.'
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -5728,7 +5975,9 @@ spec:
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
                                           calls. This field is optional, and  may
-                                          be empty if no secret is required.
+                                          be empty if no secret is required. If the
+                                          secret object contains more than one secret,
+                                          all secret references are passed.
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5764,7 +6013,11 @@ spec:
                                           mode bits used to set permissions on created
                                           files by default. Must be an octal value
                                           between 0000 and 0777 or a decimal value
-                                          between 0 and 511.'
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -5862,14 +6115,16 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: sizeLimit is the total amount
+                                        description: 'sizeLimit is the total amount
                                           of local storage required for this EmptyDir
                                           volume. The size limit is also applicable
                                           for memory medium. The maximum usage on
                                           memory medium EmptyDir would be the minimum
                                           value between the SizeLimit specified here
                                           and the sum of memory limits of all containers
-                                          in a pod.
+                                          in a pod. The default is nil which means
+                                          that the limit is undefined. More info:
+                                          http://kubernetes.'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
@@ -5885,7 +6140,10 @@ spec:
                                           PVC to provision the volume. The pod in
                                           which this EphemeralVolumeSource is embedded
                                           will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.
+                                          will be deleted together with the pod.  The
+                                          name of the PVC will be `<pod name>-<volume
+                                          name>` where `<volume name>` is the name
+                                          from the `PodSpec.Volumes` array entry.
                                         properties:
                                           metadata:
                                             description: May contain labels and annotations
@@ -5928,7 +6186,13 @@ spec:
                                               dataSource:
                                                 description: 'dataSource field can
                                                   be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.'
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                  * An existing PVC (PersistentVolumeClaim)
+                                                  If the provisioner or an external
+                                                  controller can support the specified
+                                                  data source, it will create a new
+                                                  volume based on the contents of
+                                                  the specified data source.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -5959,7 +6223,11 @@ spec:
                                                   volume is desired. This may be any
                                                   local object from a non-empty API
                                                   group (non core object) or a PersistentVolumeClaim
-                                                  object.
+                                                  object. When this field is specified,
+                                                  volume binding will only succeed
+                                                  if the type of the specified object
+                                                  matches some installed volume populator
+                                                  or dynamic provisioner.
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -5984,7 +6252,7 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resources:
-                                                description: resources represents
+                                                description: 'resources represents
                                                   the minimum resources the volume
                                                   should have. If RecoverVolumeExpansionFailure
                                                   feature is enabled users are allowed
@@ -5992,7 +6260,7 @@ spec:
                                                   that are lower than previous value
                                                   but must still be higher than capacity
                                                   recorded in the status field of
-                                                  the claim.
+                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -6221,7 +6489,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6230,7 +6500,7 @@ spec:
                                           Examples: For volume /dev/sda1, you specify
                                           the partition as "1". Similarly, the volume
                                           partition for /dev/sda is "0" (or you can
-                                          leave the property empty).'
+                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
@@ -6337,7 +6607,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       initiatorName:
                                         description: initiatorName is the custom iSCSI
@@ -6494,7 +6766,8 @@ spec:
                                           0000 and 0777 or a decimal value between
                                           0 and 511. YAML accepts both octal and decimal
                                           values, JSON requires decimal values for
-                                          mode bits.
+                                          mode bits. Directories within the path are
+                                          not affected by this setting.
                                         format: int32
                                         type: integer
                                       sources:
@@ -6747,7 +7020,13 @@ spec:
                                                     As the token approaches expiration,
                                                     the kubelet volume plugin will
                                                     proactively rotate the service
-                                                    account token.
+                                                    account token. The kubelet will
+                                                    start trying to rotate the token
+                                                    if the token is older than 80
+                                                    percent of its time to live or
+                                                    if the token is older than 24
+                                                    hours.Defaults to 1 hour and must
+                                                    be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
@@ -6811,7 +7090,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       image:
                                         description: 'image is the rados image name.
@@ -6935,7 +7216,9 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.'
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -7029,6 +7312,8 @@ spec:
                                           Kubernetes name scoping to be mirrored within
                                           StorageOS for tighter integration. Set VolumeName
                                           to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces
+                                          within StorageOS.
                                         type: string
                                     type: object
                                   vsphereVolume:

--- a/manifests/base/crds/kubeflow.org_mxjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_mxjobs.yaml
@@ -109,7 +109,10 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e.
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.
                                       items:
                                         description: An empty preferred scheduling
                                           term matches all objects with implicit weight
@@ -152,6 +155,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -191,6 +196,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -218,7 +225,9 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g.
+                                        pod execution (e.g. due to an update), the
+                                        system may or may not try to eventually evict
+                                        the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
@@ -260,6 +269,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -299,6 +310,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -326,7 +339,10 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e.
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -407,7 +423,9 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace".
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -489,7 +507,8 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods i
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
@@ -511,7 +530,9 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g.
+                                        pod execution (e.g. due to a pod label update),
+                                        the system may or may not try to eventually
+                                        evict the pod from its node.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -520,7 +541,8 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of an
+                                          that of any node on which a pod of the set
+                                          of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -588,6 +610,7 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -663,7 +686,8 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods i
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -763,7 +787,9 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace".
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -845,7 +871,8 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods i
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
@@ -867,7 +894,9 @@ spec:
                                         time, the pod will not be scheduled onto the
                                         node. If the anti-affinity requirements specified
                                         by this field cease to be met at some point
-                                        during pod execution (e.g.
+                                        during pod execution (e.g. due to a pod label
+                                        update), the system may or may not try to
+                                        eventually evict the pod from its node.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -876,7 +905,8 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of an
+                                          that of any node on which a pod of the set
+                                          of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -944,6 +974,7 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1019,7 +1050,8 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods i
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1042,22 +1074,26 @@ spec:
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      container image's CMD is used if this is not
+                                    description: 'Arguments to the entrypoint. The
+                                      container image''s CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container's environment.
+                                      expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The container image's ENTRYPOINT is
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The container image''s ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container's
+                                      $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -1073,13 +1109,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1189,7 +1228,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1256,7 +1299,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1270,7 +1313,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1360,6 +1406,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1373,7 +1421,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1474,7 +1525,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -1600,7 +1654,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -1621,7 +1677,9 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network.
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -1682,7 +1740,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -1808,7 +1869,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -1856,11 +1919,15 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -1899,7 +1966,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -1914,7 +1981,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -1933,7 +2000,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -1941,7 +2009,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -1998,7 +2070,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -2053,7 +2126,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -2179,7 +2255,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2210,13 +2288,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -2345,7 +2429,9 @@ spec:
                                 "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
                                 'ClusterFirst', 'Default' or 'None'. DNS parameters
                                 given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy.
+                                selected with DNSPolicy. To have DNS options set along
+                                with hostNetwork, you have to specify DNS policy explicitly
+                                to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
                               description: 'EnableServiceLinks indicates whether information
@@ -2359,31 +2445,40 @@ spec:
                                 pod to perform user-initiated actions such as debugging.
                                 This list cannot be specified when creating a pod,
                                 and it cannot be modified by updating the pod spec.
+                                In order to add an ephemeral container to an existing
+                                pod, use the pod's ephemeralcontainers subresource.
                               items:
                                 description: An EphemeralContainer is a temporary
                                   container that you may add to an existing Pod for
                                   user-initiated activities such as debugging. Ephemeral
                                   containers have no resource or scheduling guarantees,
                                   and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted.
+                                  when a Pod is removed or restarted. The kubelet
+                                  may evict a Pod if an ephemeral container causes
+                                  the Pod to exceed its resource allocation.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      image's CMD is used if this is not provided.
+                                    description: 'Arguments to the entrypoint. The
+                                      image''s CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
-                                      using the container's environment. If a variable
+                                      using the container''s environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged.
+                                      string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the
+                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)".'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The image's ENTRYPOINT is used if this
-                                      is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container's environment.
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The image''s ENTRYPOINT is used if
+                                      this is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -2399,13 +2494,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -2515,7 +2613,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -2577,7 +2679,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2591,7 +2693,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2681,6 +2786,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2694,7 +2801,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2794,7 +2904,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -2920,7 +3033,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2997,7 +3112,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -3123,7 +3241,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3171,11 +3291,15 @@ spec:
                                       override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -3214,7 +3338,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -3229,7 +3353,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -3248,7 +3372,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -3256,7 +3381,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3313,7 +3442,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -3365,7 +3495,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -3491,7 +3624,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3516,12 +3651,13 @@ spec:
                                       sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container
+                                    description: "If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
                                       then the ephemeral container uses the namespaces
-                                      configured in the Pod spec.
+                                      configured in the Pod spec. \n The container
+                                      runtime must implement support for this feature."
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -3530,13 +3666,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -3662,7 +3804,8 @@ spec:
                                 pod will be run in the host user namespace, useful
                                 for when the pod needs a feature only available to
                                 the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE.'
+                                module with CAP_SYS_MODULE. When set to false, a new
+                                userns is created for the pod.'
                               type: boolean
                             hostname:
                               description: Specifies the hostname of the Pod If not
@@ -3675,7 +3818,7 @@ spec:
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
                                 puller implementations for them to use. More info:
-                                https://kubernetes.'
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -3695,28 +3838,34 @@ spec:
                                 to the pod. Init containers are executed in order
                                 prior to containers being started. If any init container
                                 fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy.
+                                handled according to its restartPolicy. The name for
+                                an init container or normal container must be unique
+                                among all containers.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      container image's CMD is used if this is not
+                                    description: 'Arguments to the entrypoint. The
+                                      container image''s CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container's environment.
+                                      expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The container image's ENTRYPOINT is
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The container image''s ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container's
+                                      $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -3732,13 +3881,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -3848,7 +4000,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -3915,7 +4071,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -3929,7 +4085,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4019,6 +4178,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4032,7 +4193,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4133,7 +4297,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4259,7 +4426,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4280,7 +4449,9 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network.
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -4341,7 +4512,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4467,7 +4641,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4515,11 +4691,15 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -4558,7 +4738,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -4573,7 +4753,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -4592,7 +4772,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -4600,7 +4781,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -4657,7 +4842,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -4712,7 +4898,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4838,7 +5027,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4869,13 +5060,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -4981,13 +5178,17 @@ spec:
                                 if this is set. \n If the OS field is set to linux,
                                 the following fields must be unset: -securityContext.windowsOptions
                                 \n If the OS field is set to windows, following fields
-                                must be unset: - spec."
+                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
+                                - spec.securityContext.seLinuxOptions - spec.securityContext."
                               properties:
                                 name:
                                   description: 'Name is the name of the operating
                                     system. The currently supported values are linux
                                     and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.'
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values
+                                    and treat unrecognized values in this field as
+                                    os: null'
                                   type: string
                               required:
                               - name
@@ -5004,7 +5205,9 @@ spec:
                                 This field will be autopopulated at admission time
                                 by the RuntimeClass admission controller. If the RuntimeClass
                                 admission controller is enabled, overhead must not
-                                be set in Pod create requests.
+                                be set in Pod create requests. The RuntimeClass admission
+                                controller will reject Pod create requests which have
+                                the overhead already set.
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
@@ -5026,7 +5229,8 @@ spec:
                                 are two special keywords which indicate the highest
                                 priorities with the former being the highest priority.
                                 Any other name must be defined by creating a PriorityClass
-                                object with that name.
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
                               type: string
                             readinessGates:
                               description: 'If specified, all readiness gates will
@@ -5052,10 +5256,14 @@ spec:
                                 to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: RuntimeClassName refers to a RuntimeClass
+                              description: 'RuntimeClassName refers to a RuntimeClass
                                 object in the node.k8s.io group, which should be used
                                 to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run.
+                                the named class, the pod will not be run. If unset
+                                or empty, the "legacy" RuntimeClass will be used,
+                                which is an implicit class with an empty definition
+                                that uses the default runtime handler. More info:
+                                https://git.k8s.'
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -5079,11 +5287,14 @@ spec:
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: fsGroupChangePolicy defines behavior
+                                  description: 'fsGroupChangePolicy defines behavior
                                     of changing ownership and permission of the volume
                                     before being exposed inside Pod. This field will
                                     only apply to volume types which support fsGroup
-                                    based ownership(and permissions).
+                                    based ownership(and permissions). It will have
+                                    no effect on ephemeral volume types such as: secret,
+                                    configmaps and emptydir. Valid values are "OnRootMismatch"
+                                    and "Always". If not specified, "Always" is used.'
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -5092,7 +5303,7 @@ spec:
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
                                     for that container. Note that this field cannot
-                                    be set when spec.
+                                    be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -5111,13 +5322,19 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
                                   description: The SELinux context to be applied to
                                     all containers. If unspecified, the container
                                     runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.
+                                    for each container.  May also be set in SecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5199,7 +5416,8 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -5249,11 +5467,13 @@ spec:
                                 nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: Share a single process namespace between
+                              description: 'Share a single process namespace between
                                 all of the containers in a pod. When this is set containers
                                 will be able to view and signal processes from other
                                 containers in the same pod, and the first process
-                                in each container will not be assigned PID 1.
+                                in each container will not be assigned PID 1. HostPID
+                                and ShareProcessNamespace cannot both be set. Optional:
+                                Default to false.'
                               type: boolean
                             subdomain:
                               description: If specified, the fully qualified Pod hostname
@@ -5266,7 +5486,8 @@ spec:
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
                                 zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down).
+                                (no opportunity to shut down). If this value is nil,
+                                the default grace period will be used instead.
                               format: int64
                               type: integer
                             tolerations:
@@ -5302,7 +5523,8 @@ spec:
                                       of effect NoExecute, otherwise this field is
                                       ignored) tolerates the taint. By default, it
                                       is not set, which means tolerate the taint forever
-                                      (do not evict).
+                                      (do not evict). Zero and negative values will
+                                      be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
@@ -5379,7 +5601,13 @@ spec:
                                   matchLabelKeys:
                                     description: MatchLabelKeys is a set of pod label
                                       keys to select the pods over which spreading
-                                      will be calculated.
+                                      will be calculated. The keys are used to lookup
+                                      values from the incoming pod labels, those key-value
+                                      labels are ANDed with labelSelector to select
+                                      the group of existing pods over which spreading
+                                      will be calculated for the incoming pod. Keys
+                                      that don't exist in the incoming pod labels
+                                      will be ignored.
                                     items:
                                       type: string
                                     type: array
@@ -5389,7 +5617,10 @@ spec:
                                       pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                                       it is the maximum permitted difference between
                                       the number of matching pods in the target topology
-                                      and the global minimum.
+                                      and the global minimum. The global minimum is
+                                      the minimum number of matching pods in an eligible
+                                      domain or zero if the number of eligible domains
+                                      is less than MinDomains.
                                     format: int32
                                     type: integer
                                   minDomains:
@@ -5398,25 +5629,33 @@ spec:
                                       domains with matching topology keys is less
                                       than minDomains, Pod Topology Spread treats
                                       "global minimum" as 0, and then the calculation
-                                      of Skew is performed.
+                                      of Skew is performed. And when the number of
+                                      eligible domains with matching topology keys
+                                      equals or greater than minDomains, this value
+                                      has no effect on scheduling.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: 'NodeAffinityPolicy indicates how
-                                      we will treat Pod''s nodeAffinity/nodeSelector
+                                    description: "NodeAffinityPolicy indicates how
+                                      we will treat Pod's nodeAffinity/nodeSelector
                                       when calculating pod topology spread skew. Options
                                       are: - Honor: only nodes matching nodeAffinity/nodeSelector
                                       are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored.'
+                                      nodeAffinity/nodeSelector are ignored. All nodes
+                                      are included in the calculations. \n If this
+                                      value is nil, the behavior is equivalent to
+                                      the Honor policy."
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: 'NodeTaintsPolicy indicates how we
+                                    description: "NodeTaintsPolicy indicates how we
                                       will treat node taints when calculating pod
                                       topology spread skew. Options are: - Honor:
                                       nodes without taints, along with tainted nodes
                                       for which the incoming pod has a toleration,
                                       are included. - Ignore: node taints are ignored.
-                                      All nodes are included.'
+                                      All nodes are included. \n If this value is
+                                      nil, the behavior is equivalent to the Ignore
+                                      policy."
                                     type: string
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
@@ -5424,13 +5663,17 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket.
+                                      each bucket. We define a domain as a particular
+                                      instance of a topology.
                                     type: string
                                   whenUnsatisfiable:
                                     description: WhenUnsatisfiable indicates how to
                                       deal with a pod if it doesn't satisfy the spread
                                       constraint. - DoNotSchedule (default) tells
-                                      the scheduler not to schedule it.
+                                      the scheduler not to schedule it. - ScheduleAnyway
+                                      tells the scheduler to schedule the pod in any
+                                      location, but giving higher precedence to topologies
+                                      that would help reduce the skew.
                                     type: string
                                 required:
                                 - maxSkew
@@ -5463,7 +5706,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -5648,7 +5893,9 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.'
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -5726,7 +5973,9 @@ spec:
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
                                           calls. This field is optional, and  may
-                                          be empty if no secret is required.
+                                          be empty if no secret is required. If the
+                                          secret object contains more than one secret,
+                                          all secret references are passed.
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5762,7 +6011,11 @@ spec:
                                           mode bits used to set permissions on created
                                           files by default. Must be an octal value
                                           between 0000 and 0777 or a decimal value
-                                          between 0 and 511.'
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -5860,14 +6113,16 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: sizeLimit is the total amount
+                                        description: 'sizeLimit is the total amount
                                           of local storage required for this EmptyDir
                                           volume. The size limit is also applicable
                                           for memory medium. The maximum usage on
                                           memory medium EmptyDir would be the minimum
                                           value between the SizeLimit specified here
                                           and the sum of memory limits of all containers
-                                          in a pod.
+                                          in a pod. The default is nil which means
+                                          that the limit is undefined. More info:
+                                          http://kubernetes.'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
@@ -5883,7 +6138,10 @@ spec:
                                           PVC to provision the volume. The pod in
                                           which this EphemeralVolumeSource is embedded
                                           will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.
+                                          will be deleted together with the pod.  The
+                                          name of the PVC will be `<pod name>-<volume
+                                          name>` where `<volume name>` is the name
+                                          from the `PodSpec.Volumes` array entry.
                                         properties:
                                           metadata:
                                             description: May contain labels and annotations
@@ -5926,7 +6184,13 @@ spec:
                                               dataSource:
                                                 description: 'dataSource field can
                                                   be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.'
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                  * An existing PVC (PersistentVolumeClaim)
+                                                  If the provisioner or an external
+                                                  controller can support the specified
+                                                  data source, it will create a new
+                                                  volume based on the contents of
+                                                  the specified data source.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -5957,7 +6221,11 @@ spec:
                                                   volume is desired. This may be any
                                                   local object from a non-empty API
                                                   group (non core object) or a PersistentVolumeClaim
-                                                  object.
+                                                  object. When this field is specified,
+                                                  volume binding will only succeed
+                                                  if the type of the specified object
+                                                  matches some installed volume populator
+                                                  or dynamic provisioner.
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -5982,7 +6250,7 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resources:
-                                                description: resources represents
+                                                description: 'resources represents
                                                   the minimum resources the volume
                                                   should have. If RecoverVolumeExpansionFailure
                                                   feature is enabled users are allowed
@@ -5990,7 +6258,7 @@ spec:
                                                   that are lower than previous value
                                                   but must still be higher than capacity
                                                   recorded in the status field of
-                                                  the claim.
+                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -6219,7 +6487,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6228,7 +6498,7 @@ spec:
                                           Examples: For volume /dev/sda1, you specify
                                           the partition as "1". Similarly, the volume
                                           partition for /dev/sda is "0" (or you can
-                                          leave the property empty).'
+                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
@@ -6335,7 +6605,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       initiatorName:
                                         description: initiatorName is the custom iSCSI
@@ -6492,7 +6764,8 @@ spec:
                                           0000 and 0777 or a decimal value between
                                           0 and 511. YAML accepts both octal and decimal
                                           values, JSON requires decimal values for
-                                          mode bits.
+                                          mode bits. Directories within the path are
+                                          not affected by this setting.
                                         format: int32
                                         type: integer
                                       sources:
@@ -6745,7 +7018,13 @@ spec:
                                                     As the token approaches expiration,
                                                     the kubelet volume plugin will
                                                     proactively rotate the service
-                                                    account token.
+                                                    account token. The kubelet will
+                                                    start trying to rotate the token
+                                                    if the token is older than 80
+                                                    percent of its time to live or
+                                                    if the token is older than 24
+                                                    hours.Defaults to 1 hour and must
+                                                    be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
@@ -6809,7 +7088,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       image:
                                         description: 'image is the rados image name.
@@ -6933,7 +7214,9 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.'
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -7027,6 +7310,8 @@ spec:
                                           Kubernetes name scoping to be mirrored within
                                           StorageOS for tighter integration. Set VolumeName
                                           to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces
+                                          within StorageOS.
                                         type: string
                                     type: object
                                   vsphereVolume:

--- a/manifests/base/crds/kubeflow.org_mxjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_mxjobs.yaml
@@ -109,15 +109,7 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node matches the corresponding matchExpressions;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                        with the greatest sum of weights, i.e.
                                       items:
                                         description: An empty preferred scheduling
                                           term matches all objects with implicit weight
@@ -160,8 +152,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -201,8 +191,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -230,9 +218,7 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g. due to an update), the
-                                        system may or may not try to eventually evict
-                                        the pod from its node.
+                                        pod execution (e.g.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
@@ -274,8 +260,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -315,8 +299,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -344,15 +326,7 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node has pods which matches the corresponding
-                                        podAffinityTerm; the node(s) with the highest
-                                        sum are the most preferred.
+                                        with the greatest sum of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -433,9 +407,7 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                  means "this pod's namespace".
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -517,8 +489,7 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                  selected pods i
                                                 type: string
                                             required:
                                             - topologyKey
@@ -540,12 +511,7 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g. due to a pod label update),
-                                        the system may or may not try to eventually
-                                        evict the pod from its node. When there are
-                                        multiple elements, the lists of nodes corresponding
-                                        to each podAffinityTerm are intersected, i.e.
-                                        all terms must be satisfied.
+                                        pod execution (e.g.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -554,8 +520,7 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                          that of an
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -623,7 +588,6 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -699,8 +663,7 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                              of the selected pods i
                                             type: string
                                         required:
                                         - topologyKey
@@ -719,15 +682,7 @@ spec:
                                         may choose a node that violates one or more
                                         of the expressions. The node that is most
                                         preferred is the one with the greatest sum
-                                        of weights, i.e. for each node that meets
-                                        all of the scheduling requirements (resource
-                                        request, requiredDuringScheduling anti-affinity
-                                        expressions, etc.), compute a sum by iterating
-                                        through the elements of this field and adding
-                                        "weight" to the sum if the node has pods which
-                                        matches the corresponding podAffinityTerm;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                        of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -808,9 +763,7 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                  means "this pod's namespace".
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -892,8 +845,7 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                  selected pods i
                                                 type: string
                                             required:
                                             - topologyKey
@@ -915,12 +867,7 @@ spec:
                                         time, the pod will not be scheduled onto the
                                         node. If the anti-affinity requirements specified
                                         by this field cease to be met at some point
-                                        during pod execution (e.g. due to a pod label
-                                        update), the system may or may not try to
-                                        eventually evict the pod from its node. When
-                                        there are multiple elements, the lists of
-                                        nodes corresponding to each podAffinityTerm
-                                        are intersected, i.e. all terms must be satisfied.
+                                        during pod execution (e.g.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -929,8 +876,7 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                          that of an
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -998,7 +944,6 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1074,8 +1019,7 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                              of the selected pods i
                                             type: string
                                         required:
                                         - topologyKey
@@ -1098,34 +1042,22 @@ spec:
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
+                                    description: Arguments to the entrypoint. The
+                                      container image's CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
+                                      expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The container image's ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
+                                      $(VAR_NAME) are expanded using the container's
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -1141,19 +1073,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1263,11 +1189,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1334,7 +1256,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1348,10 +1270,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1435,21 +1354,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1463,10 +1373,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1567,10 +1474,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -1696,19 +1600,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -1729,10 +1621,7 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
-                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                      Cannot be updated.
+                                      from the network.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -1793,10 +1682,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -1922,19 +1808,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -1982,15 +1856,11 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -2029,7 +1899,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -2044,7 +1914,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -2054,10 +1924,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -2066,8 +1933,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -2075,11 +1941,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2136,8 +1998,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -2159,13 +2020,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -2180,16 +2035,11 @@ spec:
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the
-                                      Pod has successfully initialized. If specified,
+                                    description: StartupProbe indicates that the Pod
+                                      has successfully initialized. If specified,
                                       no other probes are executed until this completes
                                       successfully. If this probe fails, the Pod will
                                       be restarted, just as if the livenessProbe failed.
-                                      This can be used to provide different probe
-                                      parameters at the beginning of a Pod''s lifecycle,
-                                      when it might take a long time to load data
-                                      or warm a cache, than during steady-state operation.
-                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
@@ -2203,10 +2053,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -2332,19 +2179,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2366,15 +2201,7 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -2383,21 +2210,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -2526,9 +2345,7 @@ spec:
                                 "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
                                 'ClusterFirst', 'Default' or 'None'. DNS parameters
                                 given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy. To have DNS options set along
-                                with hostNetwork, you have to specify DNS policy explicitly
-                                to 'ClusterFirstWithHostNet'.
+                                selected with DNSPolicy.
                               type: string
                             enableServiceLinks:
                               description: 'EnableServiceLinks indicates whether information
@@ -2542,50 +2359,31 @@ spec:
                                 pod to perform user-initiated actions such as debugging.
                                 This list cannot be specified when creating a pod,
                                 and it cannot be modified by updating the pod spec.
-                                In order to add an ephemeral container to an existing
-                                pod, use the pod's ephemeralcontainers subresource.
                               items:
-                                description: "An EphemeralContainer is a temporary
+                                description: An EphemeralContainer is a temporary
                                   container that you may add to an existing Pod for
                                   user-initiated activities such as debugging. Ephemeral
                                   containers have no resource or scheduling guarantees,
                                   and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted. The kubelet
-                                  may evict a Pod if an ephemeral container causes
-                                  the Pod to exceed its resource allocation. \n To
-                                  add an ephemeral container, use the ephemeralcontainers
-                                  subresource of an existing Pod. Ephemeral containers
-                                  may not be removed or restarted."
+                                  when a Pod is removed or restarted.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      image''s CMD is used if this is not provided.
+                                    description: Arguments to the entrypoint. The
+                                      image's CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
+                                      using the container's environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the
-                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                      produce the string literal "$(VAR_NAME)". Escaped
-                                      references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The image''s ENTRYPOINT is used if
-                                      this is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container''s environment.
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The image's ENTRYPOINT is used if this
+                                      is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
@@ -2601,19 +2399,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -2723,11 +2515,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -2789,7 +2577,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2803,10 +2591,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2890,21 +2675,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2918,10 +2694,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3021,10 +2794,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -3150,19 +2920,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3239,10 +2997,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -3368,19 +3123,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3428,15 +3171,11 @@ spec:
                                       override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -3475,7 +3214,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -3490,7 +3229,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -3500,10 +3239,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -3512,8 +3248,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -3521,11 +3256,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3582,8 +3313,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -3605,13 +3335,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -3641,10 +3365,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -3770,19 +3491,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3804,26 +3513,15 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: "If set, the name of the container
+                                    description: If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
                                       then the ephemeral container uses the namespaces
-                                      configured in the Pod spec. \n The container
-                                      runtime must implement support for this feature.
-                                      If the runtime does not support namespace targeting
-                                      then the result of setting this field is undefined."
+                                      configured in the Pod spec.
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -3832,21 +3530,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -3972,13 +3662,7 @@ spec:
                                 pod will be run in the host user namespace, useful
                                 for when the pod needs a feature only available to
                                 the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE. When set to false, a new
-                                userns is created for the pod. Setting false is useful
-                                for mitigating container breakout vulnerabilities
-                                even allowing users to run their containers as root
-                                without actually having root privileges on the host.
-                                This field is alpha-level and is only honored by servers
-                                that enable the UserNamespacesSupport feature.'
+                                module with CAP_SYS_MODULE.'
                               type: boolean
                             hostname:
                               description: Specifies the hostname of the Pod If not
@@ -3991,7 +3675,7 @@ spec:
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
                                 puller implementations for them to use. More info:
-                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                https://kubernetes.'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -4007,55 +3691,32 @@ spec:
                                 x-kubernetes-map-type: atomic
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging
+                              description: List of initialization containers belonging
                                 to the pod. Init containers are executed in order
                                 prior to containers being started. If any init container
                                 fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy. The name for
-                                an init container or normal container must be unique
-                                among all containers. Init containers may not have
-                                Lifecycle actions, Readiness probes, Liveness probes,
-                                or Startup probes. The resourceRequirements of an
-                                init container are taken into account during scheduling
-                                by finding the highest request/limit for each resource
-                                type, and then using the max of of that value or the
-                                sum of the normal containers. Limits are applied to
-                                init containers in a similar fashion. Init containers
-                                cannot currently be added or removed. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                                handled according to its restartPolicy.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
+                                    description: Arguments to the entrypoint. The
+                                      container image's CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
+                                      expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The container image's ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
+                                      $(VAR_NAME) are expanded using the container's
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -4071,19 +3732,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -4193,11 +3848,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -4264,7 +3915,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4278,10 +3929,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4365,21 +4013,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4393,10 +4032,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4497,10 +4133,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -4626,19 +4259,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4659,10 +4280,7 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
-                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                      Cannot be updated.
+                                      from the network.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -4723,10 +4341,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -4852,19 +4467,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4912,15 +4515,11 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -4959,7 +4558,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -4974,7 +4573,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -4984,10 +4583,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -4996,8 +4592,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -5005,11 +4600,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -5066,8 +4657,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -5089,13 +4679,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -5110,16 +4694,11 @@ spec:
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the
-                                      Pod has successfully initialized. If specified,
+                                    description: StartupProbe indicates that the Pod
+                                      has successfully initialized. If specified,
                                       no other probes are executed until this completes
                                       successfully. If this probe fails, the Pod will
                                       be restarted, just as if the livenessProbe failed.
-                                      This can be used to provide different probe
-                                      parameters at the beginning of a Pod''s lifecycle,
-                                      when it might take a long time to load data
-                                      or warm a cache, than during steady-state operation.
-                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
@@ -5133,10 +4712,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -5262,19 +4838,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -5296,15 +4860,7 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -5313,21 +4869,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -5433,28 +4981,13 @@ spec:
                                 if this is set. \n If the OS field is set to linux,
                                 the following fields must be unset: -securityContext.windowsOptions
                                 \n If the OS field is set to windows, following fields
-                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
-                                - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
-                                - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
-                                - spec.securityContext.sysctls - spec.shareProcessNamespace
-                                - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
-                                - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions
-                                - spec.containers[*].securityContext.seccompProfile
-                                - spec.containers[*].securityContext.capabilities
-                                - spec.containers[*].securityContext.readOnlyRootFilesystem
-                                - spec.containers[*].securityContext.privileged -
-                                spec.containers[*].securityContext.allowPrivilegeEscalation
-                                - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                                - spec.containers[*].securityContext.runAsGroup"
+                                must be unset: - spec."
                               properties:
                                 name:
                                   description: 'Name is the name of the operating
                                     system. The currently supported values are linux
                                     and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                    Clients should expect to handle additional values
-                                    and treat unrecognized values in this field as
-                                    os: null'
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.'
                                   type: string
                               required:
                               - name
@@ -5466,18 +4999,12 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Overhead represents the resource overhead
+                              description: Overhead represents the resource overhead
                                 associated with running a pod for a given RuntimeClass.
                                 This field will be autopopulated at admission time
                                 by the RuntimeClass admission controller. If the RuntimeClass
                                 admission controller is enabled, overhead must not
-                                be set in Pod create requests. The RuntimeClass admission
-                                controller will reject Pod create requests which have
-                                the overhead already set. If RuntimeClass is configured
-                                and selected in the PodSpec, Overhead will be set
-                                to the value defined in the corresponding RuntimeClass,
-                                otherwise it will remain unset and treated as zero.
-                                More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                                be set in Pod create requests.
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
@@ -5499,8 +5026,7 @@ spec:
                                 are two special keywords which indicate the highest
                                 priorities with the former being the highest priority.
                                 Any other name must be defined by creating a PriorityClass
-                                object with that name. If not specified, the pod priority
-                                will be default or zero if there is no default.
+                                object with that name.
                               type: string
                             readinessGates:
                               description: 'If specified, all readiness gates will
@@ -5526,14 +5052,10 @@ spec:
                                 to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass
+                              description: RuntimeClassName refers to a RuntimeClass
                                 object in the node.k8s.io group, which should be used
                                 to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run. If unset
-                                or empty, the "legacy" RuntimeClass will be used,
-                                which is an implicit class with an empty definition
-                                that uses the default runtime handler. More info:
-                                https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                                the named class, the pod will not be run.
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -5553,24 +5075,15 @@ spec:
                                     of that volume to be owned by the pod: \n 1. The
                                     owning GID will be the FSGroup 2. The setgid bit
                                     is set (new files created in the volume will be
-                                    owned by FSGroup) 3. The permission bits are OR'd
-                                    with rw-rw---- \n If unset, the Kubelet will not
-                                    modify the ownership and permissions of any volume.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows."
+                                    owned by FSGroup) 3."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior
+                                  description: fsGroupChangePolicy defines behavior
                                     of changing ownership and permission of the volume
                                     before being exposed inside Pod. This field will
                                     only apply to volume types which support fsGroup
-                                    based ownership(and permissions). It will have
-                                    no effect on ephemeral volume types such as: secret,
-                                    configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified, "Always" is used.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.'
+                                    based ownership(and permissions).
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -5579,7 +5092,7 @@ spec:
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
                                     for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                    be set when spec.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -5589,9 +5102,7 @@ spec:
                                     does not run as UID 0 (root) and fail to start
                                     the container if it does. If unset or false, no
                                     such validation will be performed. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                    set in SecurityContext.
                                   type: boolean
                                 runAsUser:
                                   description: The UID to run the entrypoint of the
@@ -5600,19 +5111,13 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
                                   description: The SELinux context to be applied to
                                     all containers. If unspecified, the container
                                     runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                    for each container.  May also be set in SecurityContext.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5694,8 +5199,7 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                    Note that this field cannot be set when spec.os.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -5714,12 +5218,7 @@ spec:
                                         honored by components that enable the WindowsHostProcessContainers
                                         feature flag. Setting this field without the
                                         feature flag will result in errors when validating
-                                        the Pod. All of a Pod's containers must have
-                                        the same effective HostProcess value (it is
-                                        not allowed to have a mix of HostProcess containers
-                                        and non-HostProcess containers).  In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                        the Pod.
                                       type: boolean
                                     runAsUserName:
                                       description: The UserName in Windows to run
@@ -5747,20 +5246,14 @@ spec:
                                 as the pod's FQDN, rather than the leaf name (the
                                 default). In Linux containers, this means setting
                                 the FQDN in the hostname field of the kernel (the
-                                nodename field of struct utsname). In Windows containers,
-                                this means setting the registry value of hostname
-                                for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
-                                to FQDN. If a pod does not have FQDN, this has no
-                                effect. Default to false.
+                                nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between
+                              description: Share a single process namespace between
                                 all of the containers in a pod. When this is set containers
                                 will be able to view and signal processes from other
                                 containers in the same pod, and the first process
-                                in each container will not be assigned PID 1. HostPID
-                                and ShareProcessNamespace cannot both be set. Optional:
-                                Default to false.'
+                                in each container will not be assigned PID 1.
                               type: boolean
                             subdomain:
                               description: If specified, the fully qualified Pod hostname
@@ -5773,14 +5266,7 @@ spec:
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
                                 zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down). If this value is nil,
-                                the default grace period will be used instead. The
-                                grace period is the duration in seconds after the
-                                processes running in the pod are sent a termination
-                                signal and the time when the processes are forcibly
-                                halted with a kill signal. Set this value longer than
-                                the expected cleanup time for your process. Defaults
-                                to 30 seconds.
+                                (no opportunity to shut down).
                               format: int64
                               type: integer
                             tolerations:
@@ -5816,8 +5302,7 @@ spec:
                                       of effect NoExecute, otherwise this field is
                                       ignored) tolerates the taint. By default, it
                                       is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
+                                      (do not evict).
                                     format: int64
                                     type: integer
                                   value:
@@ -5894,98 +5379,44 @@ spec:
                                   matchLabelKeys:
                                     description: MatchLabelKeys is a set of pod label
                                       keys to select the pods over which spreading
-                                      will be calculated. The keys are used to lookup
-                                      values from the incoming pod labels, those key-value
-                                      labels are ANDed with labelSelector to select
-                                      the group of existing pods over which spreading
-                                      will be calculated for the incoming pod. Keys
-                                      that don't exist in the incoming pod labels
-                                      will be ignored. A null or empty list means
-                                      only match against labelSelector.
+                                      will be calculated.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   maxSkew:
-                                    description: 'MaxSkew describes the degree to
-                                      which pods may be unevenly distributed. When
-                                      `whenUnsatisfiable=DoNotSchedule`, it is the
-                                      maximum permitted difference between the number
-                                      of matching pods in the target topology and
-                                      the global minimum. The global minimum is the
-                                      minimum number of matching pods in an eligible
-                                      domain or zero if the number of eligible domains
-                                      is less than MinDomains. For example, in a 3-zone
-                                      cluster, MaxSkew is set to 1, and pods with
-                                      the same labelSelector spread as 2/2/1: In this
-                                      case, the global minimum is 1. | zone1 | zone2
-                                      | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
-                                      is 1, incoming pod can only be scheduled to
-                                      zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                                      would make the ActualSkew(3-1) on zone1(zone2)
-                                      violate MaxSkew(1). - if MaxSkew is 2, incoming
-                                      pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                                      it is used to give higher precedence to topologies
-                                      that satisfy it. It''s a required field. Default
-                                      value is 1 and 0 is not allowed.'
+                                    description: MaxSkew describes the degree to which
+                                      pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                      it is the maximum permitted difference between
+                                      the number of matching pods in the target topology
+                                      and the global minimum.
                                     format: int32
                                     type: integer
                                   minDomains:
-                                    description: "MinDomains indicates a minimum number
+                                    description: MinDomains indicates a minimum number
                                       of eligible domains. When the number of eligible
                                       domains with matching topology keys is less
                                       than minDomains, Pod Topology Spread treats
-                                      \"global minimum\" as 0, and then the calculation
-                                      of Skew is performed. And when the number of
-                                      eligible domains with matching topology keys
-                                      equals or greater than minDomains, this value
-                                      has no effect on scheduling. As a result, when
-                                      the number of eligible domains is less than
-                                      minDomains, scheduler won't schedule more than
-                                      maxSkew Pods to those domains. If value is nil,
-                                      the constraint behaves as if MinDomains is equal
-                                      to 1. Valid values are integers greater than
-                                      0. When value is not nil, WhenUnsatisfiable
-                                      must be DoNotSchedule. \n For example, in a
-                                      3-zone cluster, MaxSkew is set to 2, MinDomains
-                                      is set to 5 and pods with the same labelSelector
-                                      spread as 2/2/2: | zone1 | zone2 | zone3 | |
-                                      \ P P  |  P P  |  P P  | The number of domains
-                                      is less than 5(MinDomains), so \"global minimum\"
-                                      is treated as 0. In this situation, new pod
-                                      with the same labelSelector cannot be scheduled,
-                                      because computed skew will be 3(3 - 0) if new
-                                      Pod is scheduled to any of the three zones,
-                                      it will violate MaxSkew. \n This is a beta field
-                                      and requires the MinDomainsInPodTopologySpread
-                                      feature gate to be enabled (enabled by default)."
+                                      "global minimum" as 0, and then the calculation
+                                      of Skew is performed.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: "NodeAffinityPolicy indicates how
-                                      we will treat Pod's nodeAffinity/nodeSelector
+                                    description: 'NodeAffinityPolicy indicates how
+                                      we will treat Pod''s nodeAffinity/nodeSelector
                                       when calculating pod topology spread skew. Options
                                       are: - Honor: only nodes matching nodeAffinity/nodeSelector
                                       are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored. All nodes
-                                      are included in the calculations. \n If this
-                                      value is nil, the behavior is equivalent to
-                                      the Honor policy. This is a alpha-level feature
-                                      enabled by the NodeInclusionPolicyInPodTopologySpread
-                                      feature flag."
+                                      nodeAffinity/nodeSelector are ignored.'
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: "NodeTaintsPolicy indicates how we
+                                    description: 'NodeTaintsPolicy indicates how we
                                       will treat node taints when calculating pod
                                       topology spread skew. Options are: - Honor:
                                       nodes without taints, along with tainted nodes
                                       for which the incoming pod has a toleration,
                                       are included. - Ignore: node taints are ignored.
-                                      All nodes are included. \n If this value is
-                                      nil, the behavior is equivalent to the Ignore
-                                      policy. This is a alpha-level feature enabled
-                                      by the NodeInclusionPolicyInPodTopologySpread
-                                      feature flag."
+                                      All nodes are included.'
                                     type: string
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
@@ -5993,37 +5424,13 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket. We define a domain as a particular
-                                      instance of a topology. Also, we define an eligible
-                                      domain as a domain whose nodes meet the requirements
-                                      of nodeAffinityPolicy and nodeTaintsPolicy.
-                                      e.g. If TopologyKey is "kubernetes.io/hostname",
-                                      each Node is a domain of that topology. And,
-                                      if TopologyKey is "topology.kubernetes.io/zone",
-                                      each zone is a domain of that topology. It's
-                                      a required field.
+                                      each bucket.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: 'WhenUnsatisfiable indicates how
-                                      to deal with a pod if it doesn''t satisfy the
-                                      spread constraint. - DoNotSchedule (default)
-                                      tells the scheduler not to schedule it. - ScheduleAnyway
-                                      tells the scheduler to schedule the pod in any
-                                      location, but giving higher precedence to topologies
-                                      that would help reduce the skew. A constraint
-                                      is considered "Unsatisfiable" for an incoming
-                                      pod if and only if every possible node assignment
-                                      for that pod would violate "MaxSkew" on some
-                                      topology. For example, in a 3-zone cluster,
-                                      MaxSkew is set to 1, and pods with the same
-                                      labelSelector spread as 3/1/1: | zone1 | zone2
-                                      | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
-                                      is set to DoNotSchedule, incoming pod can only
-                                      be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
-                                      as ActualSkew(2-1) on zone2(zone3) satisfies
-                                      MaxSkew(1). In other words, the cluster can
-                                      still be imbalanced, but scheduler won''t make
-                                      it *more* imbalanced. It''s a required field.'
+                                    description: WhenUnsatisfiable indicates how to
+                                      deal with a pod if it doesn't satisfy the spread
+                                      constraint. - DoNotSchedule (default) tells
+                                      the scheduler not to schedule it.
                                     type: string
                                 required:
                                 - maxSkew
@@ -6056,9 +5463,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6243,12 +5648,7 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          values for mode bits. Defaults to 0644.'
                                         format: int32
                                         type: integer
                                       items:
@@ -6258,12 +5658,7 @@ spec:
                                           as a file whose name is the key and content
                                           is the value. If specified, the listed keys
                                           will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the ConfigMap, the volume setup will
-                                          error unless it is marked optional. Paths
-                                          must be relative and may not contain the
-                                          '..' path or start with '..'.
+                                          and unlisted keys will not be present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -6280,10 +5675,7 @@ spec:
                                                 and decimal values, JSON requires
                                                 decimal values for mode bits. If not
                                                 specified, the volume defaultMode
-                                                will be used. This might be in conflict
-                                                with other options that affect the
-                                                file mode, like fsGroup, and the result
-                                                can be other mode bits set.'
+                                                will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -6334,9 +5726,7 @@ spec:
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
                                           calls. This field is optional, and  may
-                                          be empty if no secret is required. If the
-                                          secret object contains more than one secret,
-                                          all secret references are passed.
+                                          be empty if no secret is required.
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -6372,14 +5762,7 @@ spec:
                                           mode bits used to set permissions on created
                                           files by default. Must be an octal value
                                           between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          between 0 and 511.'
                                         format: int32
                                         type: integer
                                       items:
@@ -6416,11 +5799,7 @@ spec:
                                                 and 511. YAML accepts both octal and
                                                 decimal values, JSON requires decimal
                                                 values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                                the volume defaultMode will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -6481,70 +5860,30 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'sizeLimit is the total amount
+                                        description: sizeLimit is the total amount
                                           of local storage required for this EmptyDir
                                           volume. The size limit is also applicable
                                           for memory medium. The maximum usage on
                                           memory medium EmptyDir would be the minimum
                                           value between the SizeLimit specified here
                                           and the sum of memory limits of all containers
-                                          in a pod. The default is nil which means
-                                          that the limit is undefined. More info:
-                                          http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                          in a pod.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: "ephemeral represents a volume that
+                                    description: ephemeral represents a volume that
                                       is handled by a cluster storage driver. The
                                       volume's lifecycle is tied to the pod that defines
                                       it - it will be created before the pod starts,
-                                      and deleted when the pod is removed. \n Use
-                                      this if: a) the volume is only needed while
-                                      the pod runs, b) features of normal volumes
-                                      like restoring from snapshot or capacity tracking
-                                      are needed, c) the storage driver is specified
-                                      through a storage class, and d) the storage
-                                      driver supports dynamic volume provisioning
-                                      through a PersistentVolumeClaim (see EphemeralVolumeSource
-                                      for more information on the connection between
-                                      this volume type and PersistentVolumeClaim).
-                                      \n Use PersistentVolumeClaim or one of the vendor-specific
-                                      APIs for volumes that persist for longer than
-                                      the lifecycle of an individual pod. \n Use CSI
-                                      for light-weight local ephemeral volumes if
-                                      the CSI driver is meant to be used that way
-                                      - see the documentation of the driver for more
-                                      information. \n A pod can use both types of
-                                      ephemeral volumes and persistent volumes at
-                                      the same time."
+                                      and deleted when the pod is removed.
                                     properties:
                                       volumeClaimTemplate:
-                                        description: "Will be used to create a stand-alone
+                                        description: Will be used to create a stand-alone
                                           PVC to provision the volume. The pod in
                                           which this EphemeralVolumeSource is embedded
                                           will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.  The
-                                          name of the PVC will be `<pod name>-<volume
-                                          name>` where `<volume name>` is the name
-                                          from the `PodSpec.Volumes` array entry.
-                                          Pod validation will reject the pod if the
-                                          concatenated name is not valid for a PVC
-                                          (for example, too long). \n An existing
-                                          PVC with that name that is not owned by
-                                          the pod will *not* be used for the pod to
-                                          avoid using an unrelated volume by mistake.
-                                          Starting the pod is then blocked until the
-                                          unrelated PVC is removed. If such a pre-created
-                                          PVC is meant to be used by the pod, the
-                                          PVC has to updated with an owner reference
-                                          to the pod once the pod exists. Normally
-                                          this should not be necessary, but it may
-                                          be useful when manually reconstructing a
-                                          broken cluster. \n This field is read-only
-                                          and no changes will be made by Kubernetes
-                                          to the PVC after it has been created. \n
-                                          Required, must not be nil."
+                                          will be deleted together with the pod.
                                         properties:
                                           metadata:
                                             description: May contain labels and annotations
@@ -6587,17 +5926,7 @@ spec:
                                               dataSource:
                                                 description: 'dataSource field can
                                                   be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                  * An existing PVC (PersistentVolumeClaim)
-                                                  If the provisioner or an external
-                                                  controller can support the specified
-                                                  data source, it will create a new
-                                                  volume based on the contents of
-                                                  the specified data source. If the
-                                                  AnyVolumeDataSource feature gate
-                                                  is enabled, this field will always
-                                                  have the same contents as the DataSourceRef
-                                                  field.'
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6622,38 +5951,13 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               dataSourceRef:
-                                                description: 'dataSourceRef specifies
+                                                description: dataSourceRef specifies
                                                   the object from which to populate
                                                   the volume with data, if a non-empty
                                                   volume is desired. This may be any
                                                   local object from a non-empty API
                                                   group (non core object) or a PersistentVolumeClaim
-                                                  object. When this field is specified,
-                                                  volume binding will only succeed
-                                                  if the type of the specified object
-                                                  matches some installed volume populator
-                                                  or dynamic provisioner. This field
-                                                  will replace the functionality of
-                                                  the DataSource field and as such
-                                                  if both fields are non-empty, they
-                                                  must have the same value. For backwards
-                                                  compatibility, both fields (DataSource
-                                                  and DataSourceRef) will be set to
-                                                  the same value automatically if
-                                                  one of them is empty and the other
-                                                  is non-empty. There are two important
-                                                  differences between DataSource and
-                                                  DataSourceRef: * While DataSource
-                                                  only allows two specific types of
-                                                  objects, DataSourceRef allows any
-                                                  non-core object, as well as PersistentVolumeClaim
-                                                  objects. * While DataSource ignores
-                                                  disallowed values (dropping them),
-                                                  DataSourceRef preserves all values,
-                                                  and generates an error if a disallowed
-                                                  value is specified. (Beta) Using
-                                                  this field requires the AnyVolumeDataSource
-                                                  feature gate to be enabled.'
+                                                  object.
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6678,7 +5982,7 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resources:
-                                                description: 'resources represents
+                                                description: resources represents
                                                   the minimum resources the volume
                                                   should have. If RecoverVolumeExpansionFailure
                                                   feature is enabled users are allowed
@@ -6686,7 +5990,7 @@ spec:
                                                   that are lower than previous value
                                                   but must still be higher than capacity
                                                   recorded in the status field of
-                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  the claim.
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -6915,9 +6219,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6926,7 +6228,7 @@ spec:
                                           Examples: For volume /dev/sda1, you specify
                                           the partition as "1". Similarly, the volume
                                           partition for /dev/sda is "0" (or you can
-                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          leave the property empty).'
                                         format: int32
                                         type: integer
                                       pdName:
@@ -6998,10 +6300,7 @@ spec:
                                       directly exposed to the container. This is generally
                                       used for system agents or other privileged things
                                       that are allowed to see the host machine. Most
-                                      containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                      --- TODO(jonesdl) We need to restrict who can
-                                      use host directory mounts and who can/can not
-                                      mount host directories as read/write.'
+                                      containers will NOT need this. More info: https://kubernetes.'
                                     properties:
                                       path:
                                         description: 'path of the directory on the
@@ -7036,9 +6335,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       initiatorName:
                                         description: initiatorName is the custom iSCSI
@@ -7195,11 +6492,7 @@ spec:
                                           0000 and 0777 or a decimal value between
                                           0 and 511. YAML accepts both octal and decimal
                                           values, JSON requires decimal values for
-                                          mode bits. Directories within the path are
-                                          not affected by this setting. This might
-                                          be in conflict with other options that affect
-                                          the file mode, like fsGroup, and the result
-                                          can be other mode bits set.
+                                          mode bits.
                                         format: int32
                                         type: integer
                                       sources:
@@ -7223,12 +6516,6 @@ spec:
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
-                                                    If a key is specified which is
-                                                    not present in the ConfigMap,
-                                                    the volume setup will error unless
-                                                    it is marked optional. Paths must
-                                                    be relative and may not contain
-                                                    the '..' path or start with '..'.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7248,12 +6535,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7328,12 +6610,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7397,12 +6674,6 @@ spec:
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
-                                                    If a key is specified which is
-                                                    not present in the Secret, the
-                                                    volume setup will error unless
-                                                    it is marked optional. Paths must
-                                                    be relative and may not contain
-                                                    the '..' path or start with '..'.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7422,12 +6693,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7479,13 +6745,7 @@ spec:
                                                     As the token approaches expiration,
                                                     the kubelet volume plugin will
                                                     proactively rotate the service
-                                                    account token. The kubelet will
-                                                    start trying to rotate the token
-                                                    if the token is older than 80
-                                                    percent of its time to live or
-                                                    if the token is older than 24
-                                                    hours.Defaults to 1 hour and must
-                                                    be at least 10 minutes.
+                                                    account token.
                                                   format: int64
                                                   type: integer
                                                 path:
@@ -7549,9 +6809,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       image:
                                         description: 'image is the rados image name.
@@ -7675,12 +6933,7 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          values for mode bits. Defaults to 0644.'
                                         format: int32
                                         type: integer
                                       items:
@@ -7690,12 +6943,7 @@ spec:
                                           as a file whose name is the key and content
                                           is the value. If specified, the listed keys
                                           will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the Secret, the volume setup will error
-                                          unless it is marked optional. Paths must
-                                          be relative and may not contain the '..'
-                                          path or start with '..'.
+                                          and unlisted keys will not be present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -7712,10 +6960,7 @@ spec:
                                                 and decimal values, JSON requires
                                                 decimal values for mode bits. If not
                                                 specified, the volume defaultMode
-                                                will be used. This might be in conflict
-                                                with other options that affect the
-                                                file mode, like fsGroup, and the result
-                                                can be other mode bits set.'
+                                                will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -7782,9 +7027,6 @@ spec:
                                           Kubernetes name scoping to be mirrored within
                                           StorageOS for tighter integration. Set VolumeName
                                           to any name to override the default behaviour.
-                                          Set to "default" if you are not using namespaces
-                                          within StorageOS. Namespaces that do not
-                                          pre-exist within StorageOS will be created.
                                         type: string
                                     type: object
                                   vsphereVolume:

--- a/manifests/base/crds/kubeflow.org_paddlejobs.yaml
+++ b/manifests/base/crds/kubeflow.org_paddlejobs.yaml
@@ -61,11 +61,7 @@ spec:
                       to calculate the desired replica count (the maximum replica
                       count across all metrics will be used).  The desired replica
                       count is calculated with multiplying the ratio between the target
-                      value and the current value by the current number of pods. Ergo,
-                      metrics used must decrease as the pod count is increased, and
-                      vice-versa.  See the individual metric source types for more
-                      information about how each type of metric must respond. If not
-                      set, the HPA will not be created.
+                      value and the current value by the current number of pods.
                     items:
                       description: MetricSpec specifies how to scale based on a single
                         metric (only `type` and one other matching field should be
@@ -75,11 +71,7 @@ spec:
                           description: containerResource refers to a resource metric
                             (such as those specified in requests and limits) known
                             to Kubernetes describing a single container in each pod
-                            of the current scale target (e.g. CPU or memory). Such
-                            metrics are built in to Kubernetes, and have special scaling
-                            options on top of those available to normal per-pod metrics
-                            using the "pods" source. This is an alpha feature and
-                            can be enabled by the HPAContainerMetrics feature flag.
+                            of the current scale target (e.g. CPU or memory).
                           properties:
                             container:
                               description: container is the name of the container
@@ -491,9 +483,7 @@ spec:
                           description: resource refers to a resource metric (such
                             as those specified in requests and limits) known to Kubernetes
                             describing each pod in the current scale target (e.g.
-                            CPU or memory). Such metrics are built in to Kubernetes,
-                            and have special scaling options on top of those available
-                            to normal per-pod metrics using the "pods" source.
+                            CPU or memory).
                           properties:
                             name:
                               description: name is the name of the resource in question.
@@ -620,15 +610,7 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node matches the corresponding matchExpressions;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                        with the greatest sum of weights, i.e.
                                       items:
                                         description: An empty preferred scheduling
                                           term matches all objects with implicit weight
@@ -671,8 +653,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -712,8 +692,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -741,9 +719,7 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g. due to an update), the
-                                        system may or may not try to eventually evict
-                                        the pod from its node.
+                                        pod execution (e.g.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
@@ -785,8 +761,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -826,8 +800,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -855,15 +827,7 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node has pods which matches the corresponding
-                                        podAffinityTerm; the node(s) with the highest
-                                        sum are the most preferred.
+                                        with the greatest sum of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -944,9 +908,7 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                  means "this pod's namespace".
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -1028,8 +990,7 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                  selected pods i
                                                 type: string
                                             required:
                                             - topologyKey
@@ -1051,12 +1012,7 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g. due to a pod label update),
-                                        the system may or may not try to eventually
-                                        evict the pod from its node. When there are
-                                        multiple elements, the lists of nodes corresponding
-                                        to each podAffinityTerm are intersected, i.e.
-                                        all terms must be satisfied.
+                                        pod execution (e.g.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -1065,8 +1021,7 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                          that of an
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -1134,7 +1089,6 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1210,8 +1164,7 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                              of the selected pods i
                                             type: string
                                         required:
                                         - topologyKey
@@ -1230,15 +1183,7 @@ spec:
                                         may choose a node that violates one or more
                                         of the expressions. The node that is most
                                         preferred is the one with the greatest sum
-                                        of weights, i.e. for each node that meets
-                                        all of the scheduling requirements (resource
-                                        request, requiredDuringScheduling anti-affinity
-                                        expressions, etc.), compute a sum by iterating
-                                        through the elements of this field and adding
-                                        "weight" to the sum if the node has pods which
-                                        matches the corresponding podAffinityTerm;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                        of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -1319,9 +1264,7 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                  means "this pod's namespace".
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -1403,8 +1346,7 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                  selected pods i
                                                 type: string
                                             required:
                                             - topologyKey
@@ -1426,12 +1368,7 @@ spec:
                                         time, the pod will not be scheduled onto the
                                         node. If the anti-affinity requirements specified
                                         by this field cease to be met at some point
-                                        during pod execution (e.g. due to a pod label
-                                        update), the system may or may not try to
-                                        eventually evict the pod from its node. When
-                                        there are multiple elements, the lists of
-                                        nodes corresponding to each podAffinityTerm
-                                        are intersected, i.e. all terms must be satisfied.
+                                        during pod execution (e.g.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -1440,8 +1377,7 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                          that of an
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -1509,7 +1445,6 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1585,8 +1520,7 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                              of the selected pods i
                                             type: string
                                         required:
                                         - topologyKey
@@ -1609,34 +1543,22 @@ spec:
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
+                                    description: Arguments to the entrypoint. The
+                                      container image's CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
+                                      expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The container image's ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
+                                      $(VAR_NAME) are expanded using the container's
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -1652,19 +1574,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1774,11 +1690,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1845,7 +1757,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1859,10 +1771,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1946,21 +1855,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1974,10 +1874,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2078,10 +1975,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -2207,19 +2101,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2240,10 +2122,7 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
-                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                      Cannot be updated.
+                                      from the network.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -2304,10 +2183,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -2433,19 +2309,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2493,15 +2357,11 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -2540,7 +2400,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -2555,7 +2415,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -2565,10 +2425,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -2577,8 +2434,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -2586,11 +2442,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2647,8 +2499,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -2670,13 +2521,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -2691,16 +2536,11 @@ spec:
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the
-                                      Pod has successfully initialized. If specified,
+                                    description: StartupProbe indicates that the Pod
+                                      has successfully initialized. If specified,
                                       no other probes are executed until this completes
                                       successfully. If this probe fails, the Pod will
                                       be restarted, just as if the livenessProbe failed.
-                                      This can be used to provide different probe
-                                      parameters at the beginning of a Pod''s lifecycle,
-                                      when it might take a long time to load data
-                                      or warm a cache, than during steady-state operation.
-                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
@@ -2714,10 +2554,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -2843,19 +2680,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2877,15 +2702,7 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -2894,21 +2711,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -3037,9 +2846,7 @@ spec:
                                 "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
                                 'ClusterFirst', 'Default' or 'None'. DNS parameters
                                 given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy. To have DNS options set along
-                                with hostNetwork, you have to specify DNS policy explicitly
-                                to 'ClusterFirstWithHostNet'.
+                                selected with DNSPolicy.
                               type: string
                             enableServiceLinks:
                               description: 'EnableServiceLinks indicates whether information
@@ -3053,50 +2860,31 @@ spec:
                                 pod to perform user-initiated actions such as debugging.
                                 This list cannot be specified when creating a pod,
                                 and it cannot be modified by updating the pod spec.
-                                In order to add an ephemeral container to an existing
-                                pod, use the pod's ephemeralcontainers subresource.
                               items:
-                                description: "An EphemeralContainer is a temporary
+                                description: An EphemeralContainer is a temporary
                                   container that you may add to an existing Pod for
                                   user-initiated activities such as debugging. Ephemeral
                                   containers have no resource or scheduling guarantees,
                                   and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted. The kubelet
-                                  may evict a Pod if an ephemeral container causes
-                                  the Pod to exceed its resource allocation. \n To
-                                  add an ephemeral container, use the ephemeralcontainers
-                                  subresource of an existing Pod. Ephemeral containers
-                                  may not be removed or restarted."
+                                  when a Pod is removed or restarted.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      image''s CMD is used if this is not provided.
+                                    description: Arguments to the entrypoint. The
+                                      image's CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
+                                      using the container's environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the
-                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                      produce the string literal "$(VAR_NAME)". Escaped
-                                      references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The image''s ENTRYPOINT is used if
-                                      this is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container''s environment.
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The image's ENTRYPOINT is used if this
+                                      is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
@@ -3112,19 +2900,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -3234,11 +3016,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -3300,7 +3078,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -3314,10 +3092,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3401,21 +3176,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -3429,10 +3195,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3532,10 +3295,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -3661,19 +3421,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3750,10 +3498,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -3879,19 +3624,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3939,15 +3672,11 @@ spec:
                                       override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -3986,7 +3715,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -4001,7 +3730,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -4011,10 +3740,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -4023,8 +3749,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -4032,11 +3757,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -4093,8 +3814,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -4116,13 +3836,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -4152,10 +3866,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -4281,19 +3992,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4315,26 +4014,15 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: "If set, the name of the container
+                                    description: If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
                                       then the ephemeral container uses the namespaces
-                                      configured in the Pod spec. \n The container
-                                      runtime must implement support for this feature.
-                                      If the runtime does not support namespace targeting
-                                      then the result of setting this field is undefined."
+                                      configured in the Pod spec.
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -4343,21 +4031,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -4483,13 +4163,7 @@ spec:
                                 pod will be run in the host user namespace, useful
                                 for when the pod needs a feature only available to
                                 the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE. When set to false, a new
-                                userns is created for the pod. Setting false is useful
-                                for mitigating container breakout vulnerabilities
-                                even allowing users to run their containers as root
-                                without actually having root privileges on the host.
-                                This field is alpha-level and is only honored by servers
-                                that enable the UserNamespacesSupport feature.'
+                                module with CAP_SYS_MODULE.'
                               type: boolean
                             hostname:
                               description: Specifies the hostname of the Pod If not
@@ -4502,7 +4176,7 @@ spec:
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
                                 puller implementations for them to use. More info:
-                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                https://kubernetes.'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -4518,55 +4192,32 @@ spec:
                                 x-kubernetes-map-type: atomic
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging
+                              description: List of initialization containers belonging
                                 to the pod. Init containers are executed in order
                                 prior to containers being started. If any init container
                                 fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy. The name for
-                                an init container or normal container must be unique
-                                among all containers. Init containers may not have
-                                Lifecycle actions, Readiness probes, Liveness probes,
-                                or Startup probes. The resourceRequirements of an
-                                init container are taken into account during scheduling
-                                by finding the highest request/limit for each resource
-                                type, and then using the max of of that value or the
-                                sum of the normal containers. Limits are applied to
-                                init containers in a similar fashion. Init containers
-                                cannot currently be added or removed. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                                handled according to its restartPolicy.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
+                                    description: Arguments to the entrypoint. The
+                                      container image's CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
+                                      expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The container image's ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
+                                      $(VAR_NAME) are expanded using the container's
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -4582,19 +4233,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -4704,11 +4349,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -4775,7 +4416,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4789,10 +4430,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4876,21 +4514,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4904,10 +4533,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5008,10 +4634,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -5137,19 +4760,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -5170,10 +4781,7 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
-                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                      Cannot be updated.
+                                      from the network.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -5234,10 +4842,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -5363,19 +4968,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -5423,15 +5016,11 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -5470,7 +5059,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -5485,7 +5074,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -5495,10 +5084,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -5507,8 +5093,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -5516,11 +5101,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -5577,8 +5158,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -5600,13 +5180,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -5621,16 +5195,11 @@ spec:
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the
-                                      Pod has successfully initialized. If specified,
+                                    description: StartupProbe indicates that the Pod
+                                      has successfully initialized. If specified,
                                       no other probes are executed until this completes
                                       successfully. If this probe fails, the Pod will
                                       be restarted, just as if the livenessProbe failed.
-                                      This can be used to provide different probe
-                                      parameters at the beginning of a Pod''s lifecycle,
-                                      when it might take a long time to load data
-                                      or warm a cache, than during steady-state operation.
-                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
@@ -5644,10 +5213,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -5773,19 +5339,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -5807,15 +5361,7 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -5824,21 +5370,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -5944,28 +5482,13 @@ spec:
                                 if this is set. \n If the OS field is set to linux,
                                 the following fields must be unset: -securityContext.windowsOptions
                                 \n If the OS field is set to windows, following fields
-                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
-                                - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
-                                - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
-                                - spec.securityContext.sysctls - spec.shareProcessNamespace
-                                - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
-                                - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions
-                                - spec.containers[*].securityContext.seccompProfile
-                                - spec.containers[*].securityContext.capabilities
-                                - spec.containers[*].securityContext.readOnlyRootFilesystem
-                                - spec.containers[*].securityContext.privileged -
-                                spec.containers[*].securityContext.allowPrivilegeEscalation
-                                - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                                - spec.containers[*].securityContext.runAsGroup"
+                                must be unset: - spec."
                               properties:
                                 name:
                                   description: 'Name is the name of the operating
                                     system. The currently supported values are linux
                                     and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                    Clients should expect to handle additional values
-                                    and treat unrecognized values in this field as
-                                    os: null'
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.'
                                   type: string
                               required:
                               - name
@@ -5977,18 +5500,12 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Overhead represents the resource overhead
+                              description: Overhead represents the resource overhead
                                 associated with running a pod for a given RuntimeClass.
                                 This field will be autopopulated at admission time
                                 by the RuntimeClass admission controller. If the RuntimeClass
                                 admission controller is enabled, overhead must not
-                                be set in Pod create requests. The RuntimeClass admission
-                                controller will reject Pod create requests which have
-                                the overhead already set. If RuntimeClass is configured
-                                and selected in the PodSpec, Overhead will be set
-                                to the value defined in the corresponding RuntimeClass,
-                                otherwise it will remain unset and treated as zero.
-                                More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                                be set in Pod create requests.
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
@@ -6010,8 +5527,7 @@ spec:
                                 are two special keywords which indicate the highest
                                 priorities with the former being the highest priority.
                                 Any other name must be defined by creating a PriorityClass
-                                object with that name. If not specified, the pod priority
-                                will be default or zero if there is no default.
+                                object with that name.
                               type: string
                             readinessGates:
                               description: 'If specified, all readiness gates will
@@ -6037,14 +5553,10 @@ spec:
                                 to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass
+                              description: RuntimeClassName refers to a RuntimeClass
                                 object in the node.k8s.io group, which should be used
                                 to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run. If unset
-                                or empty, the "legacy" RuntimeClass will be used,
-                                which is an implicit class with an empty definition
-                                that uses the default runtime handler. More info:
-                                https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                                the named class, the pod will not be run.
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -6064,24 +5576,15 @@ spec:
                                     of that volume to be owned by the pod: \n 1. The
                                     owning GID will be the FSGroup 2. The setgid bit
                                     is set (new files created in the volume will be
-                                    owned by FSGroup) 3. The permission bits are OR'd
-                                    with rw-rw---- \n If unset, the Kubelet will not
-                                    modify the ownership and permissions of any volume.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows."
+                                    owned by FSGroup) 3."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior
+                                  description: fsGroupChangePolicy defines behavior
                                     of changing ownership and permission of the volume
                                     before being exposed inside Pod. This field will
                                     only apply to volume types which support fsGroup
-                                    based ownership(and permissions). It will have
-                                    no effect on ephemeral volume types such as: secret,
-                                    configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified, "Always" is used.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.'
+                                    based ownership(and permissions).
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -6090,7 +5593,7 @@ spec:
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
                                     for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                    be set when spec.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -6100,9 +5603,7 @@ spec:
                                     does not run as UID 0 (root) and fail to start
                                     the container if it does. If unset or false, no
                                     such validation will be performed. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                    set in SecurityContext.
                                   type: boolean
                                 runAsUser:
                                   description: The UID to run the entrypoint of the
@@ -6111,19 +5612,13 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
                                   description: The SELinux context to be applied to
                                     all containers. If unspecified, the container
                                     runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                    for each container.  May also be set in SecurityContext.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -6205,8 +5700,7 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                    Note that this field cannot be set when spec.os.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -6225,12 +5719,7 @@ spec:
                                         honored by components that enable the WindowsHostProcessContainers
                                         feature flag. Setting this field without the
                                         feature flag will result in errors when validating
-                                        the Pod. All of a Pod's containers must have
-                                        the same effective HostProcess value (it is
-                                        not allowed to have a mix of HostProcess containers
-                                        and non-HostProcess containers).  In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                        the Pod.
                                       type: boolean
                                     runAsUserName:
                                       description: The UserName in Windows to run
@@ -6258,20 +5747,14 @@ spec:
                                 as the pod's FQDN, rather than the leaf name (the
                                 default). In Linux containers, this means setting
                                 the FQDN in the hostname field of the kernel (the
-                                nodename field of struct utsname). In Windows containers,
-                                this means setting the registry value of hostname
-                                for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
-                                to FQDN. If a pod does not have FQDN, this has no
-                                effect. Default to false.
+                                nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between
+                              description: Share a single process namespace between
                                 all of the containers in a pod. When this is set containers
                                 will be able to view and signal processes from other
                                 containers in the same pod, and the first process
-                                in each container will not be assigned PID 1. HostPID
-                                and ShareProcessNamespace cannot both be set. Optional:
-                                Default to false.'
+                                in each container will not be assigned PID 1.
                               type: boolean
                             subdomain:
                               description: If specified, the fully qualified Pod hostname
@@ -6284,14 +5767,7 @@ spec:
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
                                 zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down). If this value is nil,
-                                the default grace period will be used instead. The
-                                grace period is the duration in seconds after the
-                                processes running in the pod are sent a termination
-                                signal and the time when the processes are forcibly
-                                halted with a kill signal. Set this value longer than
-                                the expected cleanup time for your process. Defaults
-                                to 30 seconds.
+                                (no opportunity to shut down).
                               format: int64
                               type: integer
                             tolerations:
@@ -6327,8 +5803,7 @@ spec:
                                       of effect NoExecute, otherwise this field is
                                       ignored) tolerates the taint. By default, it
                                       is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
+                                      (do not evict).
                                     format: int64
                                     type: integer
                                   value:
@@ -6405,98 +5880,44 @@ spec:
                                   matchLabelKeys:
                                     description: MatchLabelKeys is a set of pod label
                                       keys to select the pods over which spreading
-                                      will be calculated. The keys are used to lookup
-                                      values from the incoming pod labels, those key-value
-                                      labels are ANDed with labelSelector to select
-                                      the group of existing pods over which spreading
-                                      will be calculated for the incoming pod. Keys
-                                      that don't exist in the incoming pod labels
-                                      will be ignored. A null or empty list means
-                                      only match against labelSelector.
+                                      will be calculated.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   maxSkew:
-                                    description: 'MaxSkew describes the degree to
-                                      which pods may be unevenly distributed. When
-                                      `whenUnsatisfiable=DoNotSchedule`, it is the
-                                      maximum permitted difference between the number
-                                      of matching pods in the target topology and
-                                      the global minimum. The global minimum is the
-                                      minimum number of matching pods in an eligible
-                                      domain or zero if the number of eligible domains
-                                      is less than MinDomains. For example, in a 3-zone
-                                      cluster, MaxSkew is set to 1, and pods with
-                                      the same labelSelector spread as 2/2/1: In this
-                                      case, the global minimum is 1. | zone1 | zone2
-                                      | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
-                                      is 1, incoming pod can only be scheduled to
-                                      zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                                      would make the ActualSkew(3-1) on zone1(zone2)
-                                      violate MaxSkew(1). - if MaxSkew is 2, incoming
-                                      pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                                      it is used to give higher precedence to topologies
-                                      that satisfy it. It''s a required field. Default
-                                      value is 1 and 0 is not allowed.'
+                                    description: MaxSkew describes the degree to which
+                                      pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                      it is the maximum permitted difference between
+                                      the number of matching pods in the target topology
+                                      and the global minimum.
                                     format: int32
                                     type: integer
                                   minDomains:
-                                    description: "MinDomains indicates a minimum number
+                                    description: MinDomains indicates a minimum number
                                       of eligible domains. When the number of eligible
                                       domains with matching topology keys is less
                                       than minDomains, Pod Topology Spread treats
-                                      \"global minimum\" as 0, and then the calculation
-                                      of Skew is performed. And when the number of
-                                      eligible domains with matching topology keys
-                                      equals or greater than minDomains, this value
-                                      has no effect on scheduling. As a result, when
-                                      the number of eligible domains is less than
-                                      minDomains, scheduler won't schedule more than
-                                      maxSkew Pods to those domains. If value is nil,
-                                      the constraint behaves as if MinDomains is equal
-                                      to 1. Valid values are integers greater than
-                                      0. When value is not nil, WhenUnsatisfiable
-                                      must be DoNotSchedule. \n For example, in a
-                                      3-zone cluster, MaxSkew is set to 2, MinDomains
-                                      is set to 5 and pods with the same labelSelector
-                                      spread as 2/2/2: | zone1 | zone2 | zone3 | |
-                                      \ P P  |  P P  |  P P  | The number of domains
-                                      is less than 5(MinDomains), so \"global minimum\"
-                                      is treated as 0. In this situation, new pod
-                                      with the same labelSelector cannot be scheduled,
-                                      because computed skew will be 3(3 - 0) if new
-                                      Pod is scheduled to any of the three zones,
-                                      it will violate MaxSkew. \n This is a beta field
-                                      and requires the MinDomainsInPodTopologySpread
-                                      feature gate to be enabled (enabled by default)."
+                                      "global minimum" as 0, and then the calculation
+                                      of Skew is performed.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: "NodeAffinityPolicy indicates how
-                                      we will treat Pod's nodeAffinity/nodeSelector
+                                    description: 'NodeAffinityPolicy indicates how
+                                      we will treat Pod''s nodeAffinity/nodeSelector
                                       when calculating pod topology spread skew. Options
                                       are: - Honor: only nodes matching nodeAffinity/nodeSelector
                                       are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored. All nodes
-                                      are included in the calculations. \n If this
-                                      value is nil, the behavior is equivalent to
-                                      the Honor policy. This is a alpha-level feature
-                                      enabled by the NodeInclusionPolicyInPodTopologySpread
-                                      feature flag."
+                                      nodeAffinity/nodeSelector are ignored.'
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: "NodeTaintsPolicy indicates how we
+                                    description: 'NodeTaintsPolicy indicates how we
                                       will treat node taints when calculating pod
                                       topology spread skew. Options are: - Honor:
                                       nodes without taints, along with tainted nodes
                                       for which the incoming pod has a toleration,
                                       are included. - Ignore: node taints are ignored.
-                                      All nodes are included. \n If this value is
-                                      nil, the behavior is equivalent to the Ignore
-                                      policy. This is a alpha-level feature enabled
-                                      by the NodeInclusionPolicyInPodTopologySpread
-                                      feature flag."
+                                      All nodes are included.'
                                     type: string
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
@@ -6504,37 +5925,13 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket. We define a domain as a particular
-                                      instance of a topology. Also, we define an eligible
-                                      domain as a domain whose nodes meet the requirements
-                                      of nodeAffinityPolicy and nodeTaintsPolicy.
-                                      e.g. If TopologyKey is "kubernetes.io/hostname",
-                                      each Node is a domain of that topology. And,
-                                      if TopologyKey is "topology.kubernetes.io/zone",
-                                      each zone is a domain of that topology. It's
-                                      a required field.
+                                      each bucket.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: 'WhenUnsatisfiable indicates how
-                                      to deal with a pod if it doesn''t satisfy the
-                                      spread constraint. - DoNotSchedule (default)
-                                      tells the scheduler not to schedule it. - ScheduleAnyway
-                                      tells the scheduler to schedule the pod in any
-                                      location, but giving higher precedence to topologies
-                                      that would help reduce the skew. A constraint
-                                      is considered "Unsatisfiable" for an incoming
-                                      pod if and only if every possible node assignment
-                                      for that pod would violate "MaxSkew" on some
-                                      topology. For example, in a 3-zone cluster,
-                                      MaxSkew is set to 1, and pods with the same
-                                      labelSelector spread as 3/1/1: | zone1 | zone2
-                                      | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
-                                      is set to DoNotSchedule, incoming pod can only
-                                      be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
-                                      as ActualSkew(2-1) on zone2(zone3) satisfies
-                                      MaxSkew(1). In other words, the cluster can
-                                      still be imbalanced, but scheduler won''t make
-                                      it *more* imbalanced. It''s a required field.'
+                                    description: WhenUnsatisfiable indicates how to
+                                      deal with a pod if it doesn't satisfy the spread
+                                      constraint. - DoNotSchedule (default) tells
+                                      the scheduler not to schedule it.
                                     type: string
                                 required:
                                 - maxSkew
@@ -6567,9 +5964,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6754,12 +6149,7 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          values for mode bits. Defaults to 0644.'
                                         format: int32
                                         type: integer
                                       items:
@@ -6769,12 +6159,7 @@ spec:
                                           as a file whose name is the key and content
                                           is the value. If specified, the listed keys
                                           will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the ConfigMap, the volume setup will
-                                          error unless it is marked optional. Paths
-                                          must be relative and may not contain the
-                                          '..' path or start with '..'.
+                                          and unlisted keys will not be present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -6791,10 +6176,7 @@ spec:
                                                 and decimal values, JSON requires
                                                 decimal values for mode bits. If not
                                                 specified, the volume defaultMode
-                                                will be used. This might be in conflict
-                                                with other options that affect the
-                                                file mode, like fsGroup, and the result
-                                                can be other mode bits set.'
+                                                will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -6845,9 +6227,7 @@ spec:
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
                                           calls. This field is optional, and  may
-                                          be empty if no secret is required. If the
-                                          secret object contains more than one secret,
-                                          all secret references are passed.
+                                          be empty if no secret is required.
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -6883,14 +6263,7 @@ spec:
                                           mode bits used to set permissions on created
                                           files by default. Must be an octal value
                                           between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          between 0 and 511.'
                                         format: int32
                                         type: integer
                                       items:
@@ -6927,11 +6300,7 @@ spec:
                                                 and 511. YAML accepts both octal and
                                                 decimal values, JSON requires decimal
                                                 values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                                the volume defaultMode will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -6992,70 +6361,30 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'sizeLimit is the total amount
+                                        description: sizeLimit is the total amount
                                           of local storage required for this EmptyDir
                                           volume. The size limit is also applicable
                                           for memory medium. The maximum usage on
                                           memory medium EmptyDir would be the minimum
                                           value between the SizeLimit specified here
                                           and the sum of memory limits of all containers
-                                          in a pod. The default is nil which means
-                                          that the limit is undefined. More info:
-                                          http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                          in a pod.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: "ephemeral represents a volume that
+                                    description: ephemeral represents a volume that
                                       is handled by a cluster storage driver. The
                                       volume's lifecycle is tied to the pod that defines
                                       it - it will be created before the pod starts,
-                                      and deleted when the pod is removed. \n Use
-                                      this if: a) the volume is only needed while
-                                      the pod runs, b) features of normal volumes
-                                      like restoring from snapshot or capacity tracking
-                                      are needed, c) the storage driver is specified
-                                      through a storage class, and d) the storage
-                                      driver supports dynamic volume provisioning
-                                      through a PersistentVolumeClaim (see EphemeralVolumeSource
-                                      for more information on the connection between
-                                      this volume type and PersistentVolumeClaim).
-                                      \n Use PersistentVolumeClaim or one of the vendor-specific
-                                      APIs for volumes that persist for longer than
-                                      the lifecycle of an individual pod. \n Use CSI
-                                      for light-weight local ephemeral volumes if
-                                      the CSI driver is meant to be used that way
-                                      - see the documentation of the driver for more
-                                      information. \n A pod can use both types of
-                                      ephemeral volumes and persistent volumes at
-                                      the same time."
+                                      and deleted when the pod is removed.
                                     properties:
                                       volumeClaimTemplate:
-                                        description: "Will be used to create a stand-alone
+                                        description: Will be used to create a stand-alone
                                           PVC to provision the volume. The pod in
                                           which this EphemeralVolumeSource is embedded
                                           will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.  The
-                                          name of the PVC will be `<pod name>-<volume
-                                          name>` where `<volume name>` is the name
-                                          from the `PodSpec.Volumes` array entry.
-                                          Pod validation will reject the pod if the
-                                          concatenated name is not valid for a PVC
-                                          (for example, too long). \n An existing
-                                          PVC with that name that is not owned by
-                                          the pod will *not* be used for the pod to
-                                          avoid using an unrelated volume by mistake.
-                                          Starting the pod is then blocked until the
-                                          unrelated PVC is removed. If such a pre-created
-                                          PVC is meant to be used by the pod, the
-                                          PVC has to updated with an owner reference
-                                          to the pod once the pod exists. Normally
-                                          this should not be necessary, but it may
-                                          be useful when manually reconstructing a
-                                          broken cluster. \n This field is read-only
-                                          and no changes will be made by Kubernetes
-                                          to the PVC after it has been created. \n
-                                          Required, must not be nil."
+                                          will be deleted together with the pod.
                                         properties:
                                           metadata:
                                             description: May contain labels and annotations
@@ -7098,17 +6427,7 @@ spec:
                                               dataSource:
                                                 description: 'dataSource field can
                                                   be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                  * An existing PVC (PersistentVolumeClaim)
-                                                  If the provisioner or an external
-                                                  controller can support the specified
-                                                  data source, it will create a new
-                                                  volume based on the contents of
-                                                  the specified data source. If the
-                                                  AnyVolumeDataSource feature gate
-                                                  is enabled, this field will always
-                                                  have the same contents as the DataSourceRef
-                                                  field.'
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -7133,38 +6452,13 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               dataSourceRef:
-                                                description: 'dataSourceRef specifies
+                                                description: dataSourceRef specifies
                                                   the object from which to populate
                                                   the volume with data, if a non-empty
                                                   volume is desired. This may be any
                                                   local object from a non-empty API
                                                   group (non core object) or a PersistentVolumeClaim
-                                                  object. When this field is specified,
-                                                  volume binding will only succeed
-                                                  if the type of the specified object
-                                                  matches some installed volume populator
-                                                  or dynamic provisioner. This field
-                                                  will replace the functionality of
-                                                  the DataSource field and as such
-                                                  if both fields are non-empty, they
-                                                  must have the same value. For backwards
-                                                  compatibility, both fields (DataSource
-                                                  and DataSourceRef) will be set to
-                                                  the same value automatically if
-                                                  one of them is empty and the other
-                                                  is non-empty. There are two important
-                                                  differences between DataSource and
-                                                  DataSourceRef: * While DataSource
-                                                  only allows two specific types of
-                                                  objects, DataSourceRef allows any
-                                                  non-core object, as well as PersistentVolumeClaim
-                                                  objects. * While DataSource ignores
-                                                  disallowed values (dropping them),
-                                                  DataSourceRef preserves all values,
-                                                  and generates an error if a disallowed
-                                                  value is specified. (Beta) Using
-                                                  this field requires the AnyVolumeDataSource
-                                                  feature gate to be enabled.'
+                                                  object.
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -7189,7 +6483,7 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resources:
-                                                description: 'resources represents
+                                                description: resources represents
                                                   the minimum resources the volume
                                                   should have. If RecoverVolumeExpansionFailure
                                                   feature is enabled users are allowed
@@ -7197,7 +6491,7 @@ spec:
                                                   that are lower than previous value
                                                   but must still be higher than capacity
                                                   recorded in the status field of
-                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  the claim.
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -7426,9 +6720,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -7437,7 +6729,7 @@ spec:
                                           Examples: For volume /dev/sda1, you specify
                                           the partition as "1". Similarly, the volume
                                           partition for /dev/sda is "0" (or you can
-                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          leave the property empty).'
                                         format: int32
                                         type: integer
                                       pdName:
@@ -7509,10 +6801,7 @@ spec:
                                       directly exposed to the container. This is generally
                                       used for system agents or other privileged things
                                       that are allowed to see the host machine. Most
-                                      containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                      --- TODO(jonesdl) We need to restrict who can
-                                      use host directory mounts and who can/can not
-                                      mount host directories as read/write.'
+                                      containers will NOT need this. More info: https://kubernetes.'
                                     properties:
                                       path:
                                         description: 'path of the directory on the
@@ -7547,9 +6836,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       initiatorName:
                                         description: initiatorName is the custom iSCSI
@@ -7706,11 +6993,7 @@ spec:
                                           0000 and 0777 or a decimal value between
                                           0 and 511. YAML accepts both octal and decimal
                                           values, JSON requires decimal values for
-                                          mode bits. Directories within the path are
-                                          not affected by this setting. This might
-                                          be in conflict with other options that affect
-                                          the file mode, like fsGroup, and the result
-                                          can be other mode bits set.
+                                          mode bits.
                                         format: int32
                                         type: integer
                                       sources:
@@ -7734,12 +7017,6 @@ spec:
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
-                                                    If a key is specified which is
-                                                    not present in the ConfigMap,
-                                                    the volume setup will error unless
-                                                    it is marked optional. Paths must
-                                                    be relative and may not contain
-                                                    the '..' path or start with '..'.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7759,12 +7036,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7839,12 +7111,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7908,12 +7175,6 @@ spec:
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
-                                                    If a key is specified which is
-                                                    not present in the Secret, the
-                                                    volume setup will error unless
-                                                    it is marked optional. Paths must
-                                                    be relative and may not contain
-                                                    the '..' path or start with '..'.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7933,12 +7194,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7990,13 +7246,7 @@ spec:
                                                     As the token approaches expiration,
                                                     the kubelet volume plugin will
                                                     proactively rotate the service
-                                                    account token. The kubelet will
-                                                    start trying to rotate the token
-                                                    if the token is older than 80
-                                                    percent of its time to live or
-                                                    if the token is older than 24
-                                                    hours.Defaults to 1 hour and must
-                                                    be at least 10 minutes.
+                                                    account token.
                                                   format: int64
                                                   type: integer
                                                 path:
@@ -8060,9 +7310,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       image:
                                         description: 'image is the rados image name.
@@ -8186,12 +7434,7 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          values for mode bits. Defaults to 0644.'
                                         format: int32
                                         type: integer
                                       items:
@@ -8201,12 +7444,7 @@ spec:
                                           as a file whose name is the key and content
                                           is the value. If specified, the listed keys
                                           will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the Secret, the volume setup will error
-                                          unless it is marked optional. Paths must
-                                          be relative and may not contain the '..'
-                                          path or start with '..'.
+                                          and unlisted keys will not be present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -8223,10 +7461,7 @@ spec:
                                                 and decimal values, JSON requires
                                                 decimal values for mode bits. If not
                                                 specified, the volume defaultMode
-                                                will be used. This might be in conflict
-                                                with other options that affect the
-                                                file mode, like fsGroup, and the result
-                                                can be other mode bits set.'
+                                                will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -8293,9 +7528,6 @@ spec:
                                           Kubernetes name scoping to be mirrored within
                                           StorageOS for tighter integration. Set VolumeName
                                           to any name to override the default behaviour.
-                                          Set to "default" if you are not using namespaces
-                                          within StorageOS. Namespaces that do not
-                                          pre-exist within StorageOS will be created.
                                         type: string
                                     type: object
                                   vsphereVolume:

--- a/manifests/base/crds/kubeflow.org_paddlejobs.yaml
+++ b/manifests/base/crds/kubeflow.org_paddlejobs.yaml
@@ -61,7 +61,9 @@ spec:
                       to calculate the desired replica count (the maximum replica
                       count across all metrics will be used).  The desired replica
                       count is calculated with multiplying the ratio between the target
-                      value and the current value by the current number of pods.
+                      value and the current value by the current number of pods. Ergo,
+                      metrics used must decrease as the pod count is increased, and
+                      vice-versa.
                     items:
                       description: MetricSpec specifies how to scale based on a single
                         metric (only `type` and one other matching field should be
@@ -71,7 +73,10 @@ spec:
                           description: containerResource refers to a resource metric
                             (such as those specified in requests and limits) known
                             to Kubernetes describing a single container in each pod
-                            of the current scale target (e.g. CPU or memory).
+                            of the current scale target (e.g. CPU or memory). Such
+                            metrics are built in to Kubernetes, and have special scaling
+                            options on top of those available to normal per-pod metrics
+                            using the "pods" source.
                           properties:
                             container:
                               description: container is the name of the container
@@ -483,7 +488,9 @@ spec:
                           description: resource refers to a resource metric (such
                             as those specified in requests and limits) known to Kubernetes
                             describing each pod in the current scale target (e.g.
-                            CPU or memory).
+                            CPU or memory). Such metrics are built in to Kubernetes,
+                            and have special scaling options on top of those available
+                            to normal per-pod metrics using the "pods" source.
                           properties:
                             name:
                               description: name is the name of the resource in question.
@@ -610,7 +617,10 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e.
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.
                                       items:
                                         description: An empty preferred scheduling
                                           term matches all objects with implicit weight
@@ -653,6 +663,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -692,6 +704,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -719,7 +733,9 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g.
+                                        pod execution (e.g. due to an update), the
+                                        system may or may not try to eventually evict
+                                        the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
@@ -761,6 +777,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -800,6 +818,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -827,7 +847,10 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e.
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -908,7 +931,9 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace".
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -990,7 +1015,8 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods i
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
@@ -1012,7 +1038,9 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g.
+                                        pod execution (e.g. due to a pod label update),
+                                        the system may or may not try to eventually
+                                        evict the pod from its node.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -1021,7 +1049,8 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of an
+                                          that of any node on which a pod of the set
+                                          of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -1089,6 +1118,7 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1164,7 +1194,8 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods i
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1264,7 +1295,9 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace".
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -1346,7 +1379,8 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods i
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
@@ -1368,7 +1402,9 @@ spec:
                                         time, the pod will not be scheduled onto the
                                         node. If the anti-affinity requirements specified
                                         by this field cease to be met at some point
-                                        during pod execution (e.g.
+                                        during pod execution (e.g. due to a pod label
+                                        update), the system may or may not try to
+                                        eventually evict the pod from its node.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -1377,7 +1413,8 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of an
+                                          that of any node on which a pod of the set
+                                          of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -1445,6 +1482,7 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1520,7 +1558,8 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods i
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1543,22 +1582,26 @@ spec:
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      container image's CMD is used if this is not
+                                    description: 'Arguments to the entrypoint. The
+                                      container image''s CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container's environment.
+                                      expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The container image's ENTRYPOINT is
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The container image''s ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container's
+                                      $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -1574,13 +1617,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1690,7 +1736,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1757,7 +1807,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1771,7 +1821,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1861,6 +1914,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1874,7 +1929,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1975,7 +2033,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -2101,7 +2162,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2122,7 +2185,9 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network.
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -2183,7 +2248,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -2309,7 +2377,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2357,11 +2427,15 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -2400,7 +2474,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -2415,7 +2489,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -2434,7 +2508,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -2442,7 +2517,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2499,7 +2578,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -2554,7 +2634,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -2680,7 +2763,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2711,13 +2796,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -2846,7 +2937,9 @@ spec:
                                 "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
                                 'ClusterFirst', 'Default' or 'None'. DNS parameters
                                 given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy.
+                                selected with DNSPolicy. To have DNS options set along
+                                with hostNetwork, you have to specify DNS policy explicitly
+                                to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
                               description: 'EnableServiceLinks indicates whether information
@@ -2860,31 +2953,40 @@ spec:
                                 pod to perform user-initiated actions such as debugging.
                                 This list cannot be specified when creating a pod,
                                 and it cannot be modified by updating the pod spec.
+                                In order to add an ephemeral container to an existing
+                                pod, use the pod's ephemeralcontainers subresource.
                               items:
                                 description: An EphemeralContainer is a temporary
                                   container that you may add to an existing Pod for
                                   user-initiated activities such as debugging. Ephemeral
                                   containers have no resource or scheduling guarantees,
                                   and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted.
+                                  when a Pod is removed or restarted. The kubelet
+                                  may evict a Pod if an ephemeral container causes
+                                  the Pod to exceed its resource allocation.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      image's CMD is used if this is not provided.
+                                    description: 'Arguments to the entrypoint. The
+                                      image''s CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
-                                      using the container's environment. If a variable
+                                      using the container''s environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged.
+                                      string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the
+                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)".'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The image's ENTRYPOINT is used if this
-                                      is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container's environment.
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The image''s ENTRYPOINT is used if
+                                      this is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -2900,13 +3002,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -3016,7 +3121,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -3078,7 +3187,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -3092,7 +3201,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3182,6 +3294,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -3195,7 +3309,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3295,7 +3412,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -3421,7 +3541,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3498,7 +3620,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -3624,7 +3749,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3672,11 +3799,15 @@ spec:
                                       override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -3715,7 +3846,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -3730,7 +3861,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -3749,7 +3880,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -3757,7 +3889,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3814,7 +3950,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -3866,7 +4003,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -3992,7 +4132,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4017,12 +4159,13 @@ spec:
                                       sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container
+                                    description: "If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
                                       then the ephemeral container uses the namespaces
-                                      configured in the Pod spec.
+                                      configured in the Pod spec. \n The container
+                                      runtime must implement support for this feature."
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -4031,13 +4174,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -4163,7 +4312,8 @@ spec:
                                 pod will be run in the host user namespace, useful
                                 for when the pod needs a feature only available to
                                 the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE.'
+                                module with CAP_SYS_MODULE. When set to false, a new
+                                userns is created for the pod.'
                               type: boolean
                             hostname:
                               description: Specifies the hostname of the Pod If not
@@ -4176,7 +4326,7 @@ spec:
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
                                 puller implementations for them to use. More info:
-                                https://kubernetes.'
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -4196,28 +4346,34 @@ spec:
                                 to the pod. Init containers are executed in order
                                 prior to containers being started. If any init container
                                 fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy.
+                                handled according to its restartPolicy. The name for
+                                an init container or normal container must be unique
+                                among all containers.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      container image's CMD is used if this is not
+                                    description: 'Arguments to the entrypoint. The
+                                      container image''s CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container's environment.
+                                      expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The container image's ENTRYPOINT is
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The container image''s ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container's
+                                      $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -4233,13 +4389,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -4349,7 +4508,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -4416,7 +4579,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4430,7 +4593,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4520,6 +4686,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4533,7 +4701,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4634,7 +4805,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4760,7 +4934,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4781,7 +4957,9 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network.
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -4842,7 +5020,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4968,7 +5149,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -5016,11 +5199,15 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -5059,7 +5246,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -5074,7 +5261,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -5093,7 +5280,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -5101,7 +5289,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -5158,7 +5350,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -5213,7 +5406,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -5339,7 +5535,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -5370,13 +5568,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -5482,13 +5686,17 @@ spec:
                                 if this is set. \n If the OS field is set to linux,
                                 the following fields must be unset: -securityContext.windowsOptions
                                 \n If the OS field is set to windows, following fields
-                                must be unset: - spec."
+                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
+                                - spec.securityContext.seLinuxOptions - spec.securityContext."
                               properties:
                                 name:
                                   description: 'Name is the name of the operating
                                     system. The currently supported values are linux
                                     and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.'
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values
+                                    and treat unrecognized values in this field as
+                                    os: null'
                                   type: string
                               required:
                               - name
@@ -5505,7 +5713,9 @@ spec:
                                 This field will be autopopulated at admission time
                                 by the RuntimeClass admission controller. If the RuntimeClass
                                 admission controller is enabled, overhead must not
-                                be set in Pod create requests.
+                                be set in Pod create requests. The RuntimeClass admission
+                                controller will reject Pod create requests which have
+                                the overhead already set.
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
@@ -5527,7 +5737,8 @@ spec:
                                 are two special keywords which indicate the highest
                                 priorities with the former being the highest priority.
                                 Any other name must be defined by creating a PriorityClass
-                                object with that name.
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
                               type: string
                             readinessGates:
                               description: 'If specified, all readiness gates will
@@ -5553,10 +5764,14 @@ spec:
                                 to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: RuntimeClassName refers to a RuntimeClass
+                              description: 'RuntimeClassName refers to a RuntimeClass
                                 object in the node.k8s.io group, which should be used
                                 to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run.
+                                the named class, the pod will not be run. If unset
+                                or empty, the "legacy" RuntimeClass will be used,
+                                which is an implicit class with an empty definition
+                                that uses the default runtime handler. More info:
+                                https://git.k8s.'
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -5580,11 +5795,14 @@ spec:
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: fsGroupChangePolicy defines behavior
+                                  description: 'fsGroupChangePolicy defines behavior
                                     of changing ownership and permission of the volume
                                     before being exposed inside Pod. This field will
                                     only apply to volume types which support fsGroup
-                                    based ownership(and permissions).
+                                    based ownership(and permissions). It will have
+                                    no effect on ephemeral volume types such as: secret,
+                                    configmaps and emptydir. Valid values are "OnRootMismatch"
+                                    and "Always". If not specified, "Always" is used.'
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -5593,7 +5811,7 @@ spec:
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
                                     for that container. Note that this field cannot
-                                    be set when spec.
+                                    be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -5612,13 +5830,19 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
                                   description: The SELinux context to be applied to
                                     all containers. If unspecified, the container
                                     runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.
+                                    for each container.  May also be set in SecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5700,7 +5924,8 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -5750,11 +5975,13 @@ spec:
                                 nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: Share a single process namespace between
+                              description: 'Share a single process namespace between
                                 all of the containers in a pod. When this is set containers
                                 will be able to view and signal processes from other
                                 containers in the same pod, and the first process
-                                in each container will not be assigned PID 1.
+                                in each container will not be assigned PID 1. HostPID
+                                and ShareProcessNamespace cannot both be set. Optional:
+                                Default to false.'
                               type: boolean
                             subdomain:
                               description: If specified, the fully qualified Pod hostname
@@ -5767,7 +5994,8 @@ spec:
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
                                 zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down).
+                                (no opportunity to shut down). If this value is nil,
+                                the default grace period will be used instead.
                               format: int64
                               type: integer
                             tolerations:
@@ -5803,7 +6031,8 @@ spec:
                                       of effect NoExecute, otherwise this field is
                                       ignored) tolerates the taint. By default, it
                                       is not set, which means tolerate the taint forever
-                                      (do not evict).
+                                      (do not evict). Zero and negative values will
+                                      be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
@@ -5880,7 +6109,13 @@ spec:
                                   matchLabelKeys:
                                     description: MatchLabelKeys is a set of pod label
                                       keys to select the pods over which spreading
-                                      will be calculated.
+                                      will be calculated. The keys are used to lookup
+                                      values from the incoming pod labels, those key-value
+                                      labels are ANDed with labelSelector to select
+                                      the group of existing pods over which spreading
+                                      will be calculated for the incoming pod. Keys
+                                      that don't exist in the incoming pod labels
+                                      will be ignored.
                                     items:
                                       type: string
                                     type: array
@@ -5890,7 +6125,10 @@ spec:
                                       pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                                       it is the maximum permitted difference between
                                       the number of matching pods in the target topology
-                                      and the global minimum.
+                                      and the global minimum. The global minimum is
+                                      the minimum number of matching pods in an eligible
+                                      domain or zero if the number of eligible domains
+                                      is less than MinDomains.
                                     format: int32
                                     type: integer
                                   minDomains:
@@ -5899,25 +6137,33 @@ spec:
                                       domains with matching topology keys is less
                                       than minDomains, Pod Topology Spread treats
                                       "global minimum" as 0, and then the calculation
-                                      of Skew is performed.
+                                      of Skew is performed. And when the number of
+                                      eligible domains with matching topology keys
+                                      equals or greater than minDomains, this value
+                                      has no effect on scheduling.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: 'NodeAffinityPolicy indicates how
-                                      we will treat Pod''s nodeAffinity/nodeSelector
+                                    description: "NodeAffinityPolicy indicates how
+                                      we will treat Pod's nodeAffinity/nodeSelector
                                       when calculating pod topology spread skew. Options
                                       are: - Honor: only nodes matching nodeAffinity/nodeSelector
                                       are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored.'
+                                      nodeAffinity/nodeSelector are ignored. All nodes
+                                      are included in the calculations. \n If this
+                                      value is nil, the behavior is equivalent to
+                                      the Honor policy."
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: 'NodeTaintsPolicy indicates how we
+                                    description: "NodeTaintsPolicy indicates how we
                                       will treat node taints when calculating pod
                                       topology spread skew. Options are: - Honor:
                                       nodes without taints, along with tainted nodes
                                       for which the incoming pod has a toleration,
                                       are included. - Ignore: node taints are ignored.
-                                      All nodes are included.'
+                                      All nodes are included. \n If this value is
+                                      nil, the behavior is equivalent to the Ignore
+                                      policy."
                                     type: string
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
@@ -5925,13 +6171,17 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket.
+                                      each bucket. We define a domain as a particular
+                                      instance of a topology.
                                     type: string
                                   whenUnsatisfiable:
                                     description: WhenUnsatisfiable indicates how to
                                       deal with a pod if it doesn't satisfy the spread
                                       constraint. - DoNotSchedule (default) tells
-                                      the scheduler not to schedule it.
+                                      the scheduler not to schedule it. - ScheduleAnyway
+                                      tells the scheduler to schedule the pod in any
+                                      location, but giving higher precedence to topologies
+                                      that would help reduce the skew.
                                     type: string
                                 required:
                                 - maxSkew
@@ -5964,7 +6214,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6149,7 +6401,9 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.'
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -6227,7 +6481,9 @@ spec:
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
                                           calls. This field is optional, and  may
-                                          be empty if no secret is required.
+                                          be empty if no secret is required. If the
+                                          secret object contains more than one secret,
+                                          all secret references are passed.
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -6263,7 +6519,11 @@ spec:
                                           mode bits used to set permissions on created
                                           files by default. Must be an octal value
                                           between 0000 and 0777 or a decimal value
-                                          between 0 and 511.'
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -6361,14 +6621,16 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: sizeLimit is the total amount
+                                        description: 'sizeLimit is the total amount
                                           of local storage required for this EmptyDir
                                           volume. The size limit is also applicable
                                           for memory medium. The maximum usage on
                                           memory medium EmptyDir would be the minimum
                                           value between the SizeLimit specified here
                                           and the sum of memory limits of all containers
-                                          in a pod.
+                                          in a pod. The default is nil which means
+                                          that the limit is undefined. More info:
+                                          http://kubernetes.'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
@@ -6384,7 +6646,10 @@ spec:
                                           PVC to provision the volume. The pod in
                                           which this EphemeralVolumeSource is embedded
                                           will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.
+                                          will be deleted together with the pod.  The
+                                          name of the PVC will be `<pod name>-<volume
+                                          name>` where `<volume name>` is the name
+                                          from the `PodSpec.Volumes` array entry.
                                         properties:
                                           metadata:
                                             description: May contain labels and annotations
@@ -6427,7 +6692,13 @@ spec:
                                               dataSource:
                                                 description: 'dataSource field can
                                                   be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.'
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                  * An existing PVC (PersistentVolumeClaim)
+                                                  If the provisioner or an external
+                                                  controller can support the specified
+                                                  data source, it will create a new
+                                                  volume based on the contents of
+                                                  the specified data source.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6458,7 +6729,11 @@ spec:
                                                   volume is desired. This may be any
                                                   local object from a non-empty API
                                                   group (non core object) or a PersistentVolumeClaim
-                                                  object.
+                                                  object. When this field is specified,
+                                                  volume binding will only succeed
+                                                  if the type of the specified object
+                                                  matches some installed volume populator
+                                                  or dynamic provisioner.
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6483,7 +6758,7 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resources:
-                                                description: resources represents
+                                                description: 'resources represents
                                                   the minimum resources the volume
                                                   should have. If RecoverVolumeExpansionFailure
                                                   feature is enabled users are allowed
@@ -6491,7 +6766,7 @@ spec:
                                                   that are lower than previous value
                                                   but must still be higher than capacity
                                                   recorded in the status field of
-                                                  the claim.
+                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -6720,7 +6995,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6729,7 +7006,7 @@ spec:
                                           Examples: For volume /dev/sda1, you specify
                                           the partition as "1". Similarly, the volume
                                           partition for /dev/sda is "0" (or you can
-                                          leave the property empty).'
+                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
@@ -6836,7 +7113,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       initiatorName:
                                         description: initiatorName is the custom iSCSI
@@ -6993,7 +7272,8 @@ spec:
                                           0000 and 0777 or a decimal value between
                                           0 and 511. YAML accepts both octal and decimal
                                           values, JSON requires decimal values for
-                                          mode bits.
+                                          mode bits. Directories within the path are
+                                          not affected by this setting.
                                         format: int32
                                         type: integer
                                       sources:
@@ -7246,7 +7526,13 @@ spec:
                                                     As the token approaches expiration,
                                                     the kubelet volume plugin will
                                                     proactively rotate the service
-                                                    account token.
+                                                    account token. The kubelet will
+                                                    start trying to rotate the token
+                                                    if the token is older than 80
+                                                    percent of its time to live or
+                                                    if the token is older than 24
+                                                    hours.Defaults to 1 hour and must
+                                                    be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
@@ -7310,7 +7596,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       image:
                                         description: 'image is the rados image name.
@@ -7434,7 +7722,9 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.'
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -7528,6 +7818,8 @@ spec:
                                           Kubernetes name scoping to be mirrored within
                                           StorageOS for tighter integration. Set VolumeName
                                           to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces
+                                          within StorageOS.
                                         type: string
                                     type: object
                                   vsphereVolume:

--- a/manifests/base/crds/kubeflow.org_pytorchjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_pytorchjobs.yaml
@@ -58,11 +58,7 @@ spec:
                       to calculate the desired replica count (the maximum replica
                       count across all metrics will be used).  The desired replica
                       count is calculated with multiplying the ratio between the target
-                      value and the current value by the current number of pods. Ergo,
-                      metrics used must decrease as the pod count is increased, and
-                      vice-versa.  See the individual metric source types for more
-                      information about how each type of metric must respond. If not
-                      set, the HPA will not be created.
+                      value and the current value by the current number of pods.
                     items:
                       description: MetricSpec specifies how to scale based on a single
                         metric (only `type` and one other matching field should be
@@ -72,11 +68,7 @@ spec:
                           description: containerResource refers to a resource metric
                             (such as those specified in requests and limits) known
                             to Kubernetes describing a single container in each pod
-                            of the current scale target (e.g. CPU or memory). Such
-                            metrics are built in to Kubernetes, and have special scaling
-                            options on top of those available to normal per-pod metrics
-                            using the "pods" source. This is an alpha feature and
-                            can be enabled by the HPAContainerMetrics feature flag.
+                            of the current scale target (e.g. CPU or memory).
                           properties:
                             container:
                               description: container is the name of the container
@@ -488,9 +480,7 @@ spec:
                           description: resource refers to a resource metric (such
                             as those specified in requests and limits) known to Kubernetes
                             describing each pod in the current scale target (e.g.
-                            CPU or memory). Such metrics are built in to Kubernetes,
-                            and have special scaling options on top of those available
-                            to normal per-pod metrics using the "pods" source.
+                            CPU or memory).
                           properties:
                             name:
                               description: name is the name of the resource in question.
@@ -649,15 +639,7 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node matches the corresponding matchExpressions;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                        with the greatest sum of weights, i.e.
                                       items:
                                         description: An empty preferred scheduling
                                           term matches all objects with implicit weight
@@ -700,8 +682,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -741,8 +721,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -770,9 +748,7 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g. due to an update), the
-                                        system may or may not try to eventually evict
-                                        the pod from its node.
+                                        pod execution (e.g.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
@@ -814,8 +790,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -855,8 +829,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -884,15 +856,7 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node has pods which matches the corresponding
-                                        podAffinityTerm; the node(s) with the highest
-                                        sum are the most preferred.
+                                        with the greatest sum of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -973,9 +937,7 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                  means "this pod's namespace".
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -1057,8 +1019,7 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                  selected pods i
                                                 type: string
                                             required:
                                             - topologyKey
@@ -1080,12 +1041,7 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g. due to a pod label update),
-                                        the system may or may not try to eventually
-                                        evict the pod from its node. When there are
-                                        multiple elements, the lists of nodes corresponding
-                                        to each podAffinityTerm are intersected, i.e.
-                                        all terms must be satisfied.
+                                        pod execution (e.g.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -1094,8 +1050,7 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                          that of an
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -1163,7 +1118,6 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1239,8 +1193,7 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                              of the selected pods i
                                             type: string
                                         required:
                                         - topologyKey
@@ -1259,15 +1212,7 @@ spec:
                                         may choose a node that violates one or more
                                         of the expressions. The node that is most
                                         preferred is the one with the greatest sum
-                                        of weights, i.e. for each node that meets
-                                        all of the scheduling requirements (resource
-                                        request, requiredDuringScheduling anti-affinity
-                                        expressions, etc.), compute a sum by iterating
-                                        through the elements of this field and adding
-                                        "weight" to the sum if the node has pods which
-                                        matches the corresponding podAffinityTerm;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                        of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -1348,9 +1293,7 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                  means "this pod's namespace".
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -1432,8 +1375,7 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                  selected pods i
                                                 type: string
                                             required:
                                             - topologyKey
@@ -1455,12 +1397,7 @@ spec:
                                         time, the pod will not be scheduled onto the
                                         node. If the anti-affinity requirements specified
                                         by this field cease to be met at some point
-                                        during pod execution (e.g. due to a pod label
-                                        update), the system may or may not try to
-                                        eventually evict the pod from its node. When
-                                        there are multiple elements, the lists of
-                                        nodes corresponding to each podAffinityTerm
-                                        are intersected, i.e. all terms must be satisfied.
+                                        during pod execution (e.g.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -1469,8 +1406,7 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                          that of an
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -1538,7 +1474,6 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1614,8 +1549,7 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                              of the selected pods i
                                             type: string
                                         required:
                                         - topologyKey
@@ -1638,34 +1572,22 @@ spec:
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
+                                    description: Arguments to the entrypoint. The
+                                      container image's CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
+                                      expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The container image's ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
+                                      $(VAR_NAME) are expanded using the container's
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -1681,19 +1603,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1803,11 +1719,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1874,7 +1786,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1888,10 +1800,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1975,21 +1884,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2003,10 +1903,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2107,10 +2004,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -2236,19 +2130,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2269,10 +2151,7 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
-                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                      Cannot be updated.
+                                      from the network.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -2333,10 +2212,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -2462,19 +2338,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2522,15 +2386,11 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -2569,7 +2429,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -2584,7 +2444,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -2594,10 +2454,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -2606,8 +2463,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -2615,11 +2471,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2676,8 +2528,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -2699,13 +2550,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -2720,16 +2565,11 @@ spec:
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the
-                                      Pod has successfully initialized. If specified,
+                                    description: StartupProbe indicates that the Pod
+                                      has successfully initialized. If specified,
                                       no other probes are executed until this completes
                                       successfully. If this probe fails, the Pod will
                                       be restarted, just as if the livenessProbe failed.
-                                      This can be used to provide different probe
-                                      parameters at the beginning of a Pod''s lifecycle,
-                                      when it might take a long time to load data
-                                      or warm a cache, than during steady-state operation.
-                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
@@ -2743,10 +2583,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -2872,19 +2709,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2906,15 +2731,7 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -2923,21 +2740,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -3066,9 +2875,7 @@ spec:
                                 "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
                                 'ClusterFirst', 'Default' or 'None'. DNS parameters
                                 given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy. To have DNS options set along
-                                with hostNetwork, you have to specify DNS policy explicitly
-                                to 'ClusterFirstWithHostNet'.
+                                selected with DNSPolicy.
                               type: string
                             enableServiceLinks:
                               description: 'EnableServiceLinks indicates whether information
@@ -3082,50 +2889,31 @@ spec:
                                 pod to perform user-initiated actions such as debugging.
                                 This list cannot be specified when creating a pod,
                                 and it cannot be modified by updating the pod spec.
-                                In order to add an ephemeral container to an existing
-                                pod, use the pod's ephemeralcontainers subresource.
                               items:
-                                description: "An EphemeralContainer is a temporary
+                                description: An EphemeralContainer is a temporary
                                   container that you may add to an existing Pod for
                                   user-initiated activities such as debugging. Ephemeral
                                   containers have no resource or scheduling guarantees,
                                   and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted. The kubelet
-                                  may evict a Pod if an ephemeral container causes
-                                  the Pod to exceed its resource allocation. \n To
-                                  add an ephemeral container, use the ephemeralcontainers
-                                  subresource of an existing Pod. Ephemeral containers
-                                  may not be removed or restarted."
+                                  when a Pod is removed or restarted.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      image''s CMD is used if this is not provided.
+                                    description: Arguments to the entrypoint. The
+                                      image's CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
+                                      using the container's environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the
-                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                      produce the string literal "$(VAR_NAME)". Escaped
-                                      references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The image''s ENTRYPOINT is used if
-                                      this is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container''s environment.
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The image's ENTRYPOINT is used if this
+                                      is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
@@ -3141,19 +2929,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -3263,11 +3045,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -3329,7 +3107,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -3343,10 +3121,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3430,21 +3205,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -3458,10 +3224,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3561,10 +3324,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -3690,19 +3450,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3779,10 +3527,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -3908,19 +3653,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3968,15 +3701,11 @@ spec:
                                       override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -4015,7 +3744,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -4030,7 +3759,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -4040,10 +3769,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -4052,8 +3778,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -4061,11 +3786,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -4122,8 +3843,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -4145,13 +3865,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -4181,10 +3895,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -4310,19 +4021,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4344,26 +4043,15 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: "If set, the name of the container
+                                    description: If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
                                       then the ephemeral container uses the namespaces
-                                      configured in the Pod spec. \n The container
-                                      runtime must implement support for this feature.
-                                      If the runtime does not support namespace targeting
-                                      then the result of setting this field is undefined."
+                                      configured in the Pod spec.
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -4372,21 +4060,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -4512,13 +4192,7 @@ spec:
                                 pod will be run in the host user namespace, useful
                                 for when the pod needs a feature only available to
                                 the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE. When set to false, a new
-                                userns is created for the pod. Setting false is useful
-                                for mitigating container breakout vulnerabilities
-                                even allowing users to run their containers as root
-                                without actually having root privileges on the host.
-                                This field is alpha-level and is only honored by servers
-                                that enable the UserNamespacesSupport feature.'
+                                module with CAP_SYS_MODULE.'
                               type: boolean
                             hostname:
                               description: Specifies the hostname of the Pod If not
@@ -4531,7 +4205,7 @@ spec:
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
                                 puller implementations for them to use. More info:
-                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                https://kubernetes.'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -4547,55 +4221,32 @@ spec:
                                 x-kubernetes-map-type: atomic
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging
+                              description: List of initialization containers belonging
                                 to the pod. Init containers are executed in order
                                 prior to containers being started. If any init container
                                 fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy. The name for
-                                an init container or normal container must be unique
-                                among all containers. Init containers may not have
-                                Lifecycle actions, Readiness probes, Liveness probes,
-                                or Startup probes. The resourceRequirements of an
-                                init container are taken into account during scheduling
-                                by finding the highest request/limit for each resource
-                                type, and then using the max of of that value or the
-                                sum of the normal containers. Limits are applied to
-                                init containers in a similar fashion. Init containers
-                                cannot currently be added or removed. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                                handled according to its restartPolicy.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
+                                    description: Arguments to the entrypoint. The
+                                      container image's CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
+                                      expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The container image's ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
+                                      $(VAR_NAME) are expanded using the container's
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -4611,19 +4262,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -4733,11 +4378,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -4804,7 +4445,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4818,10 +4459,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4905,21 +4543,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4933,10 +4562,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5037,10 +4663,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -5166,19 +4789,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -5199,10 +4810,7 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
-                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                      Cannot be updated.
+                                      from the network.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -5263,10 +4871,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -5392,19 +4997,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -5452,15 +5045,11 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -5499,7 +5088,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -5514,7 +5103,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -5524,10 +5113,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -5536,8 +5122,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -5545,11 +5130,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -5606,8 +5187,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -5629,13 +5209,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -5650,16 +5224,11 @@ spec:
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the
-                                      Pod has successfully initialized. If specified,
+                                    description: StartupProbe indicates that the Pod
+                                      has successfully initialized. If specified,
                                       no other probes are executed until this completes
                                       successfully. If this probe fails, the Pod will
                                       be restarted, just as if the livenessProbe failed.
-                                      This can be used to provide different probe
-                                      parameters at the beginning of a Pod''s lifecycle,
-                                      when it might take a long time to load data
-                                      or warm a cache, than during steady-state operation.
-                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
@@ -5673,10 +5242,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -5802,19 +5368,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -5836,15 +5390,7 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -5853,21 +5399,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -5973,28 +5511,13 @@ spec:
                                 if this is set. \n If the OS field is set to linux,
                                 the following fields must be unset: -securityContext.windowsOptions
                                 \n If the OS field is set to windows, following fields
-                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
-                                - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
-                                - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
-                                - spec.securityContext.sysctls - spec.shareProcessNamespace
-                                - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
-                                - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions
-                                - spec.containers[*].securityContext.seccompProfile
-                                - spec.containers[*].securityContext.capabilities
-                                - spec.containers[*].securityContext.readOnlyRootFilesystem
-                                - spec.containers[*].securityContext.privileged -
-                                spec.containers[*].securityContext.allowPrivilegeEscalation
-                                - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                                - spec.containers[*].securityContext.runAsGroup"
+                                must be unset: - spec."
                               properties:
                                 name:
                                   description: 'Name is the name of the operating
                                     system. The currently supported values are linux
                                     and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                    Clients should expect to handle additional values
-                                    and treat unrecognized values in this field as
-                                    os: null'
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.'
                                   type: string
                               required:
                               - name
@@ -6006,18 +5529,12 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Overhead represents the resource overhead
+                              description: Overhead represents the resource overhead
                                 associated with running a pod for a given RuntimeClass.
                                 This field will be autopopulated at admission time
                                 by the RuntimeClass admission controller. If the RuntimeClass
                                 admission controller is enabled, overhead must not
-                                be set in Pod create requests. The RuntimeClass admission
-                                controller will reject Pod create requests which have
-                                the overhead already set. If RuntimeClass is configured
-                                and selected in the PodSpec, Overhead will be set
-                                to the value defined in the corresponding RuntimeClass,
-                                otherwise it will remain unset and treated as zero.
-                                More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                                be set in Pod create requests.
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
@@ -6039,8 +5556,7 @@ spec:
                                 are two special keywords which indicate the highest
                                 priorities with the former being the highest priority.
                                 Any other name must be defined by creating a PriorityClass
-                                object with that name. If not specified, the pod priority
-                                will be default or zero if there is no default.
+                                object with that name.
                               type: string
                             readinessGates:
                               description: 'If specified, all readiness gates will
@@ -6066,14 +5582,10 @@ spec:
                                 to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass
+                              description: RuntimeClassName refers to a RuntimeClass
                                 object in the node.k8s.io group, which should be used
                                 to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run. If unset
-                                or empty, the "legacy" RuntimeClass will be used,
-                                which is an implicit class with an empty definition
-                                that uses the default runtime handler. More info:
-                                https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                                the named class, the pod will not be run.
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -6093,24 +5605,15 @@ spec:
                                     of that volume to be owned by the pod: \n 1. The
                                     owning GID will be the FSGroup 2. The setgid bit
                                     is set (new files created in the volume will be
-                                    owned by FSGroup) 3. The permission bits are OR'd
-                                    with rw-rw---- \n If unset, the Kubelet will not
-                                    modify the ownership and permissions of any volume.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows."
+                                    owned by FSGroup) 3."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior
+                                  description: fsGroupChangePolicy defines behavior
                                     of changing ownership and permission of the volume
                                     before being exposed inside Pod. This field will
                                     only apply to volume types which support fsGroup
-                                    based ownership(and permissions). It will have
-                                    no effect on ephemeral volume types such as: secret,
-                                    configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified, "Always" is used.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.'
+                                    based ownership(and permissions).
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -6119,7 +5622,7 @@ spec:
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
                                     for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                    be set when spec.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -6129,9 +5632,7 @@ spec:
                                     does not run as UID 0 (root) and fail to start
                                     the container if it does. If unset or false, no
                                     such validation will be performed. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                    set in SecurityContext.
                                   type: boolean
                                 runAsUser:
                                   description: The UID to run the entrypoint of the
@@ -6140,19 +5641,13 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
                                   description: The SELinux context to be applied to
                                     all containers. If unspecified, the container
                                     runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                    for each container.  May also be set in SecurityContext.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -6234,8 +5729,7 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                    Note that this field cannot be set when spec.os.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -6254,12 +5748,7 @@ spec:
                                         honored by components that enable the WindowsHostProcessContainers
                                         feature flag. Setting this field without the
                                         feature flag will result in errors when validating
-                                        the Pod. All of a Pod's containers must have
-                                        the same effective HostProcess value (it is
-                                        not allowed to have a mix of HostProcess containers
-                                        and non-HostProcess containers).  In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                        the Pod.
                                       type: boolean
                                     runAsUserName:
                                       description: The UserName in Windows to run
@@ -6287,20 +5776,14 @@ spec:
                                 as the pod's FQDN, rather than the leaf name (the
                                 default). In Linux containers, this means setting
                                 the FQDN in the hostname field of the kernel (the
-                                nodename field of struct utsname). In Windows containers,
-                                this means setting the registry value of hostname
-                                for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
-                                to FQDN. If a pod does not have FQDN, this has no
-                                effect. Default to false.
+                                nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between
+                              description: Share a single process namespace between
                                 all of the containers in a pod. When this is set containers
                                 will be able to view and signal processes from other
                                 containers in the same pod, and the first process
-                                in each container will not be assigned PID 1. HostPID
-                                and ShareProcessNamespace cannot both be set. Optional:
-                                Default to false.'
+                                in each container will not be assigned PID 1.
                               type: boolean
                             subdomain:
                               description: If specified, the fully qualified Pod hostname
@@ -6313,14 +5796,7 @@ spec:
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
                                 zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down). If this value is nil,
-                                the default grace period will be used instead. The
-                                grace period is the duration in seconds after the
-                                processes running in the pod are sent a termination
-                                signal and the time when the processes are forcibly
-                                halted with a kill signal. Set this value longer than
-                                the expected cleanup time for your process. Defaults
-                                to 30 seconds.
+                                (no opportunity to shut down).
                               format: int64
                               type: integer
                             tolerations:
@@ -6356,8 +5832,7 @@ spec:
                                       of effect NoExecute, otherwise this field is
                                       ignored) tolerates the taint. By default, it
                                       is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
+                                      (do not evict).
                                     format: int64
                                     type: integer
                                   value:
@@ -6434,98 +5909,44 @@ spec:
                                   matchLabelKeys:
                                     description: MatchLabelKeys is a set of pod label
                                       keys to select the pods over which spreading
-                                      will be calculated. The keys are used to lookup
-                                      values from the incoming pod labels, those key-value
-                                      labels are ANDed with labelSelector to select
-                                      the group of existing pods over which spreading
-                                      will be calculated for the incoming pod. Keys
-                                      that don't exist in the incoming pod labels
-                                      will be ignored. A null or empty list means
-                                      only match against labelSelector.
+                                      will be calculated.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   maxSkew:
-                                    description: 'MaxSkew describes the degree to
-                                      which pods may be unevenly distributed. When
-                                      `whenUnsatisfiable=DoNotSchedule`, it is the
-                                      maximum permitted difference between the number
-                                      of matching pods in the target topology and
-                                      the global minimum. The global minimum is the
-                                      minimum number of matching pods in an eligible
-                                      domain or zero if the number of eligible domains
-                                      is less than MinDomains. For example, in a 3-zone
-                                      cluster, MaxSkew is set to 1, and pods with
-                                      the same labelSelector spread as 2/2/1: In this
-                                      case, the global minimum is 1. | zone1 | zone2
-                                      | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
-                                      is 1, incoming pod can only be scheduled to
-                                      zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                                      would make the ActualSkew(3-1) on zone1(zone2)
-                                      violate MaxSkew(1). - if MaxSkew is 2, incoming
-                                      pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                                      it is used to give higher precedence to topologies
-                                      that satisfy it. It''s a required field. Default
-                                      value is 1 and 0 is not allowed.'
+                                    description: MaxSkew describes the degree to which
+                                      pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                      it is the maximum permitted difference between
+                                      the number of matching pods in the target topology
+                                      and the global minimum.
                                     format: int32
                                     type: integer
                                   minDomains:
-                                    description: "MinDomains indicates a minimum number
+                                    description: MinDomains indicates a minimum number
                                       of eligible domains. When the number of eligible
                                       domains with matching topology keys is less
                                       than minDomains, Pod Topology Spread treats
-                                      \"global minimum\" as 0, and then the calculation
-                                      of Skew is performed. And when the number of
-                                      eligible domains with matching topology keys
-                                      equals or greater than minDomains, this value
-                                      has no effect on scheduling. As a result, when
-                                      the number of eligible domains is less than
-                                      minDomains, scheduler won't schedule more than
-                                      maxSkew Pods to those domains. If value is nil,
-                                      the constraint behaves as if MinDomains is equal
-                                      to 1. Valid values are integers greater than
-                                      0. When value is not nil, WhenUnsatisfiable
-                                      must be DoNotSchedule. \n For example, in a
-                                      3-zone cluster, MaxSkew is set to 2, MinDomains
-                                      is set to 5 and pods with the same labelSelector
-                                      spread as 2/2/2: | zone1 | zone2 | zone3 | |
-                                      \ P P  |  P P  |  P P  | The number of domains
-                                      is less than 5(MinDomains), so \"global minimum\"
-                                      is treated as 0. In this situation, new pod
-                                      with the same labelSelector cannot be scheduled,
-                                      because computed skew will be 3(3 - 0) if new
-                                      Pod is scheduled to any of the three zones,
-                                      it will violate MaxSkew. \n This is a beta field
-                                      and requires the MinDomainsInPodTopologySpread
-                                      feature gate to be enabled (enabled by default)."
+                                      "global minimum" as 0, and then the calculation
+                                      of Skew is performed.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: "NodeAffinityPolicy indicates how
-                                      we will treat Pod's nodeAffinity/nodeSelector
+                                    description: 'NodeAffinityPolicy indicates how
+                                      we will treat Pod''s nodeAffinity/nodeSelector
                                       when calculating pod topology spread skew. Options
                                       are: - Honor: only nodes matching nodeAffinity/nodeSelector
                                       are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored. All nodes
-                                      are included in the calculations. \n If this
-                                      value is nil, the behavior is equivalent to
-                                      the Honor policy. This is a alpha-level feature
-                                      enabled by the NodeInclusionPolicyInPodTopologySpread
-                                      feature flag."
+                                      nodeAffinity/nodeSelector are ignored.'
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: "NodeTaintsPolicy indicates how we
+                                    description: 'NodeTaintsPolicy indicates how we
                                       will treat node taints when calculating pod
                                       topology spread skew. Options are: - Honor:
                                       nodes without taints, along with tainted nodes
                                       for which the incoming pod has a toleration,
                                       are included. - Ignore: node taints are ignored.
-                                      All nodes are included. \n If this value is
-                                      nil, the behavior is equivalent to the Ignore
-                                      policy. This is a alpha-level feature enabled
-                                      by the NodeInclusionPolicyInPodTopologySpread
-                                      feature flag."
+                                      All nodes are included.'
                                     type: string
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
@@ -6533,37 +5954,13 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket. We define a domain as a particular
-                                      instance of a topology. Also, we define an eligible
-                                      domain as a domain whose nodes meet the requirements
-                                      of nodeAffinityPolicy and nodeTaintsPolicy.
-                                      e.g. If TopologyKey is "kubernetes.io/hostname",
-                                      each Node is a domain of that topology. And,
-                                      if TopologyKey is "topology.kubernetes.io/zone",
-                                      each zone is a domain of that topology. It's
-                                      a required field.
+                                      each bucket.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: 'WhenUnsatisfiable indicates how
-                                      to deal with a pod if it doesn''t satisfy the
-                                      spread constraint. - DoNotSchedule (default)
-                                      tells the scheduler not to schedule it. - ScheduleAnyway
-                                      tells the scheduler to schedule the pod in any
-                                      location, but giving higher precedence to topologies
-                                      that would help reduce the skew. A constraint
-                                      is considered "Unsatisfiable" for an incoming
-                                      pod if and only if every possible node assignment
-                                      for that pod would violate "MaxSkew" on some
-                                      topology. For example, in a 3-zone cluster,
-                                      MaxSkew is set to 1, and pods with the same
-                                      labelSelector spread as 3/1/1: | zone1 | zone2
-                                      | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
-                                      is set to DoNotSchedule, incoming pod can only
-                                      be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
-                                      as ActualSkew(2-1) on zone2(zone3) satisfies
-                                      MaxSkew(1). In other words, the cluster can
-                                      still be imbalanced, but scheduler won''t make
-                                      it *more* imbalanced. It''s a required field.'
+                                    description: WhenUnsatisfiable indicates how to
+                                      deal with a pod if it doesn't satisfy the spread
+                                      constraint. - DoNotSchedule (default) tells
+                                      the scheduler not to schedule it.
                                     type: string
                                 required:
                                 - maxSkew
@@ -6596,9 +5993,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6783,12 +6178,7 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          values for mode bits. Defaults to 0644.'
                                         format: int32
                                         type: integer
                                       items:
@@ -6798,12 +6188,7 @@ spec:
                                           as a file whose name is the key and content
                                           is the value. If specified, the listed keys
                                           will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the ConfigMap, the volume setup will
-                                          error unless it is marked optional. Paths
-                                          must be relative and may not contain the
-                                          '..' path or start with '..'.
+                                          and unlisted keys will not be present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -6820,10 +6205,7 @@ spec:
                                                 and decimal values, JSON requires
                                                 decimal values for mode bits. If not
                                                 specified, the volume defaultMode
-                                                will be used. This might be in conflict
-                                                with other options that affect the
-                                                file mode, like fsGroup, and the result
-                                                can be other mode bits set.'
+                                                will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -6874,9 +6256,7 @@ spec:
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
                                           calls. This field is optional, and  may
-                                          be empty if no secret is required. If the
-                                          secret object contains more than one secret,
-                                          all secret references are passed.
+                                          be empty if no secret is required.
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -6912,14 +6292,7 @@ spec:
                                           mode bits used to set permissions on created
                                           files by default. Must be an octal value
                                           between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          between 0 and 511.'
                                         format: int32
                                         type: integer
                                       items:
@@ -6956,11 +6329,7 @@ spec:
                                                 and 511. YAML accepts both octal and
                                                 decimal values, JSON requires decimal
                                                 values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                                the volume defaultMode will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -7021,70 +6390,30 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'sizeLimit is the total amount
+                                        description: sizeLimit is the total amount
                                           of local storage required for this EmptyDir
                                           volume. The size limit is also applicable
                                           for memory medium. The maximum usage on
                                           memory medium EmptyDir would be the minimum
                                           value between the SizeLimit specified here
                                           and the sum of memory limits of all containers
-                                          in a pod. The default is nil which means
-                                          that the limit is undefined. More info:
-                                          http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                          in a pod.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: "ephemeral represents a volume that
+                                    description: ephemeral represents a volume that
                                       is handled by a cluster storage driver. The
                                       volume's lifecycle is tied to the pod that defines
                                       it - it will be created before the pod starts,
-                                      and deleted when the pod is removed. \n Use
-                                      this if: a) the volume is only needed while
-                                      the pod runs, b) features of normal volumes
-                                      like restoring from snapshot or capacity tracking
-                                      are needed, c) the storage driver is specified
-                                      through a storage class, and d) the storage
-                                      driver supports dynamic volume provisioning
-                                      through a PersistentVolumeClaim (see EphemeralVolumeSource
-                                      for more information on the connection between
-                                      this volume type and PersistentVolumeClaim).
-                                      \n Use PersistentVolumeClaim or one of the vendor-specific
-                                      APIs for volumes that persist for longer than
-                                      the lifecycle of an individual pod. \n Use CSI
-                                      for light-weight local ephemeral volumes if
-                                      the CSI driver is meant to be used that way
-                                      - see the documentation of the driver for more
-                                      information. \n A pod can use both types of
-                                      ephemeral volumes and persistent volumes at
-                                      the same time."
+                                      and deleted when the pod is removed.
                                     properties:
                                       volumeClaimTemplate:
-                                        description: "Will be used to create a stand-alone
+                                        description: Will be used to create a stand-alone
                                           PVC to provision the volume. The pod in
                                           which this EphemeralVolumeSource is embedded
                                           will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.  The
-                                          name of the PVC will be `<pod name>-<volume
-                                          name>` where `<volume name>` is the name
-                                          from the `PodSpec.Volumes` array entry.
-                                          Pod validation will reject the pod if the
-                                          concatenated name is not valid for a PVC
-                                          (for example, too long). \n An existing
-                                          PVC with that name that is not owned by
-                                          the pod will *not* be used for the pod to
-                                          avoid using an unrelated volume by mistake.
-                                          Starting the pod is then blocked until the
-                                          unrelated PVC is removed. If such a pre-created
-                                          PVC is meant to be used by the pod, the
-                                          PVC has to updated with an owner reference
-                                          to the pod once the pod exists. Normally
-                                          this should not be necessary, but it may
-                                          be useful when manually reconstructing a
-                                          broken cluster. \n This field is read-only
-                                          and no changes will be made by Kubernetes
-                                          to the PVC after it has been created. \n
-                                          Required, must not be nil."
+                                          will be deleted together with the pod.
                                         properties:
                                           metadata:
                                             description: May contain labels and annotations
@@ -7127,17 +6456,7 @@ spec:
                                               dataSource:
                                                 description: 'dataSource field can
                                                   be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                  * An existing PVC (PersistentVolumeClaim)
-                                                  If the provisioner or an external
-                                                  controller can support the specified
-                                                  data source, it will create a new
-                                                  volume based on the contents of
-                                                  the specified data source. If the
-                                                  AnyVolumeDataSource feature gate
-                                                  is enabled, this field will always
-                                                  have the same contents as the DataSourceRef
-                                                  field.'
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -7162,38 +6481,13 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               dataSourceRef:
-                                                description: 'dataSourceRef specifies
+                                                description: dataSourceRef specifies
                                                   the object from which to populate
                                                   the volume with data, if a non-empty
                                                   volume is desired. This may be any
                                                   local object from a non-empty API
                                                   group (non core object) or a PersistentVolumeClaim
-                                                  object. When this field is specified,
-                                                  volume binding will only succeed
-                                                  if the type of the specified object
-                                                  matches some installed volume populator
-                                                  or dynamic provisioner. This field
-                                                  will replace the functionality of
-                                                  the DataSource field and as such
-                                                  if both fields are non-empty, they
-                                                  must have the same value. For backwards
-                                                  compatibility, both fields (DataSource
-                                                  and DataSourceRef) will be set to
-                                                  the same value automatically if
-                                                  one of them is empty and the other
-                                                  is non-empty. There are two important
-                                                  differences between DataSource and
-                                                  DataSourceRef: * While DataSource
-                                                  only allows two specific types of
-                                                  objects, DataSourceRef allows any
-                                                  non-core object, as well as PersistentVolumeClaim
-                                                  objects. * While DataSource ignores
-                                                  disallowed values (dropping them),
-                                                  DataSourceRef preserves all values,
-                                                  and generates an error if a disallowed
-                                                  value is specified. (Beta) Using
-                                                  this field requires the AnyVolumeDataSource
-                                                  feature gate to be enabled.'
+                                                  object.
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -7218,7 +6512,7 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resources:
-                                                description: 'resources represents
+                                                description: resources represents
                                                   the minimum resources the volume
                                                   should have. If RecoverVolumeExpansionFailure
                                                   feature is enabled users are allowed
@@ -7226,7 +6520,7 @@ spec:
                                                   that are lower than previous value
                                                   but must still be higher than capacity
                                                   recorded in the status field of
-                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  the claim.
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -7455,9 +6749,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -7466,7 +6758,7 @@ spec:
                                           Examples: For volume /dev/sda1, you specify
                                           the partition as "1". Similarly, the volume
                                           partition for /dev/sda is "0" (or you can
-                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          leave the property empty).'
                                         format: int32
                                         type: integer
                                       pdName:
@@ -7538,10 +6830,7 @@ spec:
                                       directly exposed to the container. This is generally
                                       used for system agents or other privileged things
                                       that are allowed to see the host machine. Most
-                                      containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                      --- TODO(jonesdl) We need to restrict who can
-                                      use host directory mounts and who can/can not
-                                      mount host directories as read/write.'
+                                      containers will NOT need this. More info: https://kubernetes.'
                                     properties:
                                       path:
                                         description: 'path of the directory on the
@@ -7576,9 +6865,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       initiatorName:
                                         description: initiatorName is the custom iSCSI
@@ -7735,11 +7022,7 @@ spec:
                                           0000 and 0777 or a decimal value between
                                           0 and 511. YAML accepts both octal and decimal
                                           values, JSON requires decimal values for
-                                          mode bits. Directories within the path are
-                                          not affected by this setting. This might
-                                          be in conflict with other options that affect
-                                          the file mode, like fsGroup, and the result
-                                          can be other mode bits set.
+                                          mode bits.
                                         format: int32
                                         type: integer
                                       sources:
@@ -7763,12 +7046,6 @@ spec:
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
-                                                    If a key is specified which is
-                                                    not present in the ConfigMap,
-                                                    the volume setup will error unless
-                                                    it is marked optional. Paths must
-                                                    be relative and may not contain
-                                                    the '..' path or start with '..'.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7788,12 +7065,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7868,12 +7140,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7937,12 +7204,6 @@ spec:
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
-                                                    If a key is specified which is
-                                                    not present in the Secret, the
-                                                    volume setup will error unless
-                                                    it is marked optional. Paths must
-                                                    be relative and may not contain
-                                                    the '..' path or start with '..'.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7962,12 +7223,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -8019,13 +7275,7 @@ spec:
                                                     As the token approaches expiration,
                                                     the kubelet volume plugin will
                                                     proactively rotate the service
-                                                    account token. The kubelet will
-                                                    start trying to rotate the token
-                                                    if the token is older than 80
-                                                    percent of its time to live or
-                                                    if the token is older than 24
-                                                    hours.Defaults to 1 hour and must
-                                                    be at least 10 minutes.
+                                                    account token.
                                                   format: int64
                                                   type: integer
                                                 path:
@@ -8089,9 +7339,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       image:
                                         description: 'image is the rados image name.
@@ -8215,12 +7463,7 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          values for mode bits. Defaults to 0644.'
                                         format: int32
                                         type: integer
                                       items:
@@ -8230,12 +7473,7 @@ spec:
                                           as a file whose name is the key and content
                                           is the value. If specified, the listed keys
                                           will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the Secret, the volume setup will error
-                                          unless it is marked optional. Paths must
-                                          be relative and may not contain the '..'
-                                          path or start with '..'.
+                                          and unlisted keys will not be present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -8252,10 +7490,7 @@ spec:
                                                 and decimal values, JSON requires
                                                 decimal values for mode bits. If not
                                                 specified, the volume defaultMode
-                                                will be used. This might be in conflict
-                                                with other options that affect the
-                                                file mode, like fsGroup, and the result
-                                                can be other mode bits set.'
+                                                will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -8322,9 +7557,6 @@ spec:
                                           Kubernetes name scoping to be mirrored within
                                           StorageOS for tighter integration. Set VolumeName
                                           to any name to override the default behaviour.
-                                          Set to "default" if you are not using namespaces
-                                          within StorageOS. Namespaces that do not
-                                          pre-exist within StorageOS will be created.
                                         type: string
                                     type: object
                                   vsphereVolume:

--- a/manifests/base/crds/kubeflow.org_pytorchjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_pytorchjobs.yaml
@@ -58,7 +58,9 @@ spec:
                       to calculate the desired replica count (the maximum replica
                       count across all metrics will be used).  The desired replica
                       count is calculated with multiplying the ratio between the target
-                      value and the current value by the current number of pods.
+                      value and the current value by the current number of pods. Ergo,
+                      metrics used must decrease as the pod count is increased, and
+                      vice-versa.
                     items:
                       description: MetricSpec specifies how to scale based on a single
                         metric (only `type` and one other matching field should be
@@ -68,7 +70,10 @@ spec:
                           description: containerResource refers to a resource metric
                             (such as those specified in requests and limits) known
                             to Kubernetes describing a single container in each pod
-                            of the current scale target (e.g. CPU or memory).
+                            of the current scale target (e.g. CPU or memory). Such
+                            metrics are built in to Kubernetes, and have special scaling
+                            options on top of those available to normal per-pod metrics
+                            using the "pods" source.
                           properties:
                             container:
                               description: container is the name of the container
@@ -480,7 +485,9 @@ spec:
                           description: resource refers to a resource metric (such
                             as those specified in requests and limits) known to Kubernetes
                             describing each pod in the current scale target (e.g.
-                            CPU or memory).
+                            CPU or memory). Such metrics are built in to Kubernetes,
+                            and have special scaling options on top of those available
+                            to normal per-pod metrics using the "pods" source.
                           properties:
                             name:
                               description: name is the name of the resource in question.
@@ -639,7 +646,10 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e.
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.
                                       items:
                                         description: An empty preferred scheduling
                                           term matches all objects with implicit weight
@@ -682,6 +692,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -721,6 +733,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -748,7 +762,9 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g.
+                                        pod execution (e.g. due to an update), the
+                                        system may or may not try to eventually evict
+                                        the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
@@ -790,6 +806,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -829,6 +847,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -856,7 +876,10 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e.
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -937,7 +960,9 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace".
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -1019,7 +1044,8 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods i
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
@@ -1041,7 +1067,9 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g.
+                                        pod execution (e.g. due to a pod label update),
+                                        the system may or may not try to eventually
+                                        evict the pod from its node.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -1050,7 +1078,8 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of an
+                                          that of any node on which a pod of the set
+                                          of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -1118,6 +1147,7 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1193,7 +1223,8 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods i
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1293,7 +1324,9 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace".
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -1375,7 +1408,8 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods i
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
@@ -1397,7 +1431,9 @@ spec:
                                         time, the pod will not be scheduled onto the
                                         node. If the anti-affinity requirements specified
                                         by this field cease to be met at some point
-                                        during pod execution (e.g.
+                                        during pod execution (e.g. due to a pod label
+                                        update), the system may or may not try to
+                                        eventually evict the pod from its node.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -1406,7 +1442,8 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of an
+                                          that of any node on which a pod of the set
+                                          of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -1474,6 +1511,7 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1549,7 +1587,8 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods i
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1572,22 +1611,26 @@ spec:
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      container image's CMD is used if this is not
+                                    description: 'Arguments to the entrypoint. The
+                                      container image''s CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container's environment.
+                                      expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The container image's ENTRYPOINT is
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The container image''s ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container's
+                                      $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -1603,13 +1646,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1719,7 +1765,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1786,7 +1836,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1800,7 +1850,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1890,6 +1943,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1903,7 +1958,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2004,7 +2062,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -2130,7 +2191,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2151,7 +2214,9 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network.
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -2212,7 +2277,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -2338,7 +2406,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2386,11 +2456,15 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -2429,7 +2503,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -2444,7 +2518,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -2463,7 +2537,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -2471,7 +2546,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2528,7 +2607,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -2583,7 +2663,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -2709,7 +2792,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2740,13 +2825,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -2875,7 +2966,9 @@ spec:
                                 "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
                                 'ClusterFirst', 'Default' or 'None'. DNS parameters
                                 given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy.
+                                selected with DNSPolicy. To have DNS options set along
+                                with hostNetwork, you have to specify DNS policy explicitly
+                                to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
                               description: 'EnableServiceLinks indicates whether information
@@ -2889,31 +2982,40 @@ spec:
                                 pod to perform user-initiated actions such as debugging.
                                 This list cannot be specified when creating a pod,
                                 and it cannot be modified by updating the pod spec.
+                                In order to add an ephemeral container to an existing
+                                pod, use the pod's ephemeralcontainers subresource.
                               items:
                                 description: An EphemeralContainer is a temporary
                                   container that you may add to an existing Pod for
                                   user-initiated activities such as debugging. Ephemeral
                                   containers have no resource or scheduling guarantees,
                                   and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted.
+                                  when a Pod is removed or restarted. The kubelet
+                                  may evict a Pod if an ephemeral container causes
+                                  the Pod to exceed its resource allocation.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      image's CMD is used if this is not provided.
+                                    description: 'Arguments to the entrypoint. The
+                                      image''s CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
-                                      using the container's environment. If a variable
+                                      using the container''s environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged.
+                                      string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the
+                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)".'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The image's ENTRYPOINT is used if this
-                                      is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container's environment.
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The image''s ENTRYPOINT is used if
+                                      this is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -2929,13 +3031,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -3045,7 +3150,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -3107,7 +3216,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -3121,7 +3230,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3211,6 +3323,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -3224,7 +3338,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3324,7 +3441,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -3450,7 +3570,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3527,7 +3649,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -3653,7 +3778,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3701,11 +3828,15 @@ spec:
                                       override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -3744,7 +3875,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -3759,7 +3890,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -3778,7 +3909,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -3786,7 +3918,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3843,7 +3979,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -3895,7 +4032,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4021,7 +4161,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4046,12 +4188,13 @@ spec:
                                       sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container
+                                    description: "If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
                                       then the ephemeral container uses the namespaces
-                                      configured in the Pod spec.
+                                      configured in the Pod spec. \n The container
+                                      runtime must implement support for this feature."
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -4060,13 +4203,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -4192,7 +4341,8 @@ spec:
                                 pod will be run in the host user namespace, useful
                                 for when the pod needs a feature only available to
                                 the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE.'
+                                module with CAP_SYS_MODULE. When set to false, a new
+                                userns is created for the pod.'
                               type: boolean
                             hostname:
                               description: Specifies the hostname of the Pod If not
@@ -4205,7 +4355,7 @@ spec:
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
                                 puller implementations for them to use. More info:
-                                https://kubernetes.'
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -4225,28 +4375,34 @@ spec:
                                 to the pod. Init containers are executed in order
                                 prior to containers being started. If any init container
                                 fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy.
+                                handled according to its restartPolicy. The name for
+                                an init container or normal container must be unique
+                                among all containers.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      container image's CMD is used if this is not
+                                    description: 'Arguments to the entrypoint. The
+                                      container image''s CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container's environment.
+                                      expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The container image's ENTRYPOINT is
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The container image''s ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container's
+                                      $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -4262,13 +4418,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -4378,7 +4537,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -4445,7 +4608,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4459,7 +4622,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4549,6 +4715,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4562,7 +4730,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4663,7 +4834,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4789,7 +4963,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4810,7 +4986,9 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network.
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -4871,7 +5049,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4997,7 +5178,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -5045,11 +5228,15 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -5088,7 +5275,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -5103,7 +5290,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -5122,7 +5309,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -5130,7 +5318,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -5187,7 +5379,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -5242,7 +5435,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -5368,7 +5564,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -5399,13 +5597,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -5511,13 +5715,17 @@ spec:
                                 if this is set. \n If the OS field is set to linux,
                                 the following fields must be unset: -securityContext.windowsOptions
                                 \n If the OS field is set to windows, following fields
-                                must be unset: - spec."
+                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
+                                - spec.securityContext.seLinuxOptions - spec.securityContext."
                               properties:
                                 name:
                                   description: 'Name is the name of the operating
                                     system. The currently supported values are linux
                                     and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.'
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values
+                                    and treat unrecognized values in this field as
+                                    os: null'
                                   type: string
                               required:
                               - name
@@ -5534,7 +5742,9 @@ spec:
                                 This field will be autopopulated at admission time
                                 by the RuntimeClass admission controller. If the RuntimeClass
                                 admission controller is enabled, overhead must not
-                                be set in Pod create requests.
+                                be set in Pod create requests. The RuntimeClass admission
+                                controller will reject Pod create requests which have
+                                the overhead already set.
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
@@ -5556,7 +5766,8 @@ spec:
                                 are two special keywords which indicate the highest
                                 priorities with the former being the highest priority.
                                 Any other name must be defined by creating a PriorityClass
-                                object with that name.
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
                               type: string
                             readinessGates:
                               description: 'If specified, all readiness gates will
@@ -5582,10 +5793,14 @@ spec:
                                 to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: RuntimeClassName refers to a RuntimeClass
+                              description: 'RuntimeClassName refers to a RuntimeClass
                                 object in the node.k8s.io group, which should be used
                                 to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run.
+                                the named class, the pod will not be run. If unset
+                                or empty, the "legacy" RuntimeClass will be used,
+                                which is an implicit class with an empty definition
+                                that uses the default runtime handler. More info:
+                                https://git.k8s.'
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -5609,11 +5824,14 @@ spec:
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: fsGroupChangePolicy defines behavior
+                                  description: 'fsGroupChangePolicy defines behavior
                                     of changing ownership and permission of the volume
                                     before being exposed inside Pod. This field will
                                     only apply to volume types which support fsGroup
-                                    based ownership(and permissions).
+                                    based ownership(and permissions). It will have
+                                    no effect on ephemeral volume types such as: secret,
+                                    configmaps and emptydir. Valid values are "OnRootMismatch"
+                                    and "Always". If not specified, "Always" is used.'
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -5622,7 +5840,7 @@ spec:
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
                                     for that container. Note that this field cannot
-                                    be set when spec.
+                                    be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -5641,13 +5859,19 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
                                   description: The SELinux context to be applied to
                                     all containers. If unspecified, the container
                                     runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.
+                                    for each container.  May also be set in SecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5729,7 +5953,8 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -5779,11 +6004,13 @@ spec:
                                 nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: Share a single process namespace between
+                              description: 'Share a single process namespace between
                                 all of the containers in a pod. When this is set containers
                                 will be able to view and signal processes from other
                                 containers in the same pod, and the first process
-                                in each container will not be assigned PID 1.
+                                in each container will not be assigned PID 1. HostPID
+                                and ShareProcessNamespace cannot both be set. Optional:
+                                Default to false.'
                               type: boolean
                             subdomain:
                               description: If specified, the fully qualified Pod hostname
@@ -5796,7 +6023,8 @@ spec:
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
                                 zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down).
+                                (no opportunity to shut down). If this value is nil,
+                                the default grace period will be used instead.
                               format: int64
                               type: integer
                             tolerations:
@@ -5832,7 +6060,8 @@ spec:
                                       of effect NoExecute, otherwise this field is
                                       ignored) tolerates the taint. By default, it
                                       is not set, which means tolerate the taint forever
-                                      (do not evict).
+                                      (do not evict). Zero and negative values will
+                                      be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
@@ -5909,7 +6138,13 @@ spec:
                                   matchLabelKeys:
                                     description: MatchLabelKeys is a set of pod label
                                       keys to select the pods over which spreading
-                                      will be calculated.
+                                      will be calculated. The keys are used to lookup
+                                      values from the incoming pod labels, those key-value
+                                      labels are ANDed with labelSelector to select
+                                      the group of existing pods over which spreading
+                                      will be calculated for the incoming pod. Keys
+                                      that don't exist in the incoming pod labels
+                                      will be ignored.
                                     items:
                                       type: string
                                     type: array
@@ -5919,7 +6154,10 @@ spec:
                                       pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                                       it is the maximum permitted difference between
                                       the number of matching pods in the target topology
-                                      and the global minimum.
+                                      and the global minimum. The global minimum is
+                                      the minimum number of matching pods in an eligible
+                                      domain or zero if the number of eligible domains
+                                      is less than MinDomains.
                                     format: int32
                                     type: integer
                                   minDomains:
@@ -5928,25 +6166,33 @@ spec:
                                       domains with matching topology keys is less
                                       than minDomains, Pod Topology Spread treats
                                       "global minimum" as 0, and then the calculation
-                                      of Skew is performed.
+                                      of Skew is performed. And when the number of
+                                      eligible domains with matching topology keys
+                                      equals or greater than minDomains, this value
+                                      has no effect on scheduling.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: 'NodeAffinityPolicy indicates how
-                                      we will treat Pod''s nodeAffinity/nodeSelector
+                                    description: "NodeAffinityPolicy indicates how
+                                      we will treat Pod's nodeAffinity/nodeSelector
                                       when calculating pod topology spread skew. Options
                                       are: - Honor: only nodes matching nodeAffinity/nodeSelector
                                       are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored.'
+                                      nodeAffinity/nodeSelector are ignored. All nodes
+                                      are included in the calculations. \n If this
+                                      value is nil, the behavior is equivalent to
+                                      the Honor policy."
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: 'NodeTaintsPolicy indicates how we
+                                    description: "NodeTaintsPolicy indicates how we
                                       will treat node taints when calculating pod
                                       topology spread skew. Options are: - Honor:
                                       nodes without taints, along with tainted nodes
                                       for which the incoming pod has a toleration,
                                       are included. - Ignore: node taints are ignored.
-                                      All nodes are included.'
+                                      All nodes are included. \n If this value is
+                                      nil, the behavior is equivalent to the Ignore
+                                      policy."
                                     type: string
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
@@ -5954,13 +6200,17 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket.
+                                      each bucket. We define a domain as a particular
+                                      instance of a topology.
                                     type: string
                                   whenUnsatisfiable:
                                     description: WhenUnsatisfiable indicates how to
                                       deal with a pod if it doesn't satisfy the spread
                                       constraint. - DoNotSchedule (default) tells
-                                      the scheduler not to schedule it.
+                                      the scheduler not to schedule it. - ScheduleAnyway
+                                      tells the scheduler to schedule the pod in any
+                                      location, but giving higher precedence to topologies
+                                      that would help reduce the skew.
                                     type: string
                                 required:
                                 - maxSkew
@@ -5993,7 +6243,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6178,7 +6430,9 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.'
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -6256,7 +6510,9 @@ spec:
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
                                           calls. This field is optional, and  may
-                                          be empty if no secret is required.
+                                          be empty if no secret is required. If the
+                                          secret object contains more than one secret,
+                                          all secret references are passed.
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -6292,7 +6548,11 @@ spec:
                                           mode bits used to set permissions on created
                                           files by default. Must be an octal value
                                           between 0000 and 0777 or a decimal value
-                                          between 0 and 511.'
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -6390,14 +6650,16 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: sizeLimit is the total amount
+                                        description: 'sizeLimit is the total amount
                                           of local storage required for this EmptyDir
                                           volume. The size limit is also applicable
                                           for memory medium. The maximum usage on
                                           memory medium EmptyDir would be the minimum
                                           value between the SizeLimit specified here
                                           and the sum of memory limits of all containers
-                                          in a pod.
+                                          in a pod. The default is nil which means
+                                          that the limit is undefined. More info:
+                                          http://kubernetes.'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
@@ -6413,7 +6675,10 @@ spec:
                                           PVC to provision the volume. The pod in
                                           which this EphemeralVolumeSource is embedded
                                           will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.
+                                          will be deleted together with the pod.  The
+                                          name of the PVC will be `<pod name>-<volume
+                                          name>` where `<volume name>` is the name
+                                          from the `PodSpec.Volumes` array entry.
                                         properties:
                                           metadata:
                                             description: May contain labels and annotations
@@ -6456,7 +6721,13 @@ spec:
                                               dataSource:
                                                 description: 'dataSource field can
                                                   be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.'
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                  * An existing PVC (PersistentVolumeClaim)
+                                                  If the provisioner or an external
+                                                  controller can support the specified
+                                                  data source, it will create a new
+                                                  volume based on the contents of
+                                                  the specified data source.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6487,7 +6758,11 @@ spec:
                                                   volume is desired. This may be any
                                                   local object from a non-empty API
                                                   group (non core object) or a PersistentVolumeClaim
-                                                  object.
+                                                  object. When this field is specified,
+                                                  volume binding will only succeed
+                                                  if the type of the specified object
+                                                  matches some installed volume populator
+                                                  or dynamic provisioner.
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6512,7 +6787,7 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resources:
-                                                description: resources represents
+                                                description: 'resources represents
                                                   the minimum resources the volume
                                                   should have. If RecoverVolumeExpansionFailure
                                                   feature is enabled users are allowed
@@ -6520,7 +6795,7 @@ spec:
                                                   that are lower than previous value
                                                   but must still be higher than capacity
                                                   recorded in the status field of
-                                                  the claim.
+                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -6749,7 +7024,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6758,7 +7035,7 @@ spec:
                                           Examples: For volume /dev/sda1, you specify
                                           the partition as "1". Similarly, the volume
                                           partition for /dev/sda is "0" (or you can
-                                          leave the property empty).'
+                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
@@ -6865,7 +7142,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       initiatorName:
                                         description: initiatorName is the custom iSCSI
@@ -7022,7 +7301,8 @@ spec:
                                           0000 and 0777 or a decimal value between
                                           0 and 511. YAML accepts both octal and decimal
                                           values, JSON requires decimal values for
-                                          mode bits.
+                                          mode bits. Directories within the path are
+                                          not affected by this setting.
                                         format: int32
                                         type: integer
                                       sources:
@@ -7275,7 +7555,13 @@ spec:
                                                     As the token approaches expiration,
                                                     the kubelet volume plugin will
                                                     proactively rotate the service
-                                                    account token.
+                                                    account token. The kubelet will
+                                                    start trying to rotate the token
+                                                    if the token is older than 80
+                                                    percent of its time to live or
+                                                    if the token is older than 24
+                                                    hours.Defaults to 1 hour and must
+                                                    be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
@@ -7339,7 +7625,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       image:
                                         description: 'image is the rados image name.
@@ -7463,7 +7751,9 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.'
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -7557,6 +7847,8 @@ spec:
                                           Kubernetes name scoping to be mirrored within
                                           StorageOS for tighter integration. Set VolumeName
                                           to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces
+                                          within StorageOS.
                                         type: string
                                     type: object
                                   vsphereVolume:

--- a/manifests/base/crds/kubeflow.org_tfjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_tfjobs.yaml
@@ -161,15 +161,7 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node matches the corresponding matchExpressions;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                        with the greatest sum of weights, i.e.
                                       items:
                                         description: An empty preferred scheduling
                                           term matches all objects with implicit weight
@@ -212,8 +204,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -253,8 +243,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -282,9 +270,7 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g. due to an update), the
-                                        system may or may not try to eventually evict
-                                        the pod from its node.
+                                        pod execution (e.g.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
@@ -326,8 +312,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -367,8 +351,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -396,15 +378,7 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node has pods which matches the corresponding
-                                        podAffinityTerm; the node(s) with the highest
-                                        sum are the most preferred.
+                                        with the greatest sum of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -485,9 +459,7 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                  means "this pod's namespace".
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -569,8 +541,7 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                  selected pods i
                                                 type: string
                                             required:
                                             - topologyKey
@@ -592,12 +563,7 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g. due to a pod label update),
-                                        the system may or may not try to eventually
-                                        evict the pod from its node. When there are
-                                        multiple elements, the lists of nodes corresponding
-                                        to each podAffinityTerm are intersected, i.e.
-                                        all terms must be satisfied.
+                                        pod execution (e.g.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -606,8 +572,7 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                          that of an
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -675,7 +640,6 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -751,8 +715,7 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                              of the selected pods i
                                             type: string
                                         required:
                                         - topologyKey
@@ -771,15 +734,7 @@ spec:
                                         may choose a node that violates one or more
                                         of the expressions. The node that is most
                                         preferred is the one with the greatest sum
-                                        of weights, i.e. for each node that meets
-                                        all of the scheduling requirements (resource
-                                        request, requiredDuringScheduling anti-affinity
-                                        expressions, etc.), compute a sum by iterating
-                                        through the elements of this field and adding
-                                        "weight" to the sum if the node has pods which
-                                        matches the corresponding podAffinityTerm;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                        of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -860,9 +815,7 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                  means "this pod's namespace".
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -944,8 +897,7 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                  selected pods i
                                                 type: string
                                             required:
                                             - topologyKey
@@ -967,12 +919,7 @@ spec:
                                         time, the pod will not be scheduled onto the
                                         node. If the anti-affinity requirements specified
                                         by this field cease to be met at some point
-                                        during pod execution (e.g. due to a pod label
-                                        update), the system may or may not try to
-                                        eventually evict the pod from its node. When
-                                        there are multiple elements, the lists of
-                                        nodes corresponding to each podAffinityTerm
-                                        are intersected, i.e. all terms must be satisfied.
+                                        during pod execution (e.g.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -981,8 +928,7 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                          that of an
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -1050,7 +996,6 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1126,8 +1071,7 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                              of the selected pods i
                                             type: string
                                         required:
                                         - topologyKey
@@ -1150,34 +1094,22 @@ spec:
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
+                                    description: Arguments to the entrypoint. The
+                                      container image's CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
+                                      expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The container image's ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
+                                      $(VAR_NAME) are expanded using the container's
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -1193,19 +1125,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1315,11 +1241,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1386,7 +1308,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1400,10 +1322,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1487,21 +1406,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1515,10 +1425,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1619,10 +1526,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -1748,19 +1652,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -1781,10 +1673,7 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
-                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                      Cannot be updated.
+                                      from the network.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -1845,10 +1734,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -1974,19 +1860,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2034,15 +1908,11 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -2081,7 +1951,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -2096,7 +1966,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -2106,10 +1976,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -2118,8 +1985,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -2127,11 +1993,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2188,8 +2050,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -2211,13 +2072,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -2232,16 +2087,11 @@ spec:
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the
-                                      Pod has successfully initialized. If specified,
+                                    description: StartupProbe indicates that the Pod
+                                      has successfully initialized. If specified,
                                       no other probes are executed until this completes
                                       successfully. If this probe fails, the Pod will
                                       be restarted, just as if the livenessProbe failed.
-                                      This can be used to provide different probe
-                                      parameters at the beginning of a Pod''s lifecycle,
-                                      when it might take a long time to load data
-                                      or warm a cache, than during steady-state operation.
-                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
@@ -2255,10 +2105,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -2384,19 +2231,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2418,15 +2253,7 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -2435,21 +2262,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -2578,9 +2397,7 @@ spec:
                                 "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
                                 'ClusterFirst', 'Default' or 'None'. DNS parameters
                                 given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy. To have DNS options set along
-                                with hostNetwork, you have to specify DNS policy explicitly
-                                to 'ClusterFirstWithHostNet'.
+                                selected with DNSPolicy.
                               type: string
                             enableServiceLinks:
                               description: 'EnableServiceLinks indicates whether information
@@ -2594,50 +2411,31 @@ spec:
                                 pod to perform user-initiated actions such as debugging.
                                 This list cannot be specified when creating a pod,
                                 and it cannot be modified by updating the pod spec.
-                                In order to add an ephemeral container to an existing
-                                pod, use the pod's ephemeralcontainers subresource.
                               items:
-                                description: "An EphemeralContainer is a temporary
+                                description: An EphemeralContainer is a temporary
                                   container that you may add to an existing Pod for
                                   user-initiated activities such as debugging. Ephemeral
                                   containers have no resource or scheduling guarantees,
                                   and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted. The kubelet
-                                  may evict a Pod if an ephemeral container causes
-                                  the Pod to exceed its resource allocation. \n To
-                                  add an ephemeral container, use the ephemeralcontainers
-                                  subresource of an existing Pod. Ephemeral containers
-                                  may not be removed or restarted."
+                                  when a Pod is removed or restarted.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      image''s CMD is used if this is not provided.
+                                    description: Arguments to the entrypoint. The
+                                      image's CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
+                                      using the container's environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the
-                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                      produce the string literal "$(VAR_NAME)". Escaped
-                                      references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The image''s ENTRYPOINT is used if
-                                      this is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container''s environment.
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The image's ENTRYPOINT is used if this
+                                      is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
@@ -2653,19 +2451,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -2775,11 +2567,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -2841,7 +2629,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2855,10 +2643,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2942,21 +2727,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2970,10 +2746,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3073,10 +2846,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -3202,19 +2972,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3291,10 +3049,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -3420,19 +3175,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3480,15 +3223,11 @@ spec:
                                       override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -3527,7 +3266,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -3542,7 +3281,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -3552,10 +3291,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -3564,8 +3300,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -3573,11 +3308,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3634,8 +3365,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -3657,13 +3387,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -3693,10 +3417,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -3822,19 +3543,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3856,26 +3565,15 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: "If set, the name of the container
+                                    description: If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
                                       then the ephemeral container uses the namespaces
-                                      configured in the Pod spec. \n The container
-                                      runtime must implement support for this feature.
-                                      If the runtime does not support namespace targeting
-                                      then the result of setting this field is undefined."
+                                      configured in the Pod spec.
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -3884,21 +3582,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -4024,13 +3714,7 @@ spec:
                                 pod will be run in the host user namespace, useful
                                 for when the pod needs a feature only available to
                                 the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE. When set to false, a new
-                                userns is created for the pod. Setting false is useful
-                                for mitigating container breakout vulnerabilities
-                                even allowing users to run their containers as root
-                                without actually having root privileges on the host.
-                                This field is alpha-level and is only honored by servers
-                                that enable the UserNamespacesSupport feature.'
+                                module with CAP_SYS_MODULE.'
                               type: boolean
                             hostname:
                               description: Specifies the hostname of the Pod If not
@@ -4043,7 +3727,7 @@ spec:
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
                                 puller implementations for them to use. More info:
-                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                https://kubernetes.'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -4059,55 +3743,32 @@ spec:
                                 x-kubernetes-map-type: atomic
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging
+                              description: List of initialization containers belonging
                                 to the pod. Init containers are executed in order
                                 prior to containers being started. If any init container
                                 fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy. The name for
-                                an init container or normal container must be unique
-                                among all containers. Init containers may not have
-                                Lifecycle actions, Readiness probes, Liveness probes,
-                                or Startup probes. The resourceRequirements of an
-                                init container are taken into account during scheduling
-                                by finding the highest request/limit for each resource
-                                type, and then using the max of of that value or the
-                                sum of the normal containers. Limits are applied to
-                                init containers in a similar fashion. Init containers
-                                cannot currently be added or removed. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                                handled according to its restartPolicy.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
+                                    description: Arguments to the entrypoint. The
+                                      container image's CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
+                                      expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The container image's ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
+                                      $(VAR_NAME) are expanded using the container's
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -4123,19 +3784,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -4245,11 +3900,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -4316,7 +3967,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4330,10 +3981,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4417,21 +4065,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4445,10 +4084,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4549,10 +4185,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -4678,19 +4311,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4711,10 +4332,7 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
-                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                      Cannot be updated.
+                                      from the network.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -4775,10 +4393,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -4904,19 +4519,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4964,15 +4567,11 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -5011,7 +4610,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -5026,7 +4625,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -5036,10 +4635,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -5048,8 +4644,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -5057,11 +4652,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -5118,8 +4709,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -5141,13 +4731,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -5162,16 +4746,11 @@ spec:
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the
-                                      Pod has successfully initialized. If specified,
+                                    description: StartupProbe indicates that the Pod
+                                      has successfully initialized. If specified,
                                       no other probes are executed until this completes
                                       successfully. If this probe fails, the Pod will
                                       be restarted, just as if the livenessProbe failed.
-                                      This can be used to provide different probe
-                                      parameters at the beginning of a Pod''s lifecycle,
-                                      when it might take a long time to load data
-                                      or warm a cache, than during steady-state operation.
-                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
@@ -5185,10 +4764,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -5314,19 +4890,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -5348,15 +4912,7 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -5365,21 +4921,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -5485,28 +5033,13 @@ spec:
                                 if this is set. \n If the OS field is set to linux,
                                 the following fields must be unset: -securityContext.windowsOptions
                                 \n If the OS field is set to windows, following fields
-                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
-                                - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
-                                - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
-                                - spec.securityContext.sysctls - spec.shareProcessNamespace
-                                - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
-                                - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions
-                                - spec.containers[*].securityContext.seccompProfile
-                                - spec.containers[*].securityContext.capabilities
-                                - spec.containers[*].securityContext.readOnlyRootFilesystem
-                                - spec.containers[*].securityContext.privileged -
-                                spec.containers[*].securityContext.allowPrivilegeEscalation
-                                - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                                - spec.containers[*].securityContext.runAsGroup"
+                                must be unset: - spec."
                               properties:
                                 name:
                                   description: 'Name is the name of the operating
                                     system. The currently supported values are linux
                                     and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                    Clients should expect to handle additional values
-                                    and treat unrecognized values in this field as
-                                    os: null'
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.'
                                   type: string
                               required:
                               - name
@@ -5518,18 +5051,12 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Overhead represents the resource overhead
+                              description: Overhead represents the resource overhead
                                 associated with running a pod for a given RuntimeClass.
                                 This field will be autopopulated at admission time
                                 by the RuntimeClass admission controller. If the RuntimeClass
                                 admission controller is enabled, overhead must not
-                                be set in Pod create requests. The RuntimeClass admission
-                                controller will reject Pod create requests which have
-                                the overhead already set. If RuntimeClass is configured
-                                and selected in the PodSpec, Overhead will be set
-                                to the value defined in the corresponding RuntimeClass,
-                                otherwise it will remain unset and treated as zero.
-                                More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                                be set in Pod create requests.
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
@@ -5551,8 +5078,7 @@ spec:
                                 are two special keywords which indicate the highest
                                 priorities with the former being the highest priority.
                                 Any other name must be defined by creating a PriorityClass
-                                object with that name. If not specified, the pod priority
-                                will be default or zero if there is no default.
+                                object with that name.
                               type: string
                             readinessGates:
                               description: 'If specified, all readiness gates will
@@ -5578,14 +5104,10 @@ spec:
                                 to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass
+                              description: RuntimeClassName refers to a RuntimeClass
                                 object in the node.k8s.io group, which should be used
                                 to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run. If unset
-                                or empty, the "legacy" RuntimeClass will be used,
-                                which is an implicit class with an empty definition
-                                that uses the default runtime handler. More info:
-                                https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                                the named class, the pod will not be run.
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -5605,24 +5127,15 @@ spec:
                                     of that volume to be owned by the pod: \n 1. The
                                     owning GID will be the FSGroup 2. The setgid bit
                                     is set (new files created in the volume will be
-                                    owned by FSGroup) 3. The permission bits are OR'd
-                                    with rw-rw---- \n If unset, the Kubelet will not
-                                    modify the ownership and permissions of any volume.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows."
+                                    owned by FSGroup) 3."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior
+                                  description: fsGroupChangePolicy defines behavior
                                     of changing ownership and permission of the volume
                                     before being exposed inside Pod. This field will
                                     only apply to volume types which support fsGroup
-                                    based ownership(and permissions). It will have
-                                    no effect on ephemeral volume types such as: secret,
-                                    configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified, "Always" is used.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.'
+                                    based ownership(and permissions).
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -5631,7 +5144,7 @@ spec:
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
                                     for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                    be set when spec.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -5641,9 +5154,7 @@ spec:
                                     does not run as UID 0 (root) and fail to start
                                     the container if it does. If unset or false, no
                                     such validation will be performed. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                    set in SecurityContext.
                                   type: boolean
                                 runAsUser:
                                   description: The UID to run the entrypoint of the
@@ -5652,19 +5163,13 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
                                   description: The SELinux context to be applied to
                                     all containers. If unspecified, the container
                                     runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                    for each container.  May also be set in SecurityContext.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5746,8 +5251,7 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                    Note that this field cannot be set when spec.os.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -5766,12 +5270,7 @@ spec:
                                         honored by components that enable the WindowsHostProcessContainers
                                         feature flag. Setting this field without the
                                         feature flag will result in errors when validating
-                                        the Pod. All of a Pod's containers must have
-                                        the same effective HostProcess value (it is
-                                        not allowed to have a mix of HostProcess containers
-                                        and non-HostProcess containers).  In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                        the Pod.
                                       type: boolean
                                     runAsUserName:
                                       description: The UserName in Windows to run
@@ -5799,20 +5298,14 @@ spec:
                                 as the pod's FQDN, rather than the leaf name (the
                                 default). In Linux containers, this means setting
                                 the FQDN in the hostname field of the kernel (the
-                                nodename field of struct utsname). In Windows containers,
-                                this means setting the registry value of hostname
-                                for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
-                                to FQDN. If a pod does not have FQDN, this has no
-                                effect. Default to false.
+                                nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between
+                              description: Share a single process namespace between
                                 all of the containers in a pod. When this is set containers
                                 will be able to view and signal processes from other
                                 containers in the same pod, and the first process
-                                in each container will not be assigned PID 1. HostPID
-                                and ShareProcessNamespace cannot both be set. Optional:
-                                Default to false.'
+                                in each container will not be assigned PID 1.
                               type: boolean
                             subdomain:
                               description: If specified, the fully qualified Pod hostname
@@ -5825,14 +5318,7 @@ spec:
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
                                 zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down). If this value is nil,
-                                the default grace period will be used instead. The
-                                grace period is the duration in seconds after the
-                                processes running in the pod are sent a termination
-                                signal and the time when the processes are forcibly
-                                halted with a kill signal. Set this value longer than
-                                the expected cleanup time for your process. Defaults
-                                to 30 seconds.
+                                (no opportunity to shut down).
                               format: int64
                               type: integer
                             tolerations:
@@ -5868,8 +5354,7 @@ spec:
                                       of effect NoExecute, otherwise this field is
                                       ignored) tolerates the taint. By default, it
                                       is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
+                                      (do not evict).
                                     format: int64
                                     type: integer
                                   value:
@@ -5946,98 +5431,44 @@ spec:
                                   matchLabelKeys:
                                     description: MatchLabelKeys is a set of pod label
                                       keys to select the pods over which spreading
-                                      will be calculated. The keys are used to lookup
-                                      values from the incoming pod labels, those key-value
-                                      labels are ANDed with labelSelector to select
-                                      the group of existing pods over which spreading
-                                      will be calculated for the incoming pod. Keys
-                                      that don't exist in the incoming pod labels
-                                      will be ignored. A null or empty list means
-                                      only match against labelSelector.
+                                      will be calculated.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   maxSkew:
-                                    description: 'MaxSkew describes the degree to
-                                      which pods may be unevenly distributed. When
-                                      `whenUnsatisfiable=DoNotSchedule`, it is the
-                                      maximum permitted difference between the number
-                                      of matching pods in the target topology and
-                                      the global minimum. The global minimum is the
-                                      minimum number of matching pods in an eligible
-                                      domain or zero if the number of eligible domains
-                                      is less than MinDomains. For example, in a 3-zone
-                                      cluster, MaxSkew is set to 1, and pods with
-                                      the same labelSelector spread as 2/2/1: In this
-                                      case, the global minimum is 1. | zone1 | zone2
-                                      | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
-                                      is 1, incoming pod can only be scheduled to
-                                      zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                                      would make the ActualSkew(3-1) on zone1(zone2)
-                                      violate MaxSkew(1). - if MaxSkew is 2, incoming
-                                      pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                                      it is used to give higher precedence to topologies
-                                      that satisfy it. It''s a required field. Default
-                                      value is 1 and 0 is not allowed.'
+                                    description: MaxSkew describes the degree to which
+                                      pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                      it is the maximum permitted difference between
+                                      the number of matching pods in the target topology
+                                      and the global minimum.
                                     format: int32
                                     type: integer
                                   minDomains:
-                                    description: "MinDomains indicates a minimum number
+                                    description: MinDomains indicates a minimum number
                                       of eligible domains. When the number of eligible
                                       domains with matching topology keys is less
                                       than minDomains, Pod Topology Spread treats
-                                      \"global minimum\" as 0, and then the calculation
-                                      of Skew is performed. And when the number of
-                                      eligible domains with matching topology keys
-                                      equals or greater than minDomains, this value
-                                      has no effect on scheduling. As a result, when
-                                      the number of eligible domains is less than
-                                      minDomains, scheduler won't schedule more than
-                                      maxSkew Pods to those domains. If value is nil,
-                                      the constraint behaves as if MinDomains is equal
-                                      to 1. Valid values are integers greater than
-                                      0. When value is not nil, WhenUnsatisfiable
-                                      must be DoNotSchedule. \n For example, in a
-                                      3-zone cluster, MaxSkew is set to 2, MinDomains
-                                      is set to 5 and pods with the same labelSelector
-                                      spread as 2/2/2: | zone1 | zone2 | zone3 | |
-                                      \ P P  |  P P  |  P P  | The number of domains
-                                      is less than 5(MinDomains), so \"global minimum\"
-                                      is treated as 0. In this situation, new pod
-                                      with the same labelSelector cannot be scheduled,
-                                      because computed skew will be 3(3 - 0) if new
-                                      Pod is scheduled to any of the three zones,
-                                      it will violate MaxSkew. \n This is a beta field
-                                      and requires the MinDomainsInPodTopologySpread
-                                      feature gate to be enabled (enabled by default)."
+                                      "global minimum" as 0, and then the calculation
+                                      of Skew is performed.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: "NodeAffinityPolicy indicates how
-                                      we will treat Pod's nodeAffinity/nodeSelector
+                                    description: 'NodeAffinityPolicy indicates how
+                                      we will treat Pod''s nodeAffinity/nodeSelector
                                       when calculating pod topology spread skew. Options
                                       are: - Honor: only nodes matching nodeAffinity/nodeSelector
                                       are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored. All nodes
-                                      are included in the calculations. \n If this
-                                      value is nil, the behavior is equivalent to
-                                      the Honor policy. This is a alpha-level feature
-                                      enabled by the NodeInclusionPolicyInPodTopologySpread
-                                      feature flag."
+                                      nodeAffinity/nodeSelector are ignored.'
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: "NodeTaintsPolicy indicates how we
+                                    description: 'NodeTaintsPolicy indicates how we
                                       will treat node taints when calculating pod
                                       topology spread skew. Options are: - Honor:
                                       nodes without taints, along with tainted nodes
                                       for which the incoming pod has a toleration,
                                       are included. - Ignore: node taints are ignored.
-                                      All nodes are included. \n If this value is
-                                      nil, the behavior is equivalent to the Ignore
-                                      policy. This is a alpha-level feature enabled
-                                      by the NodeInclusionPolicyInPodTopologySpread
-                                      feature flag."
+                                      All nodes are included.'
                                     type: string
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
@@ -6045,37 +5476,13 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket. We define a domain as a particular
-                                      instance of a topology. Also, we define an eligible
-                                      domain as a domain whose nodes meet the requirements
-                                      of nodeAffinityPolicy and nodeTaintsPolicy.
-                                      e.g. If TopologyKey is "kubernetes.io/hostname",
-                                      each Node is a domain of that topology. And,
-                                      if TopologyKey is "topology.kubernetes.io/zone",
-                                      each zone is a domain of that topology. It's
-                                      a required field.
+                                      each bucket.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: 'WhenUnsatisfiable indicates how
-                                      to deal with a pod if it doesn''t satisfy the
-                                      spread constraint. - DoNotSchedule (default)
-                                      tells the scheduler not to schedule it. - ScheduleAnyway
-                                      tells the scheduler to schedule the pod in any
-                                      location, but giving higher precedence to topologies
-                                      that would help reduce the skew. A constraint
-                                      is considered "Unsatisfiable" for an incoming
-                                      pod if and only if every possible node assignment
-                                      for that pod would violate "MaxSkew" on some
-                                      topology. For example, in a 3-zone cluster,
-                                      MaxSkew is set to 1, and pods with the same
-                                      labelSelector spread as 3/1/1: | zone1 | zone2
-                                      | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
-                                      is set to DoNotSchedule, incoming pod can only
-                                      be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
-                                      as ActualSkew(2-1) on zone2(zone3) satisfies
-                                      MaxSkew(1). In other words, the cluster can
-                                      still be imbalanced, but scheduler won''t make
-                                      it *more* imbalanced. It''s a required field.'
+                                    description: WhenUnsatisfiable indicates how to
+                                      deal with a pod if it doesn't satisfy the spread
+                                      constraint. - DoNotSchedule (default) tells
+                                      the scheduler not to schedule it.
                                     type: string
                                 required:
                                 - maxSkew
@@ -6108,9 +5515,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6295,12 +5700,7 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          values for mode bits. Defaults to 0644.'
                                         format: int32
                                         type: integer
                                       items:
@@ -6310,12 +5710,7 @@ spec:
                                           as a file whose name is the key and content
                                           is the value. If specified, the listed keys
                                           will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the ConfigMap, the volume setup will
-                                          error unless it is marked optional. Paths
-                                          must be relative and may not contain the
-                                          '..' path or start with '..'.
+                                          and unlisted keys will not be present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -6332,10 +5727,7 @@ spec:
                                                 and decimal values, JSON requires
                                                 decimal values for mode bits. If not
                                                 specified, the volume defaultMode
-                                                will be used. This might be in conflict
-                                                with other options that affect the
-                                                file mode, like fsGroup, and the result
-                                                can be other mode bits set.'
+                                                will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -6386,9 +5778,7 @@ spec:
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
                                           calls. This field is optional, and  may
-                                          be empty if no secret is required. If the
-                                          secret object contains more than one secret,
-                                          all secret references are passed.
+                                          be empty if no secret is required.
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -6424,14 +5814,7 @@ spec:
                                           mode bits used to set permissions on created
                                           files by default. Must be an octal value
                                           between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          between 0 and 511.'
                                         format: int32
                                         type: integer
                                       items:
@@ -6468,11 +5851,7 @@ spec:
                                                 and 511. YAML accepts both octal and
                                                 decimal values, JSON requires decimal
                                                 values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                                the volume defaultMode will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -6533,70 +5912,30 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'sizeLimit is the total amount
+                                        description: sizeLimit is the total amount
                                           of local storage required for this EmptyDir
                                           volume. The size limit is also applicable
                                           for memory medium. The maximum usage on
                                           memory medium EmptyDir would be the minimum
                                           value between the SizeLimit specified here
                                           and the sum of memory limits of all containers
-                                          in a pod. The default is nil which means
-                                          that the limit is undefined. More info:
-                                          http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                          in a pod.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: "ephemeral represents a volume that
+                                    description: ephemeral represents a volume that
                                       is handled by a cluster storage driver. The
                                       volume's lifecycle is tied to the pod that defines
                                       it - it will be created before the pod starts,
-                                      and deleted when the pod is removed. \n Use
-                                      this if: a) the volume is only needed while
-                                      the pod runs, b) features of normal volumes
-                                      like restoring from snapshot or capacity tracking
-                                      are needed, c) the storage driver is specified
-                                      through a storage class, and d) the storage
-                                      driver supports dynamic volume provisioning
-                                      through a PersistentVolumeClaim (see EphemeralVolumeSource
-                                      for more information on the connection between
-                                      this volume type and PersistentVolumeClaim).
-                                      \n Use PersistentVolumeClaim or one of the vendor-specific
-                                      APIs for volumes that persist for longer than
-                                      the lifecycle of an individual pod. \n Use CSI
-                                      for light-weight local ephemeral volumes if
-                                      the CSI driver is meant to be used that way
-                                      - see the documentation of the driver for more
-                                      information. \n A pod can use both types of
-                                      ephemeral volumes and persistent volumes at
-                                      the same time."
+                                      and deleted when the pod is removed.
                                     properties:
                                       volumeClaimTemplate:
-                                        description: "Will be used to create a stand-alone
+                                        description: Will be used to create a stand-alone
                                           PVC to provision the volume. The pod in
                                           which this EphemeralVolumeSource is embedded
                                           will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.  The
-                                          name of the PVC will be `<pod name>-<volume
-                                          name>` where `<volume name>` is the name
-                                          from the `PodSpec.Volumes` array entry.
-                                          Pod validation will reject the pod if the
-                                          concatenated name is not valid for a PVC
-                                          (for example, too long). \n An existing
-                                          PVC with that name that is not owned by
-                                          the pod will *not* be used for the pod to
-                                          avoid using an unrelated volume by mistake.
-                                          Starting the pod is then blocked until the
-                                          unrelated PVC is removed. If such a pre-created
-                                          PVC is meant to be used by the pod, the
-                                          PVC has to updated with an owner reference
-                                          to the pod once the pod exists. Normally
-                                          this should not be necessary, but it may
-                                          be useful when manually reconstructing a
-                                          broken cluster. \n This field is read-only
-                                          and no changes will be made by Kubernetes
-                                          to the PVC after it has been created. \n
-                                          Required, must not be nil."
+                                          will be deleted together with the pod.
                                         properties:
                                           metadata:
                                             description: May contain labels and annotations
@@ -6639,17 +5978,7 @@ spec:
                                               dataSource:
                                                 description: 'dataSource field can
                                                   be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                  * An existing PVC (PersistentVolumeClaim)
-                                                  If the provisioner or an external
-                                                  controller can support the specified
-                                                  data source, it will create a new
-                                                  volume based on the contents of
-                                                  the specified data source. If the
-                                                  AnyVolumeDataSource feature gate
-                                                  is enabled, this field will always
-                                                  have the same contents as the DataSourceRef
-                                                  field.'
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6674,38 +6003,13 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               dataSourceRef:
-                                                description: 'dataSourceRef specifies
+                                                description: dataSourceRef specifies
                                                   the object from which to populate
                                                   the volume with data, if a non-empty
                                                   volume is desired. This may be any
                                                   local object from a non-empty API
                                                   group (non core object) or a PersistentVolumeClaim
-                                                  object. When this field is specified,
-                                                  volume binding will only succeed
-                                                  if the type of the specified object
-                                                  matches some installed volume populator
-                                                  or dynamic provisioner. This field
-                                                  will replace the functionality of
-                                                  the DataSource field and as such
-                                                  if both fields are non-empty, they
-                                                  must have the same value. For backwards
-                                                  compatibility, both fields (DataSource
-                                                  and DataSourceRef) will be set to
-                                                  the same value automatically if
-                                                  one of them is empty and the other
-                                                  is non-empty. There are two important
-                                                  differences between DataSource and
-                                                  DataSourceRef: * While DataSource
-                                                  only allows two specific types of
-                                                  objects, DataSourceRef allows any
-                                                  non-core object, as well as PersistentVolumeClaim
-                                                  objects. * While DataSource ignores
-                                                  disallowed values (dropping them),
-                                                  DataSourceRef preserves all values,
-                                                  and generates an error if a disallowed
-                                                  value is specified. (Beta) Using
-                                                  this field requires the AnyVolumeDataSource
-                                                  feature gate to be enabled.'
+                                                  object.
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6730,7 +6034,7 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resources:
-                                                description: 'resources represents
+                                                description: resources represents
                                                   the minimum resources the volume
                                                   should have. If RecoverVolumeExpansionFailure
                                                   feature is enabled users are allowed
@@ -6738,7 +6042,7 @@ spec:
                                                   that are lower than previous value
                                                   but must still be higher than capacity
                                                   recorded in the status field of
-                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  the claim.
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -6967,9 +6271,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6978,7 +6280,7 @@ spec:
                                           Examples: For volume /dev/sda1, you specify
                                           the partition as "1". Similarly, the volume
                                           partition for /dev/sda is "0" (or you can
-                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          leave the property empty).'
                                         format: int32
                                         type: integer
                                       pdName:
@@ -7050,10 +6352,7 @@ spec:
                                       directly exposed to the container. This is generally
                                       used for system agents or other privileged things
                                       that are allowed to see the host machine. Most
-                                      containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                      --- TODO(jonesdl) We need to restrict who can
-                                      use host directory mounts and who can/can not
-                                      mount host directories as read/write.'
+                                      containers will NOT need this. More info: https://kubernetes.'
                                     properties:
                                       path:
                                         description: 'path of the directory on the
@@ -7088,9 +6387,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       initiatorName:
                                         description: initiatorName is the custom iSCSI
@@ -7247,11 +6544,7 @@ spec:
                                           0000 and 0777 or a decimal value between
                                           0 and 511. YAML accepts both octal and decimal
                                           values, JSON requires decimal values for
-                                          mode bits. Directories within the path are
-                                          not affected by this setting. This might
-                                          be in conflict with other options that affect
-                                          the file mode, like fsGroup, and the result
-                                          can be other mode bits set.
+                                          mode bits.
                                         format: int32
                                         type: integer
                                       sources:
@@ -7275,12 +6568,6 @@ spec:
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
-                                                    If a key is specified which is
-                                                    not present in the ConfigMap,
-                                                    the volume setup will error unless
-                                                    it is marked optional. Paths must
-                                                    be relative and may not contain
-                                                    the '..' path or start with '..'.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7300,12 +6587,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7380,12 +6662,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7449,12 +6726,6 @@ spec:
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
-                                                    If a key is specified which is
-                                                    not present in the Secret, the
-                                                    volume setup will error unless
-                                                    it is marked optional. Paths must
-                                                    be relative and may not contain
-                                                    the '..' path or start with '..'.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7474,12 +6745,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7531,13 +6797,7 @@ spec:
                                                     As the token approaches expiration,
                                                     the kubelet volume plugin will
                                                     proactively rotate the service
-                                                    account token. The kubelet will
-                                                    start trying to rotate the token
-                                                    if the token is older than 80
-                                                    percent of its time to live or
-                                                    if the token is older than 24
-                                                    hours.Defaults to 1 hour and must
-                                                    be at least 10 minutes.
+                                                    account token.
                                                   format: int64
                                                   type: integer
                                                 path:
@@ -7601,9 +6861,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       image:
                                         description: 'image is the rados image name.
@@ -7727,12 +6985,7 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          values for mode bits. Defaults to 0644.'
                                         format: int32
                                         type: integer
                                       items:
@@ -7742,12 +6995,7 @@ spec:
                                           as a file whose name is the key and content
                                           is the value. If specified, the listed keys
                                           will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the Secret, the volume setup will error
-                                          unless it is marked optional. Paths must
-                                          be relative and may not contain the '..'
-                                          path or start with '..'.
+                                          and unlisted keys will not be present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -7764,10 +7012,7 @@ spec:
                                                 and decimal values, JSON requires
                                                 decimal values for mode bits. If not
                                                 specified, the volume defaultMode
-                                                will be used. This might be in conflict
-                                                with other options that affect the
-                                                file mode, like fsGroup, and the result
-                                                can be other mode bits set.'
+                                                will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -7834,9 +7079,6 @@ spec:
                                           Kubernetes name scoping to be mirrored within
                                           StorageOS for tighter integration. Set VolumeName
                                           to any name to override the default behaviour.
-                                          Set to "default" if you are not using namespaces
-                                          within StorageOS. Namespaces that do not
-                                          pre-exist within StorageOS will be created.
                                         type: string
                                     type: object
                                   vsphereVolume:

--- a/manifests/base/crds/kubeflow.org_tfjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_tfjobs.yaml
@@ -161,7 +161,10 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e.
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.
                                       items:
                                         description: An empty preferred scheduling
                                           term matches all objects with implicit weight
@@ -204,6 +207,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -243,6 +248,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -270,7 +277,9 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g.
+                                        pod execution (e.g. due to an update), the
+                                        system may or may not try to eventually evict
+                                        the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
@@ -312,6 +321,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -351,6 +362,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -378,7 +391,10 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e.
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -459,7 +475,9 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace".
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -541,7 +559,8 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods i
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
@@ -563,7 +582,9 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g.
+                                        pod execution (e.g. due to a pod label update),
+                                        the system may or may not try to eventually
+                                        evict the pod from its node.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -572,7 +593,8 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of an
+                                          that of any node on which a pod of the set
+                                          of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -640,6 +662,7 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -715,7 +738,8 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods i
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -815,7 +839,9 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace".
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -897,7 +923,8 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods i
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
@@ -919,7 +946,9 @@ spec:
                                         time, the pod will not be scheduled onto the
                                         node. If the anti-affinity requirements specified
                                         by this field cease to be met at some point
-                                        during pod execution (e.g.
+                                        during pod execution (e.g. due to a pod label
+                                        update), the system may or may not try to
+                                        eventually evict the pod from its node.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -928,7 +957,8 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of an
+                                          that of any node on which a pod of the set
+                                          of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -996,6 +1026,7 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1071,7 +1102,8 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods i
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1094,22 +1126,26 @@ spec:
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      container image's CMD is used if this is not
+                                    description: 'Arguments to the entrypoint. The
+                                      container image''s CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container's environment.
+                                      expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The container image's ENTRYPOINT is
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The container image''s ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container's
+                                      $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -1125,13 +1161,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1241,7 +1280,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1308,7 +1351,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1322,7 +1365,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1412,6 +1458,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1425,7 +1473,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1526,7 +1577,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -1652,7 +1706,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -1673,7 +1729,9 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network.
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -1734,7 +1792,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -1860,7 +1921,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -1908,11 +1971,15 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -1951,7 +2018,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -1966,7 +2033,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -1985,7 +2052,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -1993,7 +2061,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2050,7 +2122,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -2105,7 +2178,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -2231,7 +2307,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2262,13 +2340,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -2397,7 +2481,9 @@ spec:
                                 "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
                                 'ClusterFirst', 'Default' or 'None'. DNS parameters
                                 given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy.
+                                selected with DNSPolicy. To have DNS options set along
+                                with hostNetwork, you have to specify DNS policy explicitly
+                                to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
                               description: 'EnableServiceLinks indicates whether information
@@ -2411,31 +2497,40 @@ spec:
                                 pod to perform user-initiated actions such as debugging.
                                 This list cannot be specified when creating a pod,
                                 and it cannot be modified by updating the pod spec.
+                                In order to add an ephemeral container to an existing
+                                pod, use the pod's ephemeralcontainers subresource.
                               items:
                                 description: An EphemeralContainer is a temporary
                                   container that you may add to an existing Pod for
                                   user-initiated activities such as debugging. Ephemeral
                                   containers have no resource or scheduling guarantees,
                                   and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted.
+                                  when a Pod is removed or restarted. The kubelet
+                                  may evict a Pod if an ephemeral container causes
+                                  the Pod to exceed its resource allocation.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      image's CMD is used if this is not provided.
+                                    description: 'Arguments to the entrypoint. The
+                                      image''s CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
-                                      using the container's environment. If a variable
+                                      using the container''s environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged.
+                                      string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the
+                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)".'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The image's ENTRYPOINT is used if this
-                                      is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container's environment.
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The image''s ENTRYPOINT is used if
+                                      this is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -2451,13 +2546,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -2567,7 +2665,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -2629,7 +2731,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2643,7 +2745,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2733,6 +2838,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2746,7 +2853,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2846,7 +2956,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -2972,7 +3085,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3049,7 +3164,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -3175,7 +3293,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3223,11 +3343,15 @@ spec:
                                       override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -3266,7 +3390,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -3281,7 +3405,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -3300,7 +3424,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -3308,7 +3433,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3365,7 +3494,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -3417,7 +3547,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -3543,7 +3676,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3568,12 +3703,13 @@ spec:
                                       sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container
+                                    description: "If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
                                       then the ephemeral container uses the namespaces
-                                      configured in the Pod spec.
+                                      configured in the Pod spec. \n The container
+                                      runtime must implement support for this feature."
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -3582,13 +3718,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -3714,7 +3856,8 @@ spec:
                                 pod will be run in the host user namespace, useful
                                 for when the pod needs a feature only available to
                                 the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE.'
+                                module with CAP_SYS_MODULE. When set to false, a new
+                                userns is created for the pod.'
                               type: boolean
                             hostname:
                               description: Specifies the hostname of the Pod If not
@@ -3727,7 +3870,7 @@ spec:
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
                                 puller implementations for them to use. More info:
-                                https://kubernetes.'
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -3747,28 +3890,34 @@ spec:
                                 to the pod. Init containers are executed in order
                                 prior to containers being started. If any init container
                                 fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy.
+                                handled according to its restartPolicy. The name for
+                                an init container or normal container must be unique
+                                among all containers.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      container image's CMD is used if this is not
+                                    description: 'Arguments to the entrypoint. The
+                                      container image''s CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container's environment.
+                                      expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The container image's ENTRYPOINT is
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The container image''s ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container's
+                                      $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -3784,13 +3933,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -3900,7 +4052,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -3967,7 +4123,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -3981,7 +4137,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4071,6 +4230,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4084,7 +4245,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4185,7 +4349,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4311,7 +4478,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4332,7 +4501,9 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network.
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -4393,7 +4564,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4519,7 +4693,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4567,11 +4743,15 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -4610,7 +4790,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -4625,7 +4805,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -4644,7 +4824,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -4652,7 +4833,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -4709,7 +4894,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -4764,7 +4950,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4890,7 +5079,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4921,13 +5112,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -5033,13 +5230,17 @@ spec:
                                 if this is set. \n If the OS field is set to linux,
                                 the following fields must be unset: -securityContext.windowsOptions
                                 \n If the OS field is set to windows, following fields
-                                must be unset: - spec."
+                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
+                                - spec.securityContext.seLinuxOptions - spec.securityContext."
                               properties:
                                 name:
                                   description: 'Name is the name of the operating
                                     system. The currently supported values are linux
                                     and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.'
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values
+                                    and treat unrecognized values in this field as
+                                    os: null'
                                   type: string
                               required:
                               - name
@@ -5056,7 +5257,9 @@ spec:
                                 This field will be autopopulated at admission time
                                 by the RuntimeClass admission controller. If the RuntimeClass
                                 admission controller is enabled, overhead must not
-                                be set in Pod create requests.
+                                be set in Pod create requests. The RuntimeClass admission
+                                controller will reject Pod create requests which have
+                                the overhead already set.
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
@@ -5078,7 +5281,8 @@ spec:
                                 are two special keywords which indicate the highest
                                 priorities with the former being the highest priority.
                                 Any other name must be defined by creating a PriorityClass
-                                object with that name.
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
                               type: string
                             readinessGates:
                               description: 'If specified, all readiness gates will
@@ -5104,10 +5308,14 @@ spec:
                                 to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: RuntimeClassName refers to a RuntimeClass
+                              description: 'RuntimeClassName refers to a RuntimeClass
                                 object in the node.k8s.io group, which should be used
                                 to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run.
+                                the named class, the pod will not be run. If unset
+                                or empty, the "legacy" RuntimeClass will be used,
+                                which is an implicit class with an empty definition
+                                that uses the default runtime handler. More info:
+                                https://git.k8s.'
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -5131,11 +5339,14 @@ spec:
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: fsGroupChangePolicy defines behavior
+                                  description: 'fsGroupChangePolicy defines behavior
                                     of changing ownership and permission of the volume
                                     before being exposed inside Pod. This field will
                                     only apply to volume types which support fsGroup
-                                    based ownership(and permissions).
+                                    based ownership(and permissions). It will have
+                                    no effect on ephemeral volume types such as: secret,
+                                    configmaps and emptydir. Valid values are "OnRootMismatch"
+                                    and "Always". If not specified, "Always" is used.'
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -5144,7 +5355,7 @@ spec:
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
                                     for that container. Note that this field cannot
-                                    be set when spec.
+                                    be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -5163,13 +5374,19 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
                                   description: The SELinux context to be applied to
                                     all containers. If unspecified, the container
                                     runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.
+                                    for each container.  May also be set in SecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5251,7 +5468,8 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -5301,11 +5519,13 @@ spec:
                                 nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: Share a single process namespace between
+                              description: 'Share a single process namespace between
                                 all of the containers in a pod. When this is set containers
                                 will be able to view and signal processes from other
                                 containers in the same pod, and the first process
-                                in each container will not be assigned PID 1.
+                                in each container will not be assigned PID 1. HostPID
+                                and ShareProcessNamespace cannot both be set. Optional:
+                                Default to false.'
                               type: boolean
                             subdomain:
                               description: If specified, the fully qualified Pod hostname
@@ -5318,7 +5538,8 @@ spec:
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
                                 zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down).
+                                (no opportunity to shut down). If this value is nil,
+                                the default grace period will be used instead.
                               format: int64
                               type: integer
                             tolerations:
@@ -5354,7 +5575,8 @@ spec:
                                       of effect NoExecute, otherwise this field is
                                       ignored) tolerates the taint. By default, it
                                       is not set, which means tolerate the taint forever
-                                      (do not evict).
+                                      (do not evict). Zero and negative values will
+                                      be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
@@ -5431,7 +5653,13 @@ spec:
                                   matchLabelKeys:
                                     description: MatchLabelKeys is a set of pod label
                                       keys to select the pods over which spreading
-                                      will be calculated.
+                                      will be calculated. The keys are used to lookup
+                                      values from the incoming pod labels, those key-value
+                                      labels are ANDed with labelSelector to select
+                                      the group of existing pods over which spreading
+                                      will be calculated for the incoming pod. Keys
+                                      that don't exist in the incoming pod labels
+                                      will be ignored.
                                     items:
                                       type: string
                                     type: array
@@ -5441,7 +5669,10 @@ spec:
                                       pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                                       it is the maximum permitted difference between
                                       the number of matching pods in the target topology
-                                      and the global minimum.
+                                      and the global minimum. The global minimum is
+                                      the minimum number of matching pods in an eligible
+                                      domain or zero if the number of eligible domains
+                                      is less than MinDomains.
                                     format: int32
                                     type: integer
                                   minDomains:
@@ -5450,25 +5681,33 @@ spec:
                                       domains with matching topology keys is less
                                       than minDomains, Pod Topology Spread treats
                                       "global minimum" as 0, and then the calculation
-                                      of Skew is performed.
+                                      of Skew is performed. And when the number of
+                                      eligible domains with matching topology keys
+                                      equals or greater than minDomains, this value
+                                      has no effect on scheduling.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: 'NodeAffinityPolicy indicates how
-                                      we will treat Pod''s nodeAffinity/nodeSelector
+                                    description: "NodeAffinityPolicy indicates how
+                                      we will treat Pod's nodeAffinity/nodeSelector
                                       when calculating pod topology spread skew. Options
                                       are: - Honor: only nodes matching nodeAffinity/nodeSelector
                                       are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored.'
+                                      nodeAffinity/nodeSelector are ignored. All nodes
+                                      are included in the calculations. \n If this
+                                      value is nil, the behavior is equivalent to
+                                      the Honor policy."
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: 'NodeTaintsPolicy indicates how we
+                                    description: "NodeTaintsPolicy indicates how we
                                       will treat node taints when calculating pod
                                       topology spread skew. Options are: - Honor:
                                       nodes without taints, along with tainted nodes
                                       for which the incoming pod has a toleration,
                                       are included. - Ignore: node taints are ignored.
-                                      All nodes are included.'
+                                      All nodes are included. \n If this value is
+                                      nil, the behavior is equivalent to the Ignore
+                                      policy."
                                     type: string
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
@@ -5476,13 +5715,17 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket.
+                                      each bucket. We define a domain as a particular
+                                      instance of a topology.
                                     type: string
                                   whenUnsatisfiable:
                                     description: WhenUnsatisfiable indicates how to
                                       deal with a pod if it doesn't satisfy the spread
                                       constraint. - DoNotSchedule (default) tells
-                                      the scheduler not to schedule it.
+                                      the scheduler not to schedule it. - ScheduleAnyway
+                                      tells the scheduler to schedule the pod in any
+                                      location, but giving higher precedence to topologies
+                                      that would help reduce the skew.
                                     type: string
                                 required:
                                 - maxSkew
@@ -5515,7 +5758,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -5700,7 +5945,9 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.'
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -5778,7 +6025,9 @@ spec:
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
                                           calls. This field is optional, and  may
-                                          be empty if no secret is required.
+                                          be empty if no secret is required. If the
+                                          secret object contains more than one secret,
+                                          all secret references are passed.
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5814,7 +6063,11 @@ spec:
                                           mode bits used to set permissions on created
                                           files by default. Must be an octal value
                                           between 0000 and 0777 or a decimal value
-                                          between 0 and 511.'
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -5912,14 +6165,16 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: sizeLimit is the total amount
+                                        description: 'sizeLimit is the total amount
                                           of local storage required for this EmptyDir
                                           volume. The size limit is also applicable
                                           for memory medium. The maximum usage on
                                           memory medium EmptyDir would be the minimum
                                           value between the SizeLimit specified here
                                           and the sum of memory limits of all containers
-                                          in a pod.
+                                          in a pod. The default is nil which means
+                                          that the limit is undefined. More info:
+                                          http://kubernetes.'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
@@ -5935,7 +6190,10 @@ spec:
                                           PVC to provision the volume. The pod in
                                           which this EphemeralVolumeSource is embedded
                                           will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.
+                                          will be deleted together with the pod.  The
+                                          name of the PVC will be `<pod name>-<volume
+                                          name>` where `<volume name>` is the name
+                                          from the `PodSpec.Volumes` array entry.
                                         properties:
                                           metadata:
                                             description: May contain labels and annotations
@@ -5978,7 +6236,13 @@ spec:
                                               dataSource:
                                                 description: 'dataSource field can
                                                   be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.'
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                  * An existing PVC (PersistentVolumeClaim)
+                                                  If the provisioner or an external
+                                                  controller can support the specified
+                                                  data source, it will create a new
+                                                  volume based on the contents of
+                                                  the specified data source.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6009,7 +6273,11 @@ spec:
                                                   volume is desired. This may be any
                                                   local object from a non-empty API
                                                   group (non core object) or a PersistentVolumeClaim
-                                                  object.
+                                                  object. When this field is specified,
+                                                  volume binding will only succeed
+                                                  if the type of the specified object
+                                                  matches some installed volume populator
+                                                  or dynamic provisioner.
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6034,7 +6302,7 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resources:
-                                                description: resources represents
+                                                description: 'resources represents
                                                   the minimum resources the volume
                                                   should have. If RecoverVolumeExpansionFailure
                                                   feature is enabled users are allowed
@@ -6042,7 +6310,7 @@ spec:
                                                   that are lower than previous value
                                                   but must still be higher than capacity
                                                   recorded in the status field of
-                                                  the claim.
+                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -6271,7 +6539,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6280,7 +6550,7 @@ spec:
                                           Examples: For volume /dev/sda1, you specify
                                           the partition as "1". Similarly, the volume
                                           partition for /dev/sda is "0" (or you can
-                                          leave the property empty).'
+                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
@@ -6387,7 +6657,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       initiatorName:
                                         description: initiatorName is the custom iSCSI
@@ -6544,7 +6816,8 @@ spec:
                                           0000 and 0777 or a decimal value between
                                           0 and 511. YAML accepts both octal and decimal
                                           values, JSON requires decimal values for
-                                          mode bits.
+                                          mode bits. Directories within the path are
+                                          not affected by this setting.
                                         format: int32
                                         type: integer
                                       sources:
@@ -6797,7 +7070,13 @@ spec:
                                                     As the token approaches expiration,
                                                     the kubelet volume plugin will
                                                     proactively rotate the service
-                                                    account token.
+                                                    account token. The kubelet will
+                                                    start trying to rotate the token
+                                                    if the token is older than 80
+                                                    percent of its time to live or
+                                                    if the token is older than 24
+                                                    hours.Defaults to 1 hour and must
+                                                    be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
@@ -6861,7 +7140,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       image:
                                         description: 'image is the rados image name.
@@ -6985,7 +7266,9 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.'
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -7079,6 +7362,8 @@ spec:
                                           Kubernetes name scoping to be mirrored within
                                           StorageOS for tighter integration. Set VolumeName
                                           to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces
+                                          within StorageOS.
                                         type: string
                                     type: object
                                   vsphereVolume:

--- a/manifests/base/crds/kubeflow.org_xgboostjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_xgboostjobs.yaml
@@ -153,15 +153,7 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node matches the corresponding matchExpressions;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                        with the greatest sum of weights, i.e.
                                       items:
                                         description: An empty preferred scheduling
                                           term matches all objects with implicit weight
@@ -204,8 +196,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -245,8 +235,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -274,9 +262,7 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g. due to an update), the
-                                        system may or may not try to eventually evict
-                                        the pod from its node.
+                                        pod execution (e.g.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
@@ -318,8 +304,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -359,8 +343,6 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -388,15 +370,7 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.), compute a sum
-                                        by iterating through the elements of this
-                                        field and adding "weight" to the sum if the
-                                        node has pods which matches the corresponding
-                                        podAffinityTerm; the node(s) with the highest
-                                        sum are the most preferred.
+                                        with the greatest sum of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -477,9 +451,7 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                  means "this pod's namespace".
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -561,8 +533,7 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                  selected pods i
                                                 type: string
                                             required:
                                             - topologyKey
@@ -584,12 +555,7 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g. due to a pod label update),
-                                        the system may or may not try to eventually
-                                        evict the pod from its node. When there are
-                                        multiple elements, the lists of nodes corresponding
-                                        to each podAffinityTerm are intersected, i.e.
-                                        all terms must be satisfied.
+                                        pod execution (e.g.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -598,8 +564,7 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                          that of an
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -667,7 +632,6 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -743,8 +707,7 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                              of the selected pods i
                                             type: string
                                         required:
                                         - topologyKey
@@ -763,15 +726,7 @@ spec:
                                         may choose a node that violates one or more
                                         of the expressions. The node that is most
                                         preferred is the one with the greatest sum
-                                        of weights, i.e. for each node that meets
-                                        all of the scheduling requirements (resource
-                                        request, requiredDuringScheduling anti-affinity
-                                        expressions, etc.), compute a sum by iterating
-                                        through the elements of this field and adding
-                                        "weight" to the sum if the node has pods which
-                                        matches the corresponding podAffinityTerm;
-                                        the node(s) with the highest sum are the most
-                                        preferred.
+                                        of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -852,9 +807,7 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                  means "this pod's namespace".
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -936,8 +889,7 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                  selected pods i
                                                 type: string
                                             required:
                                             - topologyKey
@@ -959,12 +911,7 @@ spec:
                                         time, the pod will not be scheduled onto the
                                         node. If the anti-affinity requirements specified
                                         by this field cease to be met at some point
-                                        during pod execution (e.g. due to a pod label
-                                        update), the system may or may not try to
-                                        eventually evict the pod from its node. When
-                                        there are multiple elements, the lists of
-                                        nodes corresponding to each podAffinityTerm
-                                        are intersected, i.e. all terms must be satisfied.
+                                        during pod execution (e.g.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -973,8 +920,7 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                          that of an
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -1042,7 +988,6 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1118,8 +1063,7 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                              of the selected pods i
                                             type: string
                                         required:
                                         - topologyKey
@@ -1142,34 +1086,22 @@ spec:
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
+                                    description: Arguments to the entrypoint. The
+                                      container image's CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
+                                      expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The container image's ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
+                                      $(VAR_NAME) are expanded using the container's
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -1185,19 +1117,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1307,11 +1233,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1378,7 +1300,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1392,10 +1314,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1479,21 +1398,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1507,10 +1417,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1611,10 +1518,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -1740,19 +1644,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -1773,10 +1665,7 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
-                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                      Cannot be updated.
+                                      from the network.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -1837,10 +1726,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -1966,19 +1852,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2026,15 +1900,11 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -2073,7 +1943,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -2088,7 +1958,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -2098,10 +1968,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -2110,8 +1977,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -2119,11 +1985,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2180,8 +2042,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -2203,13 +2064,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -2224,16 +2079,11 @@ spec:
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the
-                                      Pod has successfully initialized. If specified,
+                                    description: StartupProbe indicates that the Pod
+                                      has successfully initialized. If specified,
                                       no other probes are executed until this completes
                                       successfully. If this probe fails, the Pod will
                                       be restarted, just as if the livenessProbe failed.
-                                      This can be used to provide different probe
-                                      parameters at the beginning of a Pod''s lifecycle,
-                                      when it might take a long time to load data
-                                      or warm a cache, than during steady-state operation.
-                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
@@ -2247,10 +2097,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -2376,19 +2223,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2410,15 +2245,7 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -2427,21 +2254,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -2570,9 +2389,7 @@ spec:
                                 "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
                                 'ClusterFirst', 'Default' or 'None'. DNS parameters
                                 given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy. To have DNS options set along
-                                with hostNetwork, you have to specify DNS policy explicitly
-                                to 'ClusterFirstWithHostNet'.
+                                selected with DNSPolicy.
                               type: string
                             enableServiceLinks:
                               description: 'EnableServiceLinks indicates whether information
@@ -2586,50 +2403,31 @@ spec:
                                 pod to perform user-initiated actions such as debugging.
                                 This list cannot be specified when creating a pod,
                                 and it cannot be modified by updating the pod spec.
-                                In order to add an ephemeral container to an existing
-                                pod, use the pod's ephemeralcontainers subresource.
                               items:
-                                description: "An EphemeralContainer is a temporary
+                                description: An EphemeralContainer is a temporary
                                   container that you may add to an existing Pod for
                                   user-initiated activities such as debugging. Ephemeral
                                   containers have no resource or scheduling guarantees,
                                   and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted. The kubelet
-                                  may evict a Pod if an ephemeral container causes
-                                  the Pod to exceed its resource allocation. \n To
-                                  add an ephemeral container, use the ephemeralcontainers
-                                  subresource of an existing Pod. Ephemeral containers
-                                  may not be removed or restarted."
+                                  when a Pod is removed or restarted.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      image''s CMD is used if this is not provided.
+                                    description: Arguments to the entrypoint. The
+                                      image's CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
+                                      using the container's environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the
-                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                      produce the string literal "$(VAR_NAME)". Escaped
-                                      references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The image''s ENTRYPOINT is used if
-                                      this is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container''s environment.
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The image's ENTRYPOINT is used if this
+                                      is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
@@ -2645,19 +2443,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -2767,11 +2559,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -2833,7 +2621,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2847,10 +2635,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2934,21 +2719,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2962,10 +2738,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3065,10 +2838,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -3194,19 +2964,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3283,10 +3041,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -3412,19 +3167,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3472,15 +3215,11 @@ spec:
                                       override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -3519,7 +3258,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -3534,7 +3273,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -3544,10 +3283,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -3556,8 +3292,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -3565,11 +3300,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3626,8 +3357,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -3649,13 +3379,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -3685,10 +3409,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -3814,19 +3535,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3848,26 +3557,15 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: "If set, the name of the container
+                                    description: If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
                                       then the ephemeral container uses the namespaces
-                                      configured in the Pod spec. \n The container
-                                      runtime must implement support for this feature.
-                                      If the runtime does not support namespace targeting
-                                      then the result of setting this field is undefined."
+                                      configured in the Pod spec.
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -3876,21 +3574,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -4016,13 +3706,7 @@ spec:
                                 pod will be run in the host user namespace, useful
                                 for when the pod needs a feature only available to
                                 the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE. When set to false, a new
-                                userns is created for the pod. Setting false is useful
-                                for mitigating container breakout vulnerabilities
-                                even allowing users to run their containers as root
-                                without actually having root privileges on the host.
-                                This field is alpha-level and is only honored by servers
-                                that enable the UserNamespacesSupport feature.'
+                                module with CAP_SYS_MODULE.'
                               type: boolean
                             hostname:
                               description: Specifies the hostname of the Pod If not
@@ -4035,7 +3719,7 @@ spec:
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
                                 puller implementations for them to use. More info:
-                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                https://kubernetes.'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -4051,55 +3735,32 @@ spec:
                                 x-kubernetes-map-type: atomic
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging
+                              description: List of initialization containers belonging
                                 to the pod. Init containers are executed in order
                                 prior to containers being started. If any init container
                                 fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy. The name for
-                                an init container or normal container must be unique
-                                among all containers. Init containers may not have
-                                Lifecycle actions, Readiness probes, Liveness probes,
-                                or Startup probes. The resourceRequirements of an
-                                init container are taken into account during scheduling
-                                by finding the highest request/limit for each resource
-                                type, and then using the max of of that value or the
-                                sum of the normal containers. Limits are applied to
-                                init containers in a similar fashion. Init containers
-                                cannot currently be added or removed. Cannot be updated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                                handled according to its restartPolicy.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
+                                    description: Arguments to the entrypoint. The
+                                      container image's CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
+                                      expanded using the container's environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      in the input string will be unchanged.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
+                                    description: Entrypoint array. Not executed within
+                                      a shell. The container image's ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
+                                      $(VAR_NAME) are expanded using the container's
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                      will produce the string literal "$(VAR_NAME)".
-                                      Escaped references will never be expanded, regardless
-                                      of whether the variable exists or not. Cannot
-                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -4115,19 +3776,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
+                                          description: Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded,
-                                            regardless of whether the variable exists
-                                            or not. Defaults to "".'
+                                            unchanged.
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -4237,11 +3892,7 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                      the container is starting.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -4308,7 +3959,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          More info: https://kubernetes.'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4322,10 +3973,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4409,21 +4057,12 @@ spec:
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately
+                                        description: PreStop is called immediately
                                           before a container is terminated due to
                                           an API request or management event such
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The Pod''s termination grace period countdown
-                                          begins before the PreStop hook is executed.
-                                          Regardless of the outcome of the handler,
-                                          the container will eventually terminate
-                                          within the Pod''s termination grace period
-                                          (unless delayed by finalizers). Other management
-                                          of the container blocks until the hook completes
-                                          or until the termination grace period is
-                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4437,10 +4076,7 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                  work.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4541,10 +4177,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -4670,19 +4303,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4703,10 +4324,7 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
-                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                      Cannot be updated.
+                                      from the network.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -4767,10 +4385,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -4896,19 +4511,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4956,15 +4559,11 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
+                                        description: AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                          set on the container process.
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -5003,7 +4602,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                          spec.os.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -5018,7 +4617,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          be set when spec.os.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -5028,10 +4627,7 @@ spec:
                                           to ensure that it does not run as UID 0
                                           (root) and fail to start the container if
                                           it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence.
+                                          will be performed. May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
                                         description: The UID to run the entrypoint
@@ -5040,8 +4636,7 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                          precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -5049,11 +4644,7 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                          PodSecurityContext.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -5110,8 +4701,7 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                          that this field cannot be set when spec.os.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -5133,13 +4723,7 @@ spec:
                                               that enable the WindowsHostProcessContainers
                                               feature flag. Setting this field without
                                               the feature flag will result in errors
-                                              when validating the Pod. All of a Pod's
-                                              containers must have the same effective
-                                              HostProcess value (it is not allowed
-                                              to have a mix of HostProcess containers
-                                              and non-HostProcess containers).  In
-                                              addition, if HostProcess is true then
-                                              HostNetwork must also be set to true.
+                                              when validating the Pod.
                                             type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
@@ -5154,16 +4738,11 @@ spec:
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the
-                                      Pod has successfully initialized. If specified,
+                                    description: StartupProbe indicates that the Pod
+                                      has successfully initialized. If specified,
                                       no other probes are executed until this completes
                                       successfully. If this probe fails, the Pod will
                                       be restarted, just as if the livenessProbe failed.
-                                      This can be used to provide different probe
-                                      parameters at the beginning of a Pod''s lifecycle,
-                                      when it might take a long time to load data
-                                      or warm a cache, than during steady-state operation.
-                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
@@ -5177,10 +4756,7 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                              work.
                                             items:
                                               type: string
                                             type: array
@@ -5306,19 +4882,7 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process. If this value is nil, the
-                                          pod's terminationGracePeriodSeconds will
-                                          be used. Otherwise, this value overrides
-                                          the value provided by the pod spec. Value
-                                          must be non-negative integer. The value
-                                          zero indicates stop immediately via the
-                                          kill signal (no opportunity to shut down).
-                                          This is a beta field and requires enabling
-                                          ProbeTerminationGracePeriod feature gate.
-                                          Minimum value is 1. spec.terminationGracePeriodSeconds
-                                          is used if unset.
+                                          halted with a kill signal.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -5340,15 +4904,7 @@ spec:
                                       close the stdin channel after it has been opened
                                       by a single attach. When stdin is true the stdin
                                       stream will remain open across multiple attach
-                                      sessions. If stdinOnce is set to true, stdin
-                                      is opened on container start, is empty until
-                                      the first client attaches to stdin, and then
-                                      remains open and accepts data until the client
-                                      disconnects, at which time stdin is closed and
-                                      remains closed until the container is restarted.
-                                      If this flag is false, a container processes
-                                      that reads from stdin will never receive an
-                                      EOF. Default is false
+                                      sessions.
                                     type: boolean
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -5357,21 +4913,13 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log. Cannot be updated.'
+                                      than 4096 bytes.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error. The log output is limited to 2048
-                                      bytes or 80 lines, whichever is smaller. Defaults
-                                      to File. Cannot be updated.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -5477,28 +5025,13 @@ spec:
                                 if this is set. \n If the OS field is set to linux,
                                 the following fields must be unset: -securityContext.windowsOptions
                                 \n If the OS field is set to windows, following fields
-                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
-                                - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
-                                - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
-                                - spec.securityContext.sysctls - spec.shareProcessNamespace
-                                - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
-                                - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions
-                                - spec.containers[*].securityContext.seccompProfile
-                                - spec.containers[*].securityContext.capabilities
-                                - spec.containers[*].securityContext.readOnlyRootFilesystem
-                                - spec.containers[*].securityContext.privileged -
-                                spec.containers[*].securityContext.allowPrivilegeEscalation
-                                - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
-                                - spec.containers[*].securityContext.runAsGroup"
+                                must be unset: - spec."
                               properties:
                                 name:
                                   description: 'Name is the name of the operating
                                     system. The currently supported values are linux
                                     and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                    Clients should expect to handle additional values
-                                    and treat unrecognized values in this field as
-                                    os: null'
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.'
                                   type: string
                               required:
                               - name
@@ -5510,18 +5043,12 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Overhead represents the resource overhead
+                              description: Overhead represents the resource overhead
                                 associated with running a pod for a given RuntimeClass.
                                 This field will be autopopulated at admission time
                                 by the RuntimeClass admission controller. If the RuntimeClass
                                 admission controller is enabled, overhead must not
-                                be set in Pod create requests. The RuntimeClass admission
-                                controller will reject Pod create requests which have
-                                the overhead already set. If RuntimeClass is configured
-                                and selected in the PodSpec, Overhead will be set
-                                to the value defined in the corresponding RuntimeClass,
-                                otherwise it will remain unset and treated as zero.
-                                More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                                be set in Pod create requests.
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
@@ -5543,8 +5070,7 @@ spec:
                                 are two special keywords which indicate the highest
                                 priorities with the former being the highest priority.
                                 Any other name must be defined by creating a PriorityClass
-                                object with that name. If not specified, the pod priority
-                                will be default or zero if there is no default.
+                                object with that name.
                               type: string
                             readinessGates:
                               description: 'If specified, all readiness gates will
@@ -5570,14 +5096,10 @@ spec:
                                 to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass
+                              description: RuntimeClassName refers to a RuntimeClass
                                 object in the node.k8s.io group, which should be used
                                 to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run. If unset
-                                or empty, the "legacy" RuntimeClass will be used,
-                                which is an implicit class with an empty definition
-                                that uses the default runtime handler. More info:
-                                https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                                the named class, the pod will not be run.
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -5597,24 +5119,15 @@ spec:
                                     of that volume to be owned by the pod: \n 1. The
                                     owning GID will be the FSGroup 2. The setgid bit
                                     is set (new files created in the volume will be
-                                    owned by FSGroup) 3. The permission bits are OR'd
-                                    with rw-rw---- \n If unset, the Kubelet will not
-                                    modify the ownership and permissions of any volume.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows."
+                                    owned by FSGroup) 3."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior
+                                  description: fsGroupChangePolicy defines behavior
                                     of changing ownership and permission of the volume
                                     before being exposed inside Pod. This field will
                                     only apply to volume types which support fsGroup
-                                    based ownership(and permissions). It will have
-                                    no effect on ephemeral volume types such as: secret,
-                                    configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified, "Always" is used.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.'
+                                    based ownership(and permissions).
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -5623,7 +5136,7 @@ spec:
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
                                     for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                    be set when spec.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -5633,9 +5146,7 @@ spec:
                                     does not run as UID 0 (root) and fail to start
                                     the container if it does. If unset or false, no
                                     such validation will be performed. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence.
+                                    set in SecurityContext.
                                   type: boolean
                                 runAsUser:
                                   description: The UID to run the entrypoint of the
@@ -5644,19 +5155,13 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
                                   description: The SELinux context to be applied to
                                     all containers. If unspecified, the container
                                     runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                    for each container.  May also be set in SecurityContext.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5738,8 +5243,7 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                    Note that this field cannot be set when spec.os.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -5758,12 +5262,7 @@ spec:
                                         honored by components that enable the WindowsHostProcessContainers
                                         feature flag. Setting this field without the
                                         feature flag will result in errors when validating
-                                        the Pod. All of a Pod's containers must have
-                                        the same effective HostProcess value (it is
-                                        not allowed to have a mix of HostProcess containers
-                                        and non-HostProcess containers).  In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                        the Pod.
                                       type: boolean
                                     runAsUserName:
                                       description: The UserName in Windows to run
@@ -5791,20 +5290,14 @@ spec:
                                 as the pod's FQDN, rather than the leaf name (the
                                 default). In Linux containers, this means setting
                                 the FQDN in the hostname field of the kernel (the
-                                nodename field of struct utsname). In Windows containers,
-                                this means setting the registry value of hostname
-                                for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
-                                to FQDN. If a pod does not have FQDN, this has no
-                                effect. Default to false.
+                                nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between
+                              description: Share a single process namespace between
                                 all of the containers in a pod. When this is set containers
                                 will be able to view and signal processes from other
                                 containers in the same pod, and the first process
-                                in each container will not be assigned PID 1. HostPID
-                                and ShareProcessNamespace cannot both be set. Optional:
-                                Default to false.'
+                                in each container will not be assigned PID 1.
                               type: boolean
                             subdomain:
                               description: If specified, the fully qualified Pod hostname
@@ -5817,14 +5310,7 @@ spec:
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
                                 zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down). If this value is nil,
-                                the default grace period will be used instead. The
-                                grace period is the duration in seconds after the
-                                processes running in the pod are sent a termination
-                                signal and the time when the processes are forcibly
-                                halted with a kill signal. Set this value longer than
-                                the expected cleanup time for your process. Defaults
-                                to 30 seconds.
+                                (no opportunity to shut down).
                               format: int64
                               type: integer
                             tolerations:
@@ -5860,8 +5346,7 @@ spec:
                                       of effect NoExecute, otherwise this field is
                                       ignored) tolerates the taint. By default, it
                                       is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
+                                      (do not evict).
                                     format: int64
                                     type: integer
                                   value:
@@ -5938,98 +5423,44 @@ spec:
                                   matchLabelKeys:
                                     description: MatchLabelKeys is a set of pod label
                                       keys to select the pods over which spreading
-                                      will be calculated. The keys are used to lookup
-                                      values from the incoming pod labels, those key-value
-                                      labels are ANDed with labelSelector to select
-                                      the group of existing pods over which spreading
-                                      will be calculated for the incoming pod. Keys
-                                      that don't exist in the incoming pod labels
-                                      will be ignored. A null or empty list means
-                                      only match against labelSelector.
+                                      will be calculated.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   maxSkew:
-                                    description: 'MaxSkew describes the degree to
-                                      which pods may be unevenly distributed. When
-                                      `whenUnsatisfiable=DoNotSchedule`, it is the
-                                      maximum permitted difference between the number
-                                      of matching pods in the target topology and
-                                      the global minimum. The global minimum is the
-                                      minimum number of matching pods in an eligible
-                                      domain or zero if the number of eligible domains
-                                      is less than MinDomains. For example, in a 3-zone
-                                      cluster, MaxSkew is set to 1, and pods with
-                                      the same labelSelector spread as 2/2/1: In this
-                                      case, the global minimum is 1. | zone1 | zone2
-                                      | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
-                                      is 1, incoming pod can only be scheduled to
-                                      zone3 to become 2/2/2; scheduling it onto zone1(zone2)
-                                      would make the ActualSkew(3-1) on zone1(zone2)
-                                      violate MaxSkew(1). - if MaxSkew is 2, incoming
-                                      pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                                      it is used to give higher precedence to topologies
-                                      that satisfy it. It''s a required field. Default
-                                      value is 1 and 0 is not allowed.'
+                                    description: MaxSkew describes the degree to which
+                                      pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                      it is the maximum permitted difference between
+                                      the number of matching pods in the target topology
+                                      and the global minimum.
                                     format: int32
                                     type: integer
                                   minDomains:
-                                    description: "MinDomains indicates a minimum number
+                                    description: MinDomains indicates a minimum number
                                       of eligible domains. When the number of eligible
                                       domains with matching topology keys is less
                                       than minDomains, Pod Topology Spread treats
-                                      \"global minimum\" as 0, and then the calculation
-                                      of Skew is performed. And when the number of
-                                      eligible domains with matching topology keys
-                                      equals or greater than minDomains, this value
-                                      has no effect on scheduling. As a result, when
-                                      the number of eligible domains is less than
-                                      minDomains, scheduler won't schedule more than
-                                      maxSkew Pods to those domains. If value is nil,
-                                      the constraint behaves as if MinDomains is equal
-                                      to 1. Valid values are integers greater than
-                                      0. When value is not nil, WhenUnsatisfiable
-                                      must be DoNotSchedule. \n For example, in a
-                                      3-zone cluster, MaxSkew is set to 2, MinDomains
-                                      is set to 5 and pods with the same labelSelector
-                                      spread as 2/2/2: | zone1 | zone2 | zone3 | |
-                                      \ P P  |  P P  |  P P  | The number of domains
-                                      is less than 5(MinDomains), so \"global minimum\"
-                                      is treated as 0. In this situation, new pod
-                                      with the same labelSelector cannot be scheduled,
-                                      because computed skew will be 3(3 - 0) if new
-                                      Pod is scheduled to any of the three zones,
-                                      it will violate MaxSkew. \n This is a beta field
-                                      and requires the MinDomainsInPodTopologySpread
-                                      feature gate to be enabled (enabled by default)."
+                                      "global minimum" as 0, and then the calculation
+                                      of Skew is performed.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: "NodeAffinityPolicy indicates how
-                                      we will treat Pod's nodeAffinity/nodeSelector
+                                    description: 'NodeAffinityPolicy indicates how
+                                      we will treat Pod''s nodeAffinity/nodeSelector
                                       when calculating pod topology spread skew. Options
                                       are: - Honor: only nodes matching nodeAffinity/nodeSelector
                                       are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored. All nodes
-                                      are included in the calculations. \n If this
-                                      value is nil, the behavior is equivalent to
-                                      the Honor policy. This is a alpha-level feature
-                                      enabled by the NodeInclusionPolicyInPodTopologySpread
-                                      feature flag."
+                                      nodeAffinity/nodeSelector are ignored.'
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: "NodeTaintsPolicy indicates how we
+                                    description: 'NodeTaintsPolicy indicates how we
                                       will treat node taints when calculating pod
                                       topology spread skew. Options are: - Honor:
                                       nodes without taints, along with tainted nodes
                                       for which the incoming pod has a toleration,
                                       are included. - Ignore: node taints are ignored.
-                                      All nodes are included. \n If this value is
-                                      nil, the behavior is equivalent to the Ignore
-                                      policy. This is a alpha-level feature enabled
-                                      by the NodeInclusionPolicyInPodTopologySpread
-                                      feature flag."
+                                      All nodes are included.'
                                     type: string
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
@@ -6037,37 +5468,13 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket. We define a domain as a particular
-                                      instance of a topology. Also, we define an eligible
-                                      domain as a domain whose nodes meet the requirements
-                                      of nodeAffinityPolicy and nodeTaintsPolicy.
-                                      e.g. If TopologyKey is "kubernetes.io/hostname",
-                                      each Node is a domain of that topology. And,
-                                      if TopologyKey is "topology.kubernetes.io/zone",
-                                      each zone is a domain of that topology. It's
-                                      a required field.
+                                      each bucket.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: 'WhenUnsatisfiable indicates how
-                                      to deal with a pod if it doesn''t satisfy the
-                                      spread constraint. - DoNotSchedule (default)
-                                      tells the scheduler not to schedule it. - ScheduleAnyway
-                                      tells the scheduler to schedule the pod in any
-                                      location, but giving higher precedence to topologies
-                                      that would help reduce the skew. A constraint
-                                      is considered "Unsatisfiable" for an incoming
-                                      pod if and only if every possible node assignment
-                                      for that pod would violate "MaxSkew" on some
-                                      topology. For example, in a 3-zone cluster,
-                                      MaxSkew is set to 1, and pods with the same
-                                      labelSelector spread as 3/1/1: | zone1 | zone2
-                                      | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
-                                      is set to DoNotSchedule, incoming pod can only
-                                      be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
-                                      as ActualSkew(2-1) on zone2(zone3) satisfies
-                                      MaxSkew(1). In other words, the cluster can
-                                      still be imbalanced, but scheduler won''t make
-                                      it *more* imbalanced. It''s a required field.'
+                                    description: WhenUnsatisfiable indicates how to
+                                      deal with a pod if it doesn't satisfy the spread
+                                      constraint. - DoNotSchedule (default) tells
+                                      the scheduler not to schedule it.
                                     type: string
                                 required:
                                 - maxSkew
@@ -6100,9 +5507,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6287,12 +5692,7 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          values for mode bits. Defaults to 0644.'
                                         format: int32
                                         type: integer
                                       items:
@@ -6302,12 +5702,7 @@ spec:
                                           as a file whose name is the key and content
                                           is the value. If specified, the listed keys
                                           will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the ConfigMap, the volume setup will
-                                          error unless it is marked optional. Paths
-                                          must be relative and may not contain the
-                                          '..' path or start with '..'.
+                                          and unlisted keys will not be present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -6324,10 +5719,7 @@ spec:
                                                 and decimal values, JSON requires
                                                 decimal values for mode bits. If not
                                                 specified, the volume defaultMode
-                                                will be used. This might be in conflict
-                                                with other options that affect the
-                                                file mode, like fsGroup, and the result
-                                                can be other mode bits set.'
+                                                will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -6378,9 +5770,7 @@ spec:
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
                                           calls. This field is optional, and  may
-                                          be empty if no secret is required. If the
-                                          secret object contains more than one secret,
-                                          all secret references are passed.
+                                          be empty if no secret is required.
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -6416,14 +5806,7 @@ spec:
                                           mode bits used to set permissions on created
                                           files by default. Must be an octal value
                                           between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          between 0 and 511.'
                                         format: int32
                                         type: integer
                                       items:
@@ -6460,11 +5843,7 @@ spec:
                                                 and 511. YAML accepts both octal and
                                                 decimal values, JSON requires decimal
                                                 values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                                the volume defaultMode will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -6525,70 +5904,30 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'sizeLimit is the total amount
+                                        description: sizeLimit is the total amount
                                           of local storage required for this EmptyDir
                                           volume. The size limit is also applicable
                                           for memory medium. The maximum usage on
                                           memory medium EmptyDir would be the minimum
                                           value between the SizeLimit specified here
                                           and the sum of memory limits of all containers
-                                          in a pod. The default is nil which means
-                                          that the limit is undefined. More info:
-                                          http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                          in a pod.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: "ephemeral represents a volume that
+                                    description: ephemeral represents a volume that
                                       is handled by a cluster storage driver. The
                                       volume's lifecycle is tied to the pod that defines
                                       it - it will be created before the pod starts,
-                                      and deleted when the pod is removed. \n Use
-                                      this if: a) the volume is only needed while
-                                      the pod runs, b) features of normal volumes
-                                      like restoring from snapshot or capacity tracking
-                                      are needed, c) the storage driver is specified
-                                      through a storage class, and d) the storage
-                                      driver supports dynamic volume provisioning
-                                      through a PersistentVolumeClaim (see EphemeralVolumeSource
-                                      for more information on the connection between
-                                      this volume type and PersistentVolumeClaim).
-                                      \n Use PersistentVolumeClaim or one of the vendor-specific
-                                      APIs for volumes that persist for longer than
-                                      the lifecycle of an individual pod. \n Use CSI
-                                      for light-weight local ephemeral volumes if
-                                      the CSI driver is meant to be used that way
-                                      - see the documentation of the driver for more
-                                      information. \n A pod can use both types of
-                                      ephemeral volumes and persistent volumes at
-                                      the same time."
+                                      and deleted when the pod is removed.
                                     properties:
                                       volumeClaimTemplate:
-                                        description: "Will be used to create a stand-alone
+                                        description: Will be used to create a stand-alone
                                           PVC to provision the volume. The pod in
                                           which this EphemeralVolumeSource is embedded
                                           will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.  The
-                                          name of the PVC will be `<pod name>-<volume
-                                          name>` where `<volume name>` is the name
-                                          from the `PodSpec.Volumes` array entry.
-                                          Pod validation will reject the pod if the
-                                          concatenated name is not valid for a PVC
-                                          (for example, too long). \n An existing
-                                          PVC with that name that is not owned by
-                                          the pod will *not* be used for the pod to
-                                          avoid using an unrelated volume by mistake.
-                                          Starting the pod is then blocked until the
-                                          unrelated PVC is removed. If such a pre-created
-                                          PVC is meant to be used by the pod, the
-                                          PVC has to updated with an owner reference
-                                          to the pod once the pod exists. Normally
-                                          this should not be necessary, but it may
-                                          be useful when manually reconstructing a
-                                          broken cluster. \n This field is read-only
-                                          and no changes will be made by Kubernetes
-                                          to the PVC after it has been created. \n
-                                          Required, must not be nil."
+                                          will be deleted together with the pod.
                                         properties:
                                           metadata:
                                             description: May contain labels and annotations
@@ -6631,17 +5970,7 @@ spec:
                                               dataSource:
                                                 description: 'dataSource field can
                                                   be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                  * An existing PVC (PersistentVolumeClaim)
-                                                  If the provisioner or an external
-                                                  controller can support the specified
-                                                  data source, it will create a new
-                                                  volume based on the contents of
-                                                  the specified data source. If the
-                                                  AnyVolumeDataSource feature gate
-                                                  is enabled, this field will always
-                                                  have the same contents as the DataSourceRef
-                                                  field.'
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6666,38 +5995,13 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               dataSourceRef:
-                                                description: 'dataSourceRef specifies
+                                                description: dataSourceRef specifies
                                                   the object from which to populate
                                                   the volume with data, if a non-empty
                                                   volume is desired. This may be any
                                                   local object from a non-empty API
                                                   group (non core object) or a PersistentVolumeClaim
-                                                  object. When this field is specified,
-                                                  volume binding will only succeed
-                                                  if the type of the specified object
-                                                  matches some installed volume populator
-                                                  or dynamic provisioner. This field
-                                                  will replace the functionality of
-                                                  the DataSource field and as such
-                                                  if both fields are non-empty, they
-                                                  must have the same value. For backwards
-                                                  compatibility, both fields (DataSource
-                                                  and DataSourceRef) will be set to
-                                                  the same value automatically if
-                                                  one of them is empty and the other
-                                                  is non-empty. There are two important
-                                                  differences between DataSource and
-                                                  DataSourceRef: * While DataSource
-                                                  only allows two specific types of
-                                                  objects, DataSourceRef allows any
-                                                  non-core object, as well as PersistentVolumeClaim
-                                                  objects. * While DataSource ignores
-                                                  disallowed values (dropping them),
-                                                  DataSourceRef preserves all values,
-                                                  and generates an error if a disallowed
-                                                  value is specified. (Beta) Using
-                                                  this field requires the AnyVolumeDataSource
-                                                  feature gate to be enabled.'
+                                                  object.
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6722,7 +6026,7 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resources:
-                                                description: 'resources represents
+                                                description: resources represents
                                                   the minimum resources the volume
                                                   should have. If RecoverVolumeExpansionFailure
                                                   feature is enabled users are allowed
@@ -6730,7 +6034,7 @@ spec:
                                                   that are lower than previous value
                                                   but must still be higher than capacity
                                                   recorded in the status field of
-                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  the claim.
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -6959,9 +6263,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6970,7 +6272,7 @@ spec:
                                           Examples: For volume /dev/sda1, you specify
                                           the partition as "1". Similarly, the volume
                                           partition for /dev/sda is "0" (or you can
-                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          leave the property empty).'
                                         format: int32
                                         type: integer
                                       pdName:
@@ -7042,10 +6344,7 @@ spec:
                                       directly exposed to the container. This is generally
                                       used for system agents or other privileged things
                                       that are allowed to see the host machine. Most
-                                      containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                      --- TODO(jonesdl) We need to restrict who can
-                                      use host directory mounts and who can/can not
-                                      mount host directories as read/write.'
+                                      containers will NOT need this. More info: https://kubernetes.'
                                     properties:
                                       path:
                                         description: 'path of the directory on the
@@ -7080,9 +6379,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       initiatorName:
                                         description: initiatorName is the custom iSCSI
@@ -7239,11 +6536,7 @@ spec:
                                           0000 and 0777 or a decimal value between
                                           0 and 511. YAML accepts both octal and decimal
                                           values, JSON requires decimal values for
-                                          mode bits. Directories within the path are
-                                          not affected by this setting. This might
-                                          be in conflict with other options that affect
-                                          the file mode, like fsGroup, and the result
-                                          can be other mode bits set.
+                                          mode bits.
                                         format: int32
                                         type: integer
                                       sources:
@@ -7267,12 +6560,6 @@ spec:
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
-                                                    If a key is specified which is
-                                                    not present in the ConfigMap,
-                                                    the volume setup will error unless
-                                                    it is marked optional. Paths must
-                                                    be relative and may not contain
-                                                    the '..' path or start with '..'.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7292,12 +6579,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7372,12 +6654,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7441,12 +6718,6 @@ spec:
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
-                                                    If a key is specified which is
-                                                    not present in the Secret, the
-                                                    volume setup will error unless
-                                                    it is marked optional. Paths must
-                                                    be relative and may not contain
-                                                    the '..' path or start with '..'.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7466,12 +6737,7 @@ spec:
                                                           values, JSON requires decimal
                                                           values for mode bits. If
                                                           not specified, the volume
-                                                          defaultMode will be used.
-                                                          This might be in conflict
-                                                          with other options that
-                                                          affect the file mode, like
-                                                          fsGroup, and the result
-                                                          can be other mode bits set.'
+                                                          defaultMode will be used.'
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7523,13 +6789,7 @@ spec:
                                                     As the token approaches expiration,
                                                     the kubelet volume plugin will
                                                     proactively rotate the service
-                                                    account token. The kubelet will
-                                                    start trying to rotate the token
-                                                    if the token is older than 80
-                                                    percent of its time to live or
-                                                    if the token is older than 24
-                                                    hours.Defaults to 1 hour and must
-                                                    be at least 10 minutes.
+                                                    account token.
                                                   format: int64
                                                   type: integer
                                                 path:
@@ -7593,9 +6853,7 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                          https://kubernetes.'
                                         type: string
                                       image:
                                         description: 'image is the rados image name.
@@ -7719,12 +6977,7 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
+                                          values for mode bits. Defaults to 0644.'
                                         format: int32
                                         type: integer
                                       items:
@@ -7734,12 +6987,7 @@ spec:
                                           as a file whose name is the key and content
                                           is the value. If specified, the listed keys
                                           will be projected into the specified paths,
-                                          and unlisted keys will not be present. If
-                                          a key is specified which is not present
-                                          in the Secret, the volume setup will error
-                                          unless it is marked optional. Paths must
-                                          be relative and may not contain the '..'
-                                          path or start with '..'.
+                                          and unlisted keys will not be present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -7756,10 +7004,7 @@ spec:
                                                 and decimal values, JSON requires
                                                 decimal values for mode bits. If not
                                                 specified, the volume defaultMode
-                                                will be used. This might be in conflict
-                                                with other options that affect the
-                                                file mode, like fsGroup, and the result
-                                                can be other mode bits set.'
+                                                will be used.'
                                               format: int32
                                               type: integer
                                             path:
@@ -7826,9 +7071,6 @@ spec:
                                           Kubernetes name scoping to be mirrored within
                                           StorageOS for tighter integration. Set VolumeName
                                           to any name to override the default behaviour.
-                                          Set to "default" if you are not using namespaces
-                                          within StorageOS. Namespaces that do not
-                                          pre-exist within StorageOS will be created.
                                         type: string
                                     type: object
                                   vsphereVolume:

--- a/manifests/base/crds/kubeflow.org_xgboostjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_xgboostjobs.yaml
@@ -153,7 +153,10 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e.
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.
                                       items:
                                         description: An empty preferred scheduling
                                           term matches all objects with implicit weight
@@ -196,6 +199,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -235,6 +240,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -262,7 +269,9 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g.
+                                        pod execution (e.g. due to an update), the
+                                        system may or may not try to eventually evict
+                                        the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
@@ -304,6 +313,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -343,6 +354,8 @@ spec:
                                                         the values array must have
                                                         a single element, which will
                                                         be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -370,7 +383,10 @@ spec:
                                         specified by this field, but it may choose
                                         a node that violates one or more of the expressions.
                                         The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e.
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -451,7 +467,9 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace".
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -533,7 +551,8 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods i
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
@@ -555,7 +574,9 @@ spec:
                                         the pod will not be scheduled onto the node.
                                         If the affinity requirements specified by
                                         this field cease to be met at some point during
-                                        pod execution (e.g.
+                                        pod execution (e.g. due to a pod label update),
+                                        the system may or may not try to eventually
+                                        evict the pod from its node.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -564,7 +585,8 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of an
+                                          that of any node on which a pod of the set
+                                          of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -632,6 +654,7 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -707,7 +730,8 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods i
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -807,7 +831,9 @@ spec:
                                                   by this field and the ones listed
                                                   in the namespaces field. null selector
                                                   and null or empty namespaces list
-                                                  means "this pod's namespace".
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -889,7 +915,8 @@ spec:
                                                   on a node whose value of the label
                                                   with key topologyKey matches that
                                                   of any node on which any of the
-                                                  selected pods i
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
@@ -911,7 +938,9 @@ spec:
                                         time, the pod will not be scheduled onto the
                                         node. If the anti-affinity requirements specified
                                         by this field cease to be met at some point
-                                        during pod execution (e.g.
+                                        during pod execution (e.g. due to a pod label
+                                        update), the system may or may not try to
+                                        eventually evict the pod from its node.
                                       items:
                                         description: Defines a set of pods (namely
                                           those matching the labelSelector relative
@@ -920,7 +949,8 @@ spec:
                                           (anti-affinity) with, where co-located is
                                           defined as running on a node whose value
                                           of the label with key <topologyKey> matches
-                                          that of an
+                                          that of any node on which a pod of the set
+                                          of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -988,6 +1018,7 @@ spec:
                                               and the ones listed in the namespaces
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -1063,7 +1094,8 @@ spec:
                                               is defined as running on a node whose
                                               value of the label with key topologyKey
                                               matches that of any node on which any
-                                              of the selected pods i
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1086,22 +1118,26 @@ spec:
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      container image's CMD is used if this is not
+                                    description: 'Arguments to the entrypoint. The
+                                      container image''s CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container's environment.
+                                      expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The container image's ENTRYPOINT is
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The container image''s ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container's
+                                      $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -1117,13 +1153,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1233,7 +1272,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1300,7 +1343,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1314,7 +1357,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1404,6 +1450,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -1417,7 +1465,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1518,7 +1569,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -1644,7 +1698,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -1665,7 +1721,9 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network.
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -1726,7 +1784,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -1852,7 +1913,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -1900,11 +1963,15 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -1943,7 +2010,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -1958,7 +2025,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -1977,7 +2044,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -1985,7 +2053,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2042,7 +2114,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -2097,7 +2170,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -2223,7 +2299,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -2254,13 +2332,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -2389,7 +2473,9 @@ spec:
                                 "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
                                 'ClusterFirst', 'Default' or 'None'. DNS parameters
                                 given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy.
+                                selected with DNSPolicy. To have DNS options set along
+                                with hostNetwork, you have to specify DNS policy explicitly
+                                to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
                               description: 'EnableServiceLinks indicates whether information
@@ -2403,31 +2489,40 @@ spec:
                                 pod to perform user-initiated actions such as debugging.
                                 This list cannot be specified when creating a pod,
                                 and it cannot be modified by updating the pod spec.
+                                In order to add an ephemeral container to an existing
+                                pod, use the pod's ephemeralcontainers subresource.
                               items:
                                 description: An EphemeralContainer is a temporary
                                   container that you may add to an existing Pod for
                                   user-initiated activities such as debugging. Ephemeral
                                   containers have no resource or scheduling guarantees,
                                   and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted.
+                                  when a Pod is removed or restarted. The kubelet
+                                  may evict a Pod if an ephemeral container causes
+                                  the Pod to exceed its resource allocation.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      image's CMD is used if this is not provided.
+                                    description: 'Arguments to the entrypoint. The
+                                      image''s CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
-                                      using the container's environment. If a variable
+                                      using the container''s environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged.
+                                      string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the
+                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)".'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The image's ENTRYPOINT is used if this
-                                      is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container's environment.
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The image''s ENTRYPOINT is used if
+                                      this is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -2443,13 +2538,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -2559,7 +2657,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -2621,7 +2723,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2635,7 +2737,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2725,6 +2830,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -2738,7 +2845,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2838,7 +2948,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -2964,7 +3077,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3041,7 +3156,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -3167,7 +3285,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3215,11 +3335,15 @@ spec:
                                       override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -3258,7 +3382,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -3273,7 +3397,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -3292,7 +3416,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -3300,7 +3425,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3357,7 +3486,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -3409,7 +3539,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -3535,7 +3668,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -3560,12 +3695,13 @@ spec:
                                       sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container
+                                    description: "If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
                                       then the ephemeral container uses the namespaces
-                                      configured in the Pod spec.
+                                      configured in the Pod spec. \n The container
+                                      runtime must implement support for this feature."
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -3574,13 +3710,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -3706,7 +3848,8 @@ spec:
                                 pod will be run in the host user namespace, useful
                                 for when the pod needs a feature only available to
                                 the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE.'
+                                module with CAP_SYS_MODULE. When set to false, a new
+                                userns is created for the pod.'
                               type: boolean
                             hostname:
                               description: Specifies the hostname of the Pod If not
@@ -3719,7 +3862,7 @@ spec:
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
                                 puller implementations for them to use. More info:
-                                https://kubernetes.'
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -3739,28 +3882,34 @@ spec:
                                 to the pod. Init containers are executed in order
                                 prior to containers being started. If any init container
                                 fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy.
+                                handled according to its restartPolicy. The name for
+                                an init container or normal container must be unique
+                                among all containers.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: Arguments to the entrypoint. The
-                                      container image's CMD is used if this is not
+                                    description: 'Arguments to the entrypoint. The
+                                      container image''s CMD is used if this is not
                                       provided. Variable references $(VAR_NAME) are
-                                      expanded using the container's environment.
+                                      expanded using the container''s environment.
                                       If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged.
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: Entrypoint array. Not executed within
-                                      a shell. The container image's ENTRYPOINT is
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The container image''s ENTRYPOINT is
                                       used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container's
+                                      $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e.'
                                     items:
                                       type: string
                                     type: array
@@ -3776,13 +3925,16 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: Variable references $(VAR_NAME)
+                                          description: 'Variable references $(VAR_NAME)
                                             are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged.
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".'
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -3892,7 +4044,11 @@ spec:
                                       variables in the container. The keys defined
                                       within a source must be a C_IDENTIFIER. All
                                       invalid keys will be reported as an event when
-                                      the container is starting.
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -3959,7 +4115,7 @@ spec:
                                           fails, the container is terminated and restarted
                                           according to its restart policy. Other management
                                           of the container blocks until the hook completes.
-                                          More info: https://kubernetes.'
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -3973,7 +4129,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4063,6 +4222,8 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
+                                          The Pod's termination grace period countdown
+                                          begins before the PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
@@ -4076,7 +4237,10 @@ spec:
                                                   The command is simply exec'd, it
                                                   is not run inside a shell, so traditional
                                                   shell instructions ('|', etc) won't
-                                                  work.
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4177,7 +4341,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4303,7 +4470,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4324,7 +4493,9 @@ spec:
                                       prevent that port from being exposed. Any port
                                       which is listening on the default "0.0.0.0"
                                       address inside a container will be accessible
-                                      from the network.
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
@@ -4385,7 +4556,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4511,7 +4685,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4559,11 +4735,15 @@ spec:
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: AllowPrivilegeEscalation controls
+                                        description: 'AllowPrivilegeEscalation controls
                                           whether a process can gain more privileges
                                           than its parent process. This bool directly
                                           controls if the no_new_privs flag will be
-                                          set on the container process.
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
@@ -4602,7 +4782,7 @@ spec:
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when
-                                          spec.os.
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
@@ -4617,7 +4797,7 @@ spec:
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
                                           precedence. Note that this field cannot
-                                          be set when spec.os.
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -4636,7 +4816,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -4644,7 +4825,11 @@ spec:
                                           to the container. If unspecified, the container
                                           runtime will allocate a random SELinux context
                                           for each container.  May also be set in
-                                          PodSecurityContext.
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -4701,7 +4886,8 @@ spec:
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
                                           in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -4756,7 +4942,10 @@ spec:
                                               The command is simply exec'd, it is
                                               not run inside a shell, so traditional
                                               shell instructions ('|', etc) won't
-                                              work.
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
@@ -4882,7 +5071,9 @@ spec:
                                           in seconds after the processes running in
                                           the pod are sent a termination signal and
                                           the time when the processes are forcibly
-                                          halted with a kill signal.
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
@@ -4913,13 +5104,19 @@ spec:
                                       filesystem. Message written is intended to be
                                       brief final status, such as an assertion failure
                                       message. Will be truncated by the node if greater
-                                      than 4096 bytes.'
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log.'
                                     type: string
                                   terminationMessagePolicy:
                                     description: Indicate how the termination message
                                       should be populated. File will use the contents
                                       of terminationMessagePath to populate the container
                                       status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error.
                                     type: string
                                   tty:
                                     description: Whether this container should allocate
@@ -5025,13 +5222,17 @@ spec:
                                 if this is set. \n If the OS field is set to linux,
                                 the following fields must be unset: -securityContext.windowsOptions
                                 \n If the OS field is set to windows, following fields
-                                must be unset: - spec."
+                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
+                                - spec.securityContext.seLinuxOptions - spec.securityContext."
                               properties:
                                 name:
                                   description: 'Name is the name of the operating
                                     system. The currently supported values are linux
                                     and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.'
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values
+                                    and treat unrecognized values in this field as
+                                    os: null'
                                   type: string
                               required:
                               - name
@@ -5048,7 +5249,9 @@ spec:
                                 This field will be autopopulated at admission time
                                 by the RuntimeClass admission controller. If the RuntimeClass
                                 admission controller is enabled, overhead must not
-                                be set in Pod create requests.
+                                be set in Pod create requests. The RuntimeClass admission
+                                controller will reject Pod create requests which have
+                                the overhead already set.
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
@@ -5070,7 +5273,8 @@ spec:
                                 are two special keywords which indicate the highest
                                 priorities with the former being the highest priority.
                                 Any other name must be defined by creating a PriorityClass
-                                object with that name.
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
                               type: string
                             readinessGates:
                               description: 'If specified, all readiness gates will
@@ -5096,10 +5300,14 @@ spec:
                                 to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: RuntimeClassName refers to a RuntimeClass
+                              description: 'RuntimeClassName refers to a RuntimeClass
                                 object in the node.k8s.io group, which should be used
                                 to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run.
+                                the named class, the pod will not be run. If unset
+                                or empty, the "legacy" RuntimeClass will be used,
+                                which is an implicit class with an empty definition
+                                that uses the default runtime handler. More info:
+                                https://git.k8s.'
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -5123,11 +5331,14 @@ spec:
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: fsGroupChangePolicy defines behavior
+                                  description: 'fsGroupChangePolicy defines behavior
                                     of changing ownership and permission of the volume
                                     before being exposed inside Pod. This field will
                                     only apply to volume types which support fsGroup
-                                    based ownership(and permissions).
+                                    based ownership(and permissions). It will have
+                                    no effect on ephemeral volume types such as: secret,
+                                    configmaps and emptydir. Valid values are "OnRootMismatch"
+                                    and "Always". If not specified, "Always" is used.'
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -5136,7 +5347,7 @@ spec:
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
                                     for that container. Note that this field cannot
-                                    be set when spec.
+                                    be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -5155,13 +5366,19 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
                                   description: The SELinux context to be applied to
                                     all containers. If unspecified, the container
                                     runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.
+                                    for each container.  May also be set in SecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5243,7 +5460,8 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -5293,11 +5511,13 @@ spec:
                                 nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: Share a single process namespace between
+                              description: 'Share a single process namespace between
                                 all of the containers in a pod. When this is set containers
                                 will be able to view and signal processes from other
                                 containers in the same pod, and the first process
-                                in each container will not be assigned PID 1.
+                                in each container will not be assigned PID 1. HostPID
+                                and ShareProcessNamespace cannot both be set. Optional:
+                                Default to false.'
                               type: boolean
                             subdomain:
                               description: If specified, the fully qualified Pod hostname
@@ -5310,7 +5530,8 @@ spec:
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
                                 zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down).
+                                (no opportunity to shut down). If this value is nil,
+                                the default grace period will be used instead.
                               format: int64
                               type: integer
                             tolerations:
@@ -5346,7 +5567,8 @@ spec:
                                       of effect NoExecute, otherwise this field is
                                       ignored) tolerates the taint. By default, it
                                       is not set, which means tolerate the taint forever
-                                      (do not evict).
+                                      (do not evict). Zero and negative values will
+                                      be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
@@ -5423,7 +5645,13 @@ spec:
                                   matchLabelKeys:
                                     description: MatchLabelKeys is a set of pod label
                                       keys to select the pods over which spreading
-                                      will be calculated.
+                                      will be calculated. The keys are used to lookup
+                                      values from the incoming pod labels, those key-value
+                                      labels are ANDed with labelSelector to select
+                                      the group of existing pods over which spreading
+                                      will be calculated for the incoming pod. Keys
+                                      that don't exist in the incoming pod labels
+                                      will be ignored.
                                     items:
                                       type: string
                                     type: array
@@ -5433,7 +5661,10 @@ spec:
                                       pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                                       it is the maximum permitted difference between
                                       the number of matching pods in the target topology
-                                      and the global minimum.
+                                      and the global minimum. The global minimum is
+                                      the minimum number of matching pods in an eligible
+                                      domain or zero if the number of eligible domains
+                                      is less than MinDomains.
                                     format: int32
                                     type: integer
                                   minDomains:
@@ -5442,25 +5673,33 @@ spec:
                                       domains with matching topology keys is less
                                       than minDomains, Pod Topology Spread treats
                                       "global minimum" as 0, and then the calculation
-                                      of Skew is performed.
+                                      of Skew is performed. And when the number of
+                                      eligible domains with matching topology keys
+                                      equals or greater than minDomains, this value
+                                      has no effect on scheduling.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: 'NodeAffinityPolicy indicates how
-                                      we will treat Pod''s nodeAffinity/nodeSelector
+                                    description: "NodeAffinityPolicy indicates how
+                                      we will treat Pod's nodeAffinity/nodeSelector
                                       when calculating pod topology spread skew. Options
                                       are: - Honor: only nodes matching nodeAffinity/nodeSelector
                                       are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored.'
+                                      nodeAffinity/nodeSelector are ignored. All nodes
+                                      are included in the calculations. \n If this
+                                      value is nil, the behavior is equivalent to
+                                      the Honor policy."
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: 'NodeTaintsPolicy indicates how we
+                                    description: "NodeTaintsPolicy indicates how we
                                       will treat node taints when calculating pod
                                       topology spread skew. Options are: - Honor:
                                       nodes without taints, along with tainted nodes
                                       for which the incoming pod has a toleration,
                                       are included. - Ignore: node taints are ignored.
-                                      All nodes are included.'
+                                      All nodes are included. \n If this value is
+                                      nil, the behavior is equivalent to the Ignore
+                                      policy."
                                     type: string
                                   topologyKey:
                                     description: TopologyKey is the key of node labels.
@@ -5468,13 +5707,17 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket.
+                                      each bucket. We define a domain as a particular
+                                      instance of a topology.
                                     type: string
                                   whenUnsatisfiable:
                                     description: WhenUnsatisfiable indicates how to
                                       deal with a pod if it doesn't satisfy the spread
                                       constraint. - DoNotSchedule (default) tells
-                                      the scheduler not to schedule it.
+                                      the scheduler not to schedule it. - ScheduleAnyway
+                                      tells the scheduler to schedule the pod in any
+                                      location, but giving higher precedence to topologies
+                                      that would help reduce the skew.
                                     type: string
                                 required:
                                 - maxSkew
@@ -5507,7 +5750,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -5692,7 +5937,9 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.'
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -5770,7 +6017,9 @@ spec:
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
                                           calls. This field is optional, and  may
-                                          be empty if no secret is required.
+                                          be empty if no secret is required. If the
+                                          secret object contains more than one secret,
+                                          all secret references are passed.
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5806,7 +6055,11 @@ spec:
                                           mode bits used to set permissions on created
                                           files by default. Must be an octal value
                                           between 0000 and 0777 or a decimal value
-                                          between 0 and 511.'
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -5904,14 +6157,16 @@ spec:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: sizeLimit is the total amount
+                                        description: 'sizeLimit is the total amount
                                           of local storage required for this EmptyDir
                                           volume. The size limit is also applicable
                                           for memory medium. The maximum usage on
                                           memory medium EmptyDir would be the minimum
                                           value between the SizeLimit specified here
                                           and the sum of memory limits of all containers
-                                          in a pod.
+                                          in a pod. The default is nil which means
+                                          that the limit is undefined. More info:
+                                          http://kubernetes.'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
@@ -5927,7 +6182,10 @@ spec:
                                           PVC to provision the volume. The pod in
                                           which this EphemeralVolumeSource is embedded
                                           will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.
+                                          will be deleted together with the pod.  The
+                                          name of the PVC will be `<pod name>-<volume
+                                          name>` where `<volume name>` is the name
+                                          from the `PodSpec.Volumes` array entry.
                                         properties:
                                           metadata:
                                             description: May contain labels and annotations
@@ -5970,7 +6228,13 @@ spec:
                                               dataSource:
                                                 description: 'dataSource field can
                                                   be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.'
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                  * An existing PVC (PersistentVolumeClaim)
+                                                  If the provisioner or an external
+                                                  controller can support the specified
+                                                  data source, it will create a new
+                                                  volume based on the contents of
+                                                  the specified data source.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6001,7 +6265,11 @@ spec:
                                                   volume is desired. This may be any
                                                   local object from a non-empty API
                                                   group (non core object) or a PersistentVolumeClaim
-                                                  object.
+                                                  object. When this field is specified,
+                                                  volume binding will only succeed
+                                                  if the type of the specified object
+                                                  matches some installed volume populator
+                                                  or dynamic provisioner.
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6026,7 +6294,7 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resources:
-                                                description: resources represents
+                                                description: 'resources represents
                                                   the minimum resources the volume
                                                   should have. If RecoverVolumeExpansionFailure
                                                   feature is enabled users are allowed
@@ -6034,7 +6302,7 @@ spec:
                                                   that are lower than previous value
                                                   but must still be higher than capacity
                                                   recorded in the status field of
-                                                  the claim.
+                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -6263,7 +6531,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       partition:
                                         description: 'partition is the partition in
@@ -6272,7 +6542,7 @@ spec:
                                           Examples: For volume /dev/sda1, you specify
                                           the partition as "1". Similarly, the volume
                                           partition for /dev/sda is "0" (or you can
-                                          leave the property empty).'
+                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
@@ -6379,7 +6649,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       initiatorName:
                                         description: initiatorName is the custom iSCSI
@@ -6536,7 +6808,8 @@ spec:
                                           0000 and 0777 or a decimal value between
                                           0 and 511. YAML accepts both octal and decimal
                                           values, JSON requires decimal values for
-                                          mode bits.
+                                          mode bits. Directories within the path are
+                                          not affected by this setting.
                                         format: int32
                                         type: integer
                                       sources:
@@ -6789,7 +7062,13 @@ spec:
                                                     As the token approaches expiration,
                                                     the kubelet volume plugin will
                                                     proactively rotate the service
-                                                    account token.
+                                                    account token. The kubelet will
+                                                    start trying to rotate the token
+                                                    if the token is older than 80
+                                                    percent of its time to live or
+                                                    if the token is older than 24
+                                                    hours.Defaults to 1 hour and must
+                                                    be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
@@ -6853,7 +7132,9 @@ spec:
                                           by the host operating system. Examples:
                                           "ext4", "xfs", "ntfs". Implicitly inferred
                                           to be "ext4" if unspecified. More info:
-                                          https://kubernetes.'
+                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
                                         type: string
                                       image:
                                         description: 'image is the rados image name.
@@ -6977,7 +7258,9 @@ spec:
                                           between 0000 and 0777 or a decimal value
                                           between 0 and 511. YAML accepts both octal
                                           and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.'
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting.'
                                         format: int32
                                         type: integer
                                       items:
@@ -7071,6 +7354,8 @@ spec:
                                           Kubernetes name scoping to be mirrored within
                                           StorageOS for tighter integration. Set VolumeName
                                           to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces
+                                          within StorageOS.
                                         type: string
                                     type: object
                                   vsphereVolume:


### PR DESCRIPTION
Signed-off-by: Yuki Iwai <yuki.iwai.tz@gmail.com>

Trim down CRD descriptions to avoid the following apply errors:

```shell
The CustomResourceDefinition "pytorchjobs.kubeflow.org" is invalid: metadata.annotations: Too long: must have at most 262144 bytes
```

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
