### PR TITLE
Add E2E test for gang-scheduling

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -2,6 +2,10 @@ name: integration test
 on:
   - pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   integration-test:
     runs-on: ubuntu-latest
@@ -9,10 +13,13 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes-version: ["v1.23.12", "v1.24.6", "v1.25.2"]
+        # TODO (tenzen-y): Add volcano.
+        gang-scheduler-name: ["none", "scheduler-plugins"]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      
+
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.3.0
         with:
@@ -25,15 +32,19 @@ jobs:
           ./scripts/gha/build-image.sh
         env:
           TRAINING_CI_IMAGE: kubeflowtraining/training-operator:test
-    
+
       - name: Deploy training operator
         run: |
           ./scripts/gha/setup-training-operator.sh
         env:
           KIND_CLUSTER: training-operator-cluster
           TRAINING_CI_IMAGE: kubeflowtraining/training-operator:test
+          GANG_SCHEDULER_NAME: ${{ matrix.gang-scheduler-name }}
+          KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}
 
       - name: Run tests
         run: |
           pip install pytest
           python3 -m pip install -e sdk/python; pytest sdk/python/test --log-cli-level=info
+        env:
+          GANG_SCHEDULER_NAME: ${{ matrix.gang-scheduler-name }}

--- a/pkg/controller.v1/mxnet/mxjob_controller.go
+++ b/pkg/controller.v1/mxnet/mxjob_controller.go
@@ -372,7 +372,7 @@ func (r *MXJobReconciler) UpdateJobStatus(job interface{}, replicas map[commonv1
 		}
 	}
 
-	//check whether mxnet singleHost training
+	// check whether mxnet singleHost training
 	singleTraining := r.isSingleWorker(replicas)
 
 	for rtype, spec := range replicas {

--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -811,7 +811,7 @@ class TrainingClient(object):
         """Patch the TFJob.
 
         Args:
-            tfjob: TFJob object of type KubeflowOrgV1TFJob.
+            tfjob: TFJob object of type KubeflowOrgV1TFJob to patch.
             name: Name for the TFJob.
             namespace: Namespace for the TFJob.
 
@@ -823,8 +823,8 @@ class TrainingClient(object):
         return utils.patch_job(
             custom_api=self.custom_api,
             job=tfjob,
-            namespace=namespace,
             name=name,
+            namespace=namespace,
             job_kind=constants.TFJOB_KIND,
             job_plural=constants.TFJOB_PLURAL,
         )
@@ -1048,8 +1048,8 @@ class TrainingClient(object):
         return utils.patch_job(
             custom_api=self.custom_api,
             job=pytorchjob,
-            namespace=namespace,
             name=name,
+            namespace=namespace,
             job_kind=constants.PYTORCHJOB_KIND,
             job_plural=constants.PYTORCHJOB_PLURAL,
         )
@@ -1200,8 +1200,8 @@ class TrainingClient(object):
         return utils.patch_job(
             custom_api=self.custom_api,
             job=mxjob,
-            namespace=namespace,
             name=name,
+            namespace=namespace,
             job_kind=constants.MXJOB_KIND,
             job_plural=constants.MXJOB_PLURAL,
         )
@@ -1352,8 +1352,8 @@ class TrainingClient(object):
         return utils.patch_job(
             custom_api=self.custom_api,
             job=xgboostjob,
-            namespace=namespace,
             name=name,
+            namespace=namespace,
             job_kind=constants.XGBOOSTJOB_KIND,
             job_plural=constants.XGBOOSTJOB_PLURAL,
         )
@@ -1504,8 +1504,8 @@ class TrainingClient(object):
         return utils.patch_job(
             custom_api=self.custom_api,
             job=mpijob,
-            namespace=namespace,
             name=name,
+            namespace=namespace,
             job_kind=constants.MPIJOB_KIND,
             job_plural=constants.MPIJOB_PLURAL,
         )
@@ -1656,8 +1656,8 @@ class TrainingClient(object):
         return utils.patch_job(
             custom_api=self.custom_api,
             job=paddlejob,
-            namespace=namespace,
             name=name,
+            namespace=namespace,
             job_kind=constants.PADDLEJOB_KIND,
             job_plural=constants.PADDLEJOB_PLURAL,
         )

--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -752,12 +752,12 @@ class TrainingClient(object):
 
         Args:
             namespace: Namespace to list the TFJobs.
+            timeout: Optional, Kubernetes API server timeout in seconds
+                to execute the request.
 
         Returns:
             list[KubeflowOrgV1TFJob]: List of TFJobs objects. It returns
             empty list if TFJobs cannot be found.
-            timeout: Optional, Kubernetes API server timeout in seconds
-                to execute the request.
 
         Raises:
             TimeoutError: Timeout to list TFJobs.
@@ -800,6 +800,33 @@ class TrainingClient(object):
             job_kind=constants.TFJOB_KIND,
             job_plural=constants.TFJOB_PLURAL,
             delete_options=delete_options,
+        )
+
+    def patch_tfjob(
+        self,
+        tfjob: models.KubeflowOrgV1TFJob,
+        name: str,
+        namespace: str = utils.get_default_target_namespace(),
+    ):
+        """Patch the TFJob.
+
+        Args:
+            tfjob: TFJob object of type KubeflowOrgV1TFJob.
+            name: Name for the TFJob.
+            namespace: Namespace for the TFJob.
+
+        Raises:
+            TimeoutError: Timeout to patch TFJob.
+            RuntimeError: Failed to patch TFJob.
+        """
+
+        return utils.patch_job(
+            custom_api=self.custom_api,
+            job=tfjob,
+            namespace=namespace,
+            name=name,
+            job_kind=constants.TFJOB_KIND,
+            job_plural=constants.TFJOB_PLURAL,
         )
 
     # ------------------------------------------------------------------------ #
@@ -1000,6 +1027,33 @@ class TrainingClient(object):
             delete_options=delete_options,
         )
 
+    def patch_pytorchjob(
+        self,
+        pytorchjob: models.KubeflowOrgV1PyTorchJob,
+        name: str,
+        namespace: str = utils.get_default_target_namespace(),
+    ):
+        """Patch the PyTorchJob.
+
+        Args:
+            pytorchjob: PyTorchJob object of type KubeflowOrgV1PyTorchJob.
+            name: Name for the PyTorchJob.
+            namespace: Namespace for the PyTorchJob.
+
+        Raises:
+            TimeoutError: Timeout to patch PyTorchJob.
+            RuntimeError: Failed to patch PyTorchJob.
+        """
+
+        return utils.patch_job(
+            custom_api=self.custom_api,
+            job=pytorchjob,
+            namespace=namespace,
+            name=name,
+            job_kind=constants.PYTORCHJOB_KIND,
+            job_plural=constants.PYTORCHJOB_PLURAL,
+        )
+
     # ------------------------------------------------------------------------ #
     # MXJob Training Client APIs.
     # ------------------------------------------------------------------------ #
@@ -1044,6 +1098,8 @@ class TrainingClient(object):
         Args:
             name: Name for the MXJob.
             namespace: Namespace for the MXJob.
+            timeout: Optional, Kubernetes API server timeout in seconds
+                to execute the request.
 
         Returns:
             KubeflowOrgV1MXJob: MXJob object.
@@ -1121,6 +1177,33 @@ class TrainingClient(object):
             job_kind=constants.MXJOB_KIND,
             job_plural=constants.MXJOB_PLURAL,
             delete_options=delete_options,
+        )
+
+    def patch_mxjob(
+        self,
+        mxjob: models.KubeflowOrgV1MXJob,
+        name: str,
+        namespace: str = utils.get_default_target_namespace(),
+    ):
+        """Patch the MXJob.
+
+        Args:
+            mxjob: MXJob object of type KubeflowOrgV1MXJob.
+            name: Name for the MXJob.
+            namespace: Namespace for the MXJob.
+
+        Raises:
+            TimeoutError: Timeout to patch MXJob.
+            RuntimeError: Failed to patch MXJob.
+        """
+
+        return utils.patch_job(
+            custom_api=self.custom_api,
+            job=mxjob,
+            namespace=namespace,
+            name=name,
+            job_kind=constants.MXJOB_KIND,
+            job_plural=constants.MXJOB_PLURAL,
         )
 
     # ------------------------------------------------------------------------ #
@@ -1248,6 +1331,33 @@ class TrainingClient(object):
             delete_options=delete_options,
         )
 
+    def patch_xgboostjob(
+        self,
+        xgboostjob: models.KubeflowOrgV1XGBoostJob,
+        name: str,
+        namespace: str = utils.get_default_target_namespace(),
+    ):
+        """Patch the XGBoostJob.
+
+        Args:
+            xgboostjob: XGBoostJob object of type KubeflowOrgV1XGBoostJob.
+            name: Name for the XGBoostJob.
+            namespace: Namespace for the XGBoostJob.
+
+        Raises:
+            TimeoutError: Timeout to patch XGBoostJob.
+            RuntimeError: Failed to patch XGBoostJob.
+        """
+
+        return utils.patch_job(
+            custom_api=self.custom_api,
+            job=xgboostjob,
+            namespace=namespace,
+            name=name,
+            job_kind=constants.XGBOOSTJOB_KIND,
+            job_plural=constants.XGBOOSTJOB_PLURAL,
+        )
+
     # ------------------------------------------------------------------------ #
     # MPIJob Training Client APIs.
     # ------------------------------------------------------------------------ #
@@ -1323,12 +1433,12 @@ class TrainingClient(object):
 
         Args:
             namespace: Namespace to list the MPIJobs.
+            timeout: Optional, Kubernetes API server timeout in seconds
+                to execute the request.
 
         Returns:
             list[KubeflowOrgV1MPIJob]: List of MPIJobs objects. It returns
             empty list if MPIJobs cannot be found.
-            timeout: Optional, Kubernetes API server timeout in seconds
-                to execute the request.
 
         Raises:
             TimeoutError: Timeout to list MPIJobs.
@@ -1371,6 +1481,33 @@ class TrainingClient(object):
             job_kind=constants.MPIJOB_KIND,
             job_plural=constants.MPIJOB_PLURAL,
             delete_options=delete_options,
+        )
+
+    def patch_mpijob(
+        self,
+        mpijob: models.KubeflowOrgV1MPIJob,
+        name: str,
+        namespace: str = utils.get_default_target_namespace(),
+    ):
+        """Patch the MPIJob.
+
+        Args:
+            mpijob: MPIJob object of type KubeflowOrgV1MPIJob.
+            name: Name for the MPIJob.
+            namespace: Namespace for the MPIJob.
+
+        Raises:
+            TimeoutError: Timeout to patch MPIJob.
+            RuntimeError: Failed to patch MPIJob.
+        """
+
+        return utils.patch_job(
+            custom_api=self.custom_api,
+            job=mpijob,
+            namespace=namespace,
+            name=name,
+            job_kind=constants.MPIJOB_KIND,
+            job_plural=constants.MPIJOB_PLURAL,
         )
 
     # ------------------------------------------------------------------------ #
@@ -1417,6 +1554,8 @@ class TrainingClient(object):
         Args:
             name: Name for the PaddleJob.
             namespace: Namespace for the PaddleJob.
+            timeout: Optional, Kubernetes API server timeout in seconds
+                to execute the request.
 
         Returns:
             KubeflowOrgV1PaddleJob: PaddleJob object.
@@ -1494,4 +1633,31 @@ class TrainingClient(object):
             job_kind=constants.PADDLEJOB_KIND,
             job_plural=constants.PADDLEJOB_PLURAL,
             delete_options=delete_options,
+        )
+
+    def patch_paddlejob(
+        self,
+        paddlejob: models.KubeflowOrgV1PaddleJob,
+        name: str,
+        namespace: str = utils.get_default_target_namespace(),
+    ):
+        """Patch the PaddleJob.
+
+        Args:
+            paddlejob: PaddleJob object of type KubeflowOrgV1PaddleJob.
+            name: Name for the PaddleJob.
+            namespace: Namespace for the PaddleJob.
+
+        Raises:
+            TimeoutError: Timeout to patch PaddleJob.
+            RuntimeError: Failed to patch PaddleJob.
+        """
+
+        return utils.patch_job(
+            custom_api=self.custom_api,
+            job=paddlejob,
+            namespace=namespace,
+            name=name,
+            job_kind=constants.PADDLEJOB_KIND,
+            job_plural=constants.PADDLEJOB_PLURAL,
         )

--- a/sdk/python/kubeflow/training/constants/constants.py
+++ b/sdk/python/kubeflow/training/constants/constants.py
@@ -91,7 +91,6 @@ PADDLEJOB_BASE_IMAGE = (
     "docker.io/paddlepaddle/paddle:2.4.0rc0-gpu-cuda11.2-cudnn8.1-trt8.0"
 )
 
-
 # Dictionary to get plural and model for each Job kind.
 JOB_KINDS = {
     TFJOB_KIND: {"plural": TFJOB_PLURAL, "model": models.KubeflowOrgV1TFJob},

--- a/sdk/python/kubeflow/training/utils/utils.py
+++ b/sdk/python/kubeflow/training/utils/utils.py
@@ -187,6 +187,37 @@ def delete_job(
     logging.info(f"{job_kind} {namespace}/{name} has been deleted")
 
 
+def patch_job(
+    custom_api: client.CustomObjectsApi,
+    job: object,
+    namespace: str,
+    name: str,
+    job_kind: str,
+    job_plural: str,
+):
+    """Patch the Training Job."""
+
+    try:
+        custom_api.patch_namespaced_custom_object(
+            constants.KUBEFLOW_GROUP,
+            constants.OPERATOR_VERSION,
+            namespace,
+            job_plural,
+            name,
+            job,
+        )
+    except multiprocessing.TimeoutError:
+        raise TimeoutError(
+            f"Timeout to create {job_kind}: {namespace}/{job.metadata.name}"
+        )
+    except Exception:
+        raise RuntimeError(
+            f"Failed to create {job_kind}: {namespace}/{job.metadata.name}"
+        )
+
+    logging.info(f"{job_kind} {namespace}/{job.metadata.name} has been patched")
+
+
 def wrap_log_stream(q, stream):
     while True:
         try:

--- a/sdk/python/kubeflow/training/utils/utils.py
+++ b/sdk/python/kubeflow/training/utils/utils.py
@@ -190,8 +190,8 @@ def delete_job(
 def patch_job(
     custom_api: client.CustomObjectsApi,
     job: object,
-    namespace: str,
     name: str,
+    namespace: str,
     job_kind: str,
     job_plural: str,
 ):
@@ -208,11 +208,11 @@ def patch_job(
         )
     except multiprocessing.TimeoutError:
         raise TimeoutError(
-            f"Timeout to create {job_kind}: {namespace}/{job.metadata.name}"
+            f"Timeout to patch {job_kind}: {namespace}/{job.metadata.name}"
         )
     except Exception:
         raise RuntimeError(
-            f"Failed to create {job_kind}: {namespace}/{job.metadata.name}"
+            f"Failed to patch {job_kind}: {namespace}/{job.metadata.name}"
         )
 
     logging.info(f"{job_kind} {namespace}/{job.metadata.name} has been patched")

--- a/sdk/python/test/e2e/constants.py
+++ b/sdk/python/test/e2e/constants.py
@@ -1,0 +1,23 @@
+# Copyright 2023 kubeflow.org.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TEST_GANG_SCHEDULER_NAME_ENV_KEY = "GANG_SCHEDULER_NAME"
+TEST_GANG_SCHEDULER_NAME_SCHEDULER_PLUGINS = "scheduler-plugins"
+TEST_GANG_SCHEDULER_NAME_VOLCANO = "volcano"
+TEST_GANG_SCHEDULER_NAME_NONE = "none"
+
+GANG_SCHEDULERS = {TEST_GANG_SCHEDULER_NAME_SCHEDULER_PLUGINS, TEST_GANG_SCHEDULER_NAME_VOLCANO}
+NONE_GANG_SCHEDULERS = {TEST_GANG_SCHEDULER_NAME_NONE, ""}
+
+DEFAULT_SCHEDULER_PLUGINS_NAME = "scheduler-plugins-scheduler"

--- a/sdk/python/test/e2e/test_e2e_mpijob.py
+++ b/sdk/python/test/e2e/test_e2e_mpijob.py
@@ -14,6 +14,8 @@
 
 import os
 import logging
+import pytest
+from typing import Tuple
 
 from kubernetes.client import V1PodTemplateSpec
 from kubernetes.client import V1ObjectMeta
@@ -25,9 +27,12 @@ from kubeflow.training import V1ReplicaSpec
 from kubeflow.training import KubeflowOrgV1MPIJob
 from kubeflow.training import KubeflowOrgV1MPIJobSpec
 from kubeflow.training import V1RunPolicy
+from kubeflow.training import V1SchedulingPolicy
 from kubeflow.training.constants import constants
 
-from test.e2e.utils import verify_job_e2e
+from test.e2e.utils import verify_job_e2e, verify_unschedulable_job_e2e, get_pod_spec_scheduler_name
+from test.e2e.constants import TEST_GANG_SCHEDULER_NAME_ENV_KEY
+from test.e2e.constants import GANG_SCHEDULERS, NONE_GANG_SCHEDULERS
 
 logging.basicConfig(format="%(message)s")
 logging.getLogger().setLevel(logging.INFO)
@@ -36,10 +41,119 @@ TRAINING_CLIENT = TrainingClient(config_file=os.getenv("KUBECONFIG", "~/.kube/co
 JOB_NAME = "mpijob-mxnet-ci-test"
 JOB_NAMESPACE = "default"
 CONTAINER_NAME = "mpi"
+GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 
 
+@pytest.mark.skipif(
+    GANG_SCHEDULER_NAME in NONE_GANG_SCHEDULERS, reason="For gang-scheduling",
+)
+def test_sdk_e2e_with_gang_scheduling():
+    launcher_container, worker_container = generate_containers()
+
+    launcher = V1ReplicaSpec(
+        replicas=1,
+        restart_policy="Never",
+        template=V1PodTemplateSpec(spec=V1PodSpec(
+            containers=[launcher_container],
+            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+        )),
+    )
+
+    worker = V1ReplicaSpec(
+        replicas=1,
+        restart_policy="Never",
+        template=V1PodTemplateSpec(spec=V1PodSpec(
+            containers=[worker_container],
+            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+        )),
+    )
+
+    mpijob = generate_mpijob(launcher, worker, V1SchedulingPolicy(min_available=10))
+    patched_mpijob = generate_mpijob(launcher, worker, V1SchedulingPolicy(min_available=2))
+
+    TRAINING_CLIENT.create_mpijob(mpijob, JOB_NAMESPACE)
+    logging.info(f"List of created {constants.MPIJOB_KIND}s")
+    logging.info(TRAINING_CLIENT.list_mpijobs(JOB_NAMESPACE))
+
+    verify_unschedulable_job_e2e(
+        TRAINING_CLIENT,
+        JOB_NAME,
+        JOB_NAMESPACE,
+        constants.MPIJOB_KIND,
+    )
+
+    TRAINING_CLIENT.patch_mpijob(patched_mpijob, JOB_NAME, JOB_NAMESPACE)
+    logging.info(f"List of patched {constants.MPIJOB_KIND}s")
+    logging.info(TRAINING_CLIENT.list_mpijobs(JOB_NAMESPACE))
+
+    verify_job_e2e(
+        TRAINING_CLIENT,
+        JOB_NAME,
+        JOB_NAMESPACE,
+        constants.MPIJOB_KIND,
+        CONTAINER_NAME,
+    )
+
+    TRAINING_CLIENT.delete_mpijob(JOB_NAME, JOB_NAMESPACE)
+
+
+@pytest.mark.skipif(
+    GANG_SCHEDULER_NAME in GANG_SCHEDULERS, reason="For plain scheduling",
+)
 def test_sdk_e2e():
-    master_container = V1Container(
+    launcher_container, worker_container = generate_containers()
+
+    launcher = V1ReplicaSpec(
+        replicas=1,
+        restart_policy="Never",
+        template=V1PodTemplateSpec(spec=V1PodSpec(containers=[launcher_container])),
+    )
+
+    worker = V1ReplicaSpec(
+        replicas=1,
+        restart_policy="Never",
+        template=V1PodTemplateSpec(spec=V1PodSpec(containers=[worker_container])),
+    )
+
+    mpijob = generate_mpijob(launcher, worker, None)
+
+    TRAINING_CLIENT.create_mpijob(mpijob, JOB_NAMESPACE)
+    logging.info(f"List of created {constants.MPIJOB_KIND}s")
+    logging.info(TRAINING_CLIENT.list_mpijobs(JOB_NAMESPACE))
+
+    verify_job_e2e(
+        TRAINING_CLIENT,
+        JOB_NAME,
+        JOB_NAMESPACE,
+        constants.MPIJOB_KIND,
+        CONTAINER_NAME,
+    )
+
+    TRAINING_CLIENT.delete_mpijob(JOB_NAME, JOB_NAMESPACE)
+
+
+def generate_mpijob(
+    launcher: V1ReplicaSpec,
+    worker: V1ReplicaSpec,
+    scheduling_policy: V1SchedulingPolicy = None,
+) -> KubeflowOrgV1MPIJob:
+    return KubeflowOrgV1MPIJob(
+        api_version="kubeflow.org/v1",
+        kind="MPIJob",
+        metadata=V1ObjectMeta(name=JOB_NAME, namespace=JOB_NAMESPACE),
+        spec=KubeflowOrgV1MPIJobSpec(
+            slots_per_worker=1,
+            run_policy=V1RunPolicy(
+                clean_pod_policy="None",
+                scheduling_policy=scheduling_policy,
+            ),
+            mpi_replica_specs={"Launcher": launcher, "Worker": worker},
+        ),
+    )
+
+
+def generate_containers() -> Tuple[V1Container, V1Container]:
+    launcher_container = V1Container(
         name=CONTAINER_NAME,
         image="horovod/horovod:0.20.0-tf2.3.0-torch1.6.0-mxnet1.5.0-py3.7-cpu",
         command=["mpirun"],
@@ -74,35 +188,4 @@ def test_sdk_e2e():
         image="horovod/horovod:0.20.0-tf2.3.0-torch1.6.0-mxnet1.5.0-py3.7-cpu",
     )
 
-    master = V1ReplicaSpec(
-        replicas=1,
-        restart_policy="Never",
-        template=V1PodTemplateSpec(spec=V1PodSpec(containers=[master_container])),
-    )
-
-    worker = V1ReplicaSpec(
-        replicas=1,
-        restart_policy="Never",
-        template=V1PodTemplateSpec(spec=V1PodSpec(containers=[worker_container])),
-    )
-
-    mpijob = KubeflowOrgV1MPIJob(
-        api_version="kubeflow.org/v1",
-        kind="MPIJob",
-        metadata=V1ObjectMeta(name=JOB_NAME, namespace=JOB_NAMESPACE),
-        spec=KubeflowOrgV1MPIJobSpec(
-            slots_per_worker=1,
-            run_policy=V1RunPolicy(clean_pod_policy="None",),
-            mpi_replica_specs={"Launcher": master, "Worker": worker},
-        ),
-    )
-
-    TRAINING_CLIENT.create_mpijob(mpijob, JOB_NAMESPACE)
-    logging.info(f"List of created {constants.MPIJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_mpijobs(JOB_NAMESPACE))
-
-    verify_job_e2e(
-        TRAINING_CLIENT, JOB_NAME, JOB_NAMESPACE, constants.MPIJOB_KIND, CONTAINER_NAME,
-    )
-
-    TRAINING_CLIENT.delete_mpijob(JOB_NAME, JOB_NAMESPACE)
+    return launcher_container, worker_container

--- a/sdk/python/test/e2e/test_e2e_mxjob.py
+++ b/sdk/python/test/e2e/test_e2e_mxjob.py
@@ -14,6 +14,8 @@
 
 import os
 import logging
+import pytest
+from typing import Tuple
 
 from kubernetes.client import V1PodTemplateSpec
 from kubernetes.client import V1ObjectMeta
@@ -26,9 +28,12 @@ from kubeflow.training import V1ReplicaSpec
 from kubeflow.training import KubeflowOrgV1MXJob
 from kubeflow.training import KubeflowOrgV1MXJobSpec
 from kubeflow.training import V1RunPolicy
+from kubeflow.training import V1SchedulingPolicy
 from kubeflow.training.constants import constants
 
-from test.e2e.utils import verify_job_e2e
+from test.e2e.utils import verify_job_e2e, verify_unschedulable_job_e2e, get_pod_spec_scheduler_name
+from test.e2e.constants import TEST_GANG_SCHEDULER_NAME_ENV_KEY
+from test.e2e.constants import GANG_SCHEDULERS, NONE_GANG_SCHEDULERS
 
 logging.basicConfig(format="%(message)s")
 logging.getLogger().setLevel(logging.INFO)
@@ -37,36 +42,76 @@ TRAINING_CLIENT = TrainingClient(config_file=os.getenv("KUBECONFIG", "~/.kube/co
 JOB_NAME = "mxjob-mnist-ci-test"
 JOB_NAMESPACE = "default"
 CONTAINER_NAME = "mxnet"
+GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 
 
+@pytest.mark.skipif(
+    GANG_SCHEDULER_NAME in NONE_GANG_SCHEDULERS, reason="For gang-scheduling",
+)
+def test_sdk_e2e_with_gang_scheduling():
+    worker_container, server_container, scheduler_container = generate_containers()
+
+    worker = V1ReplicaSpec(
+        replicas=1,
+        restart_policy="Never",
+        template=V1PodTemplateSpec(spec=V1PodSpec(
+            containers=[worker_container],
+            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+        )),
+    )
+
+    server = V1ReplicaSpec(
+        replicas=1,
+        restart_policy="Never",
+        template=V1PodTemplateSpec(spec=V1PodSpec(
+            containers=[server_container],
+            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+        )),
+    )
+
+    scheduler = V1ReplicaSpec(
+        replicas=1,
+        restart_policy="Never",
+        template=V1PodTemplateSpec(spec=V1PodSpec(
+            containers=[scheduler_container],
+            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+        )),
+    )
+
+    unschedulable_mxjob = generate_mxjob(scheduler, server, worker, V1SchedulingPolicy(min_available=10))
+    schedulable_mxjob = generate_mxjob(scheduler, server, worker, V1SchedulingPolicy(min_available=3))
+
+    TRAINING_CLIENT.create_mxjob(unschedulable_mxjob, JOB_NAMESPACE)
+    logging.info(f"List of created {constants.MXJOB_KIND}s")
+    logging.info(TRAINING_CLIENT.list_mxjobs(JOB_NAMESPACE))
+
+    verify_unschedulable_job_e2e(
+        TRAINING_CLIENT,
+        JOB_NAME,
+        JOB_NAMESPACE,
+        constants.MXJOB_KIND,
+    )
+
+    TRAINING_CLIENT.patch_mxjob(schedulable_mxjob, JOB_NAME, JOB_NAMESPACE)
+    logging.info(f"List of patched {constants.MXJOB_KIND}s")
+    logging.info(TRAINING_CLIENT.list_mxjobs(JOB_NAMESPACE))
+
+    verify_job_e2e(
+        TRAINING_CLIENT,
+        JOB_NAME,
+        JOB_NAMESPACE,
+        constants.MXJOB_KIND,
+        CONTAINER_NAME,
+    )
+
+    TRAINING_CLIENT.delete_mxjob(JOB_NAME, JOB_NAMESPACE)
+
+
+@pytest.mark.skipif(
+    GANG_SCHEDULER_NAME in GANG_SCHEDULERS, reason="For plain scheduling",
+)
 def test_sdk_e2e():
-    worker_container = V1Container(
-        name=CONTAINER_NAME,
-        image="docker.io/johnugeorge/mxnet:1.9.1_cpu_py3",
-        command=["/usr/local/bin/python3"],
-        args=[
-            "incubator-mxnet/example/image-classification/train_mnist.py",
-            "--num-epochs",
-            "5",
-            "--num-examples",
-            "1000",
-            "--kv-store",
-            "dist_sync",
-        ],
-        ports=[V1ContainerPort(container_port=9991, name="mxjob-port")],
-    )
-
-    server_container = V1Container(
-        name=CONTAINER_NAME,
-        image="docker.io/johnugeorge/mxnet:1.9.1_cpu_py3",
-        ports=[V1ContainerPort(container_port=9991, name="mxjob-port")],
-    )
-
-    scheduler_container = V1Container(
-        name=CONTAINER_NAME,
-        image="docker.io/johnugeorge/mxnet:1.9.1_cpu_py3",
-        ports=[V1ContainerPort(container_port=9991, name="mxjob-port")],
-    )
+    worker_container, server_container, scheduler_container = generate_containers()
 
     worker = V1ReplicaSpec(
         replicas=1,
@@ -86,13 +131,39 @@ def test_sdk_e2e():
         template=V1PodTemplateSpec(spec=V1PodSpec(containers=[scheduler_container])),
     )
 
-    mxjob = KubeflowOrgV1MXJob(
+    mxjob = generate_mxjob(scheduler, server, worker)
+
+    TRAINING_CLIENT.create_mxjob(mxjob, JOB_NAMESPACE)
+    logging.info(f"List of created {constants.MXJOB_KIND}s")
+    logging.info(TRAINING_CLIENT.list_mxjobs(JOB_NAMESPACE))
+
+    verify_job_e2e(
+        TRAINING_CLIENT,
+        JOB_NAME,
+        JOB_NAMESPACE,
+        constants.MXJOB_KIND,
+        CONTAINER_NAME,
+    )
+
+    TRAINING_CLIENT.delete_mxjob(JOB_NAME, JOB_NAMESPACE)
+
+
+def generate_mxjob(
+    scheduler: V1ReplicaSpec,
+    server: V1ReplicaSpec,
+    worker: V1ReplicaSpec,
+    scheduling_policy: V1SchedulingPolicy = None,
+) -> KubeflowOrgV1MXJob:
+    return KubeflowOrgV1MXJob(
         api_version="kubeflow.org/v1",
         kind="MXJob",
         metadata=V1ObjectMeta(name=JOB_NAME, namespace=JOB_NAMESPACE),
         spec=KubeflowOrgV1MXJobSpec(
             job_mode="MXTrain",
-            run_policy=V1RunPolicy(clean_pod_policy="None",),
+            run_policy=V1RunPolicy(
+                clean_pod_policy="None",
+                scheduling_policy=scheduling_policy,
+            ),
             mx_replica_specs={
                 "Scheduler": scheduler,
                 "Server": server,
@@ -101,12 +172,37 @@ def test_sdk_e2e():
         ),
     )
 
-    TRAINING_CLIENT.create_mxjob(mxjob, JOB_NAMESPACE)
-    logging.info(f"List of created {constants.MXJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_mxjobs(JOB_NAMESPACE))
 
-    verify_job_e2e(
-        TRAINING_CLIENT, JOB_NAME, JOB_NAMESPACE, constants.MXJOB_KIND, CONTAINER_NAME,
+def generate_containers() -> Tuple[V1Container, V1Container, V1Container]:
+    worker_container = V1Container(
+        name=CONTAINER_NAME,
+        # TODO (tenzen-y): Replace the below image with the kubeflow hosted image
+        image="docker.io/johnugeorge/mxnet:1.9.1_cpu_py3",
+        command=["/usr/local/bin/python3"],
+        args=[
+            "incubator-mxnet/example/image-classification/train_mnist.py",
+            "--num-epochs",
+            "1",
+            "--num-examples",
+            "1000",
+            "--kv-store",
+            "dist_sync",
+        ],
+        ports=[V1ContainerPort(container_port=9991, name="mxjob-port")],
     )
 
-    TRAINING_CLIENT.delete_mxjob(JOB_NAME, JOB_NAMESPACE)
+    server_container = V1Container(
+        name=CONTAINER_NAME,
+        # TODO (tenzen-y): Replace the below image with the kubeflow hosted image
+        image="docker.io/johnugeorge/mxnet:1.9.1_cpu_py3",
+        ports=[V1ContainerPort(container_port=9991, name="mxjob-port")],
+    )
+
+    scheduler_container = V1Container(
+        name=CONTAINER_NAME,
+        # TODO (tenzen-y): Replace the below image with the kubeflow hosted image
+        image="docker.io/johnugeorge/mxnet:1.9.1_cpu_py3",
+        ports=[V1ContainerPort(container_port=9991, name="mxjob-port")],
+    )
+
+    return worker_container, server_container, scheduler_container

--- a/sdk/python/test/e2e/test_e2e_paddlejob.py
+++ b/sdk/python/test/e2e/test_e2e_paddlejob.py
@@ -14,6 +14,7 @@
 
 import os
 import logging
+import pytest
 
 from kubernetes.client import V1PodTemplateSpec
 from kubernetes.client import V1ObjectMeta
@@ -25,9 +26,12 @@ from kubeflow.training import V1ReplicaSpec
 from kubeflow.training import KubeflowOrgV1PaddleJob
 from kubeflow.training import KubeflowOrgV1PaddleJobSpec
 from kubeflow.training import V1RunPolicy
+from kubeflow.training import V1SchedulingPolicy
 from kubeflow.training.constants import constants
 
-from test.e2e.utils import verify_job_e2e
+from test.e2e.utils import verify_job_e2e, verify_unschedulable_job_e2e, get_pod_spec_scheduler_name
+from test.e2e.constants import TEST_GANG_SCHEDULER_NAME_ENV_KEY
+from test.e2e.constants import GANG_SCHEDULERS, NONE_GANG_SCHEDULERS
 
 logging.basicConfig(format="%(message)s")
 logging.getLogger().setLevel(logging.INFO)
@@ -36,15 +40,58 @@ TRAINING_CLIENT = TrainingClient(config_file=os.getenv("KUBECONFIG", "~/.kube/co
 JOB_NAME = "paddlejob-cpu-ci-test"
 JOB_NAMESPACE = "default"
 CONTAINER_NAME = "paddle"
+GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 
 
-def test_sdk_e2e():
-    container = V1Container(
-        name=CONTAINER_NAME,
-        image="docker.io/paddlepaddle/paddle:2.4.0rc0-cpu",
-        command=["python"],
-        args=["-m", "paddle.distributed.launch", "run_check"],
+@pytest.mark.skipif(
+    GANG_SCHEDULER_NAME in NONE_GANG_SCHEDULERS, reason="For gang-scheduling",
+)
+def test_sdk_e2e_with_gang_scheduling():
+    container = generate_container()
+
+    worker = V1ReplicaSpec(
+        replicas=2,
+        restart_policy="OnFailure",
+        template=V1PodTemplateSpec(spec=V1PodSpec(
+            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+            containers=[container],
+        )),
     )
+
+    unschedulable_paddlejob = generate_paddlejob(worker, V1SchedulingPolicy(min_available=10))
+    schedulable_paddlejob = generate_paddlejob(worker, V1SchedulingPolicy(min_available=2))
+
+    TRAINING_CLIENT.create_paddlejob(unschedulable_paddlejob, JOB_NAMESPACE)
+    logging.info(f"List of created {constants.PADDLEJOB_KIND}s")
+    logging.info(TRAINING_CLIENT.list_paddlejobs(JOB_NAMESPACE))
+
+    verify_unschedulable_job_e2e(
+        TRAINING_CLIENT,
+        JOB_NAME,
+        JOB_NAMESPACE,
+        constants.PADDLEJOB_KIND,
+    )
+
+    TRAINING_CLIENT.patch_paddlejob(schedulable_paddlejob, JOB_NAME, JOB_NAMESPACE)
+    logging.info(f"List of patched {constants.PADDLEJOB_KIND}s")
+    logging.info(TRAINING_CLIENT.list_paddlejobs(JOB_NAMESPACE))
+
+    verify_job_e2e(
+        TRAINING_CLIENT,
+        JOB_NAME,
+        JOB_NAMESPACE,
+        constants.PADDLEJOB_KIND,
+        CONTAINER_NAME,
+    )
+
+    TRAINING_CLIENT.delete_paddlejob(JOB_NAME, JOB_NAMESPACE)
+
+
+@pytest.mark.skipif(
+    GANG_SCHEDULER_NAME in GANG_SCHEDULERS, reason="For plain scheduling",
+)
+def test_sdk_e2e():
+    container = generate_container()
 
     worker = V1ReplicaSpec(
         replicas=2,
@@ -52,15 +99,7 @@ def test_sdk_e2e():
         template=V1PodTemplateSpec(spec=V1PodSpec(containers=[container])),
     )
 
-    paddlejob = KubeflowOrgV1PaddleJob(
-        api_version="kubeflow.org/v1",
-        kind="PaddleJob",
-        metadata=V1ObjectMeta(name=JOB_NAME, namespace=JOB_NAMESPACE),
-        spec=KubeflowOrgV1PaddleJobSpec(
-            run_policy=V1RunPolicy(clean_pod_policy="None",),
-            paddle_replica_specs={"Worker": worker},
-        ),
-    )
+    paddlejob = generate_paddlejob(worker)
 
     TRAINING_CLIENT.create_paddlejob(paddlejob, JOB_NAMESPACE)
     logging.info(f"List of created {constants.PADDLEJOB_KIND}s")
@@ -75,3 +114,30 @@ def test_sdk_e2e():
     )
 
     TRAINING_CLIENT.delete_paddlejob(JOB_NAME, JOB_NAMESPACE)
+
+
+def generate_paddlejob(
+    worker: V1ReplicaSpec,
+    scheduling_policy: V1SchedulingPolicy = None,
+) -> KubeflowOrgV1PaddleJob:
+    return KubeflowOrgV1PaddleJob(
+        api_version="kubeflow.org/v1",
+        kind="PaddleJob",
+        metadata=V1ObjectMeta(name=JOB_NAME, namespace=JOB_NAMESPACE),
+        spec=KubeflowOrgV1PaddleJobSpec(
+            run_policy=V1RunPolicy(
+                scheduling_policy=scheduling_policy,
+                clean_pod_policy="None",
+            ),
+            paddle_replica_specs={"Worker": worker},
+        ),
+    )
+
+
+def generate_container() -> V1Container:
+    return V1Container(
+        name=CONTAINER_NAME,
+        image="docker.io/paddlepaddle/paddle:2.4.0rc0-cpu",
+        command=["python"],
+        args=["-m", "paddle.distributed.launch", "run_check"],
+    )

--- a/sdk/python/test/e2e/test_e2e_pytorchjob.py
+++ b/sdk/python/test/e2e/test_e2e_pytorchjob.py
@@ -14,6 +14,7 @@
 
 import os
 import logging
+import pytest
 
 from kubernetes.client import V1PodTemplateSpec
 from kubernetes.client import V1ObjectMeta
@@ -25,9 +26,12 @@ from kubeflow.training import V1ReplicaSpec
 from kubeflow.training import KubeflowOrgV1PyTorchJob
 from kubeflow.training import KubeflowOrgV1PyTorchJobSpec
 from kubeflow.training import V1RunPolicy
+from kubeflow.training import V1SchedulingPolicy
 from kubeflow.training.constants import constants
 
-from test.e2e.utils import verify_job_e2e
+from test.e2e.utils import verify_job_e2e, verify_unschedulable_job_e2e, get_pod_spec_scheduler_name
+from test.e2e.constants import TEST_GANG_SCHEDULER_NAME_ENV_KEY
+from test.e2e.constants import GANG_SCHEDULERS, NONE_GANG_SCHEDULERS
 
 logging.basicConfig(format="%(message)s")
 logging.getLogger().setLevel(logging.INFO)
@@ -36,14 +40,67 @@ TRAINING_CLIENT = TrainingClient(config_file=os.getenv("KUBECONFIG", "~/.kube/co
 JOB_NAME = "pytorchjob-mnist-ci-test"
 JOB_NAMESPACE = "default"
 CONTAINER_NAME = "pytorch"
+GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 
 
-def test_sdk_e2e():
-    container = V1Container(
-        name=CONTAINER_NAME,
-        image="gcr.io/kubeflow-ci/pytorch-dist-mnist-test:v1.0",
-        args=["--backend", "gloo"],
+@pytest.mark.skipif(
+    GANG_SCHEDULER_NAME in NONE_GANG_SCHEDULERS, reason="For gang-scheduling",
+)
+def test_sdk_e2e_with_gang_scheduling():
+    container = generate_container()
+
+    master = V1ReplicaSpec(
+        replicas=1,
+        restart_policy="OnFailure",
+        template=V1PodTemplateSpec(spec=V1PodSpec(
+            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+            containers=[container],
+        )),
     )
+
+    worker = V1ReplicaSpec(
+        replicas=1,
+        restart_policy="OnFailure",
+        template=V1PodTemplateSpec(spec=V1PodSpec(
+            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+            containers=[container],
+        )),
+    )
+
+    unschedulable_pytorchjob = generate_pytorchjob(master, worker, V1SchedulingPolicy(min_available=10))
+    schedulable_pytorchjob = generate_pytorchjob(master, worker, V1SchedulingPolicy(min_available=2))
+
+    TRAINING_CLIENT.create_pytorchjob(unschedulable_pytorchjob, JOB_NAMESPACE)
+    logging.info(f"List of created {constants.PYTORCHJOB_KIND}s")
+    logging.info(TRAINING_CLIENT.list_pytorchjobs(JOB_NAMESPACE))
+
+    verify_unschedulable_job_e2e(
+        TRAINING_CLIENT,
+        JOB_NAME,
+        JOB_NAMESPACE,
+        constants.PYTORCHJOB_KIND,
+    )
+
+    TRAINING_CLIENT.patch_pytorchjob(schedulable_pytorchjob, JOB_NAME, JOB_NAMESPACE)
+    logging.info(f"List of patched {constants.PYTORCHJOB_KIND}s")
+    logging.info(TRAINING_CLIENT.list_pytorchjobs(JOB_NAMESPACE))
+
+    verify_job_e2e(
+        TRAINING_CLIENT,
+        JOB_NAME,
+        JOB_NAMESPACE,
+        constants.PYTORCHJOB_KIND,
+        CONTAINER_NAME,
+    )
+
+    TRAINING_CLIENT.delete_pytorchjob(JOB_NAME, JOB_NAMESPACE)
+
+
+@pytest.mark.skipif(
+    GANG_SCHEDULER_NAME in GANG_SCHEDULERS, reason="For plain scheduling",
+)
+def test_sdk_e2e():
+    container = generate_container()
 
     master = V1ReplicaSpec(
         replicas=1,
@@ -57,15 +114,7 @@ def test_sdk_e2e():
         template=V1PodTemplateSpec(spec=V1PodSpec(containers=[container])),
     )
 
-    pytorchjob = KubeflowOrgV1PyTorchJob(
-        api_version="kubeflow.org/v1",
-        kind="PyTorchJob",
-        metadata=V1ObjectMeta(name=JOB_NAME, namespace=JOB_NAMESPACE),
-        spec=KubeflowOrgV1PyTorchJobSpec(
-            run_policy=V1RunPolicy(clean_pod_policy="None",),
-            pytorch_replica_specs={"Master": master, "Worker": worker},
-        ),
-    )
+    pytorchjob = generate_pytorchjob(master, worker)
 
     TRAINING_CLIENT.create_pytorchjob(pytorchjob, JOB_NAMESPACE)
     logging.info(f"List of created {constants.PYTORCHJOB_KIND}s")
@@ -80,3 +129,30 @@ def test_sdk_e2e():
     )
 
     TRAINING_CLIENT.delete_pytorchjob(JOB_NAME, JOB_NAMESPACE)
+
+
+def generate_pytorchjob(
+    master: V1ReplicaSpec,
+    worker: V1ReplicaSpec,
+    scheduling_policy: V1SchedulingPolicy = None,
+) -> KubeflowOrgV1PyTorchJob:
+    return KubeflowOrgV1PyTorchJob(
+        api_version="kubeflow.org/v1",
+        kind="PyTorchJob",
+        metadata=V1ObjectMeta(name=JOB_NAME, namespace=JOB_NAMESPACE),
+        spec=KubeflowOrgV1PyTorchJobSpec(
+            run_policy=V1RunPolicy(
+                clean_pod_policy="None",
+                scheduling_policy=scheduling_policy,
+            ),
+            pytorch_replica_specs={"Master": master, "Worker": worker},
+        ),
+    )
+
+
+def generate_container() -> V1Container:
+    return V1Container(
+        name=CONTAINER_NAME,
+        image="gcr.io/kubeflow-ci/pytorch-dist-mnist-test:v1.0",
+        args=["--backend", "gloo"],
+    )

--- a/sdk/python/test/e2e/test_e2e_xgboostjob.py
+++ b/sdk/python/test/e2e/test_e2e_xgboostjob.py
@@ -14,6 +14,7 @@
 
 import os
 import logging
+import pytest
 
 from kubernetes.client import V1PodTemplateSpec
 from kubernetes.client import V1ObjectMeta
@@ -25,9 +26,12 @@ from kubeflow.training import V1ReplicaSpec
 from kubeflow.training import KubeflowOrgV1XGBoostJob
 from kubeflow.training import KubeflowOrgV1XGBoostJobSpec
 from kubeflow.training import V1RunPolicy
+from kubeflow.training import V1SchedulingPolicy
 from kubeflow.training.constants import constants
 
-from test.e2e.utils import verify_job_e2e
+from test.e2e.utils import verify_job_e2e, verify_unschedulable_job_e2e, get_pod_spec_scheduler_name
+from test.e2e.constants import TEST_GANG_SCHEDULER_NAME_ENV_KEY
+from test.e2e.constants import GANG_SCHEDULERS, NONE_GANG_SCHEDULERS
 
 logging.basicConfig(format="%(message)s")
 logging.getLogger().setLevel(logging.INFO)
@@ -36,21 +40,67 @@ TRAINING_CLIENT = TrainingClient(config_file=os.getenv("KUBECONFIG", "~/.kube/co
 JOB_NAME = "xgboostjob-iris-ci-test"
 JOB_NAMESPACE = "default"
 CONTAINER_NAME = "xgboost"
+GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 
 
-def test_sdk_e2e():
-    container = V1Container(
-        name=CONTAINER_NAME,
-        image="docker.io/merlintang/xgboost-dist-iris:1.1",
-        args=[
-            "--job_type=Train",
-            "--xgboost_parameter=objective:multi:softprob,num_class:3",
-            "--n_estimators=10",
-            "--learning_rate=0.1",
-            "--model_path=/tmp/xgboost-model",
-            "--model_storage_type=local",
-        ],
+@pytest.mark.skipif(
+    GANG_SCHEDULER_NAME in NONE_GANG_SCHEDULERS, reason="For gang-scheduling",
+)
+def test_sdk_e2e_with_gang_scheduling():
+    container = generate_container()
+
+    master = V1ReplicaSpec(
+        replicas=1,
+        restart_policy="Never",
+        template=V1PodTemplateSpec(spec=V1PodSpec(
+            containers=[container],
+            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+        )),
     )
+
+    worker = V1ReplicaSpec(
+        replicas=1,
+        restart_policy="Never",
+        template=V1PodTemplateSpec(spec=V1PodSpec(
+            containers=[container],
+            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+        )),
+    )
+
+    unschedulable_xgboostjob = generate_xgboostjob(master, worker, V1SchedulingPolicy(min_available=10))
+    schedulable_xgboostjob = generate_xgboostjob(master, worker, V1SchedulingPolicy(min_available=2))
+
+    TRAINING_CLIENT.create_xgboostjob(unschedulable_xgboostjob, JOB_NAMESPACE)
+    logging.info(f"List of created {constants.XGBOOSTJOB_KIND}s")
+    logging.info(TRAINING_CLIENT.list_xgboostjobs(JOB_NAMESPACE))
+
+    verify_unschedulable_job_e2e(
+        TRAINING_CLIENT,
+        JOB_NAME,
+        JOB_NAMESPACE,
+        constants.XGBOOSTJOB_KIND,
+    )
+
+    TRAINING_CLIENT.patch_xgboostjob(schedulable_xgboostjob, JOB_NAME, JOB_NAMESPACE)
+    logging.info(f"List of patched {constants.XGBOOSTJOB_KIND}s")
+    logging.info(TRAINING_CLIENT.list_xgboostjobs(JOB_NAMESPACE))
+
+    verify_job_e2e(
+        TRAINING_CLIENT,
+        JOB_NAME,
+        JOB_NAMESPACE,
+        constants.XGBOOSTJOB_KIND,
+        CONTAINER_NAME,
+    )
+
+    TRAINING_CLIENT.delete_xgboostjob(JOB_NAME, JOB_NAMESPACE)
+
+
+@pytest.mark.skipif(
+    GANG_SCHEDULER_NAME in GANG_SCHEDULERS, reason="For plain scheduling",
+)
+def test_sdk_e2e():
+    container = generate_container()
 
     master = V1ReplicaSpec(
         replicas=1,
@@ -64,15 +114,7 @@ def test_sdk_e2e():
         template=V1PodTemplateSpec(spec=V1PodSpec(containers=[container])),
     )
 
-    xgboostjob = KubeflowOrgV1XGBoostJob(
-        api_version="kubeflow.org/v1",
-        kind="XGBoostJob",
-        metadata=V1ObjectMeta(name=JOB_NAME, namespace=JOB_NAMESPACE),
-        spec=KubeflowOrgV1XGBoostJobSpec(
-            run_policy=V1RunPolicy(clean_pod_policy="None",),
-            xgb_replica_specs={"Master": master, "Worker": worker},
-        ),
-    )
+    xgboostjob = generate_xgboostjob(master, worker)
 
     TRAINING_CLIENT.create_xgboostjob(xgboostjob, JOB_NAMESPACE)
     logging.info(f"List of created {constants.XGBOOSTJOB_KIND}s")
@@ -87,3 +129,37 @@ def test_sdk_e2e():
     )
 
     TRAINING_CLIENT.delete_xgboostjob(JOB_NAME, JOB_NAMESPACE)
+
+
+def generate_xgboostjob(
+    master: V1ReplicaSpec,
+    worker: V1ReplicaSpec,
+    scheduling_policy: V1SchedulingPolicy = None,
+) -> KubeflowOrgV1XGBoostJob:
+    return KubeflowOrgV1XGBoostJob(
+        api_version="kubeflow.org/v1",
+        kind="XGBoostJob",
+        metadata=V1ObjectMeta(name=JOB_NAME, namespace=JOB_NAMESPACE),
+        spec=KubeflowOrgV1XGBoostJobSpec(
+            run_policy=V1RunPolicy(
+                clean_pod_policy="None",
+                scheduling_policy=scheduling_policy,
+            ),
+            xgb_replica_specs={"Master": master, "Worker": worker},
+        ),
+    )
+
+
+def generate_container() -> V1Container:
+    return V1Container(
+        name=CONTAINER_NAME,
+        image="docker.io/merlintang/xgboost-dist-iris:1.1",
+        args=[
+            "--job_type=Train",
+            "--xgboost_parameter=objective:multi:softprob,num_class:3",
+            "--n_estimators=10",
+            "--learning_rate=0.1",
+            "--model_path=/tmp/xgboost-model",
+            "--model_storage_type=local",
+        ],
+    )

--- a/sdk/python/test/e2e/utils.py
+++ b/sdk/python/test/e2e/utils.py
@@ -69,6 +69,7 @@ def verify_job_e2e(
 def get_pod_spec_scheduler_name(gang_scheduler_name: str) -> str:
     if gang_scheduler_name == TEST_GANG_SCHEDULER_NAME_SCHEDULER_PLUGINS:
         return DEFAULT_SCHEDULER_PLUGINS_NAME
+    # TODO (tenzen-y): Implement E2E tests using volcano.
     elif gang_scheduler_name == TEST_GANG_SCHEDULER_NAME_VOLCANO:
         return ""
 

--- a/sdk/python/test/e2e/utils.py
+++ b/sdk/python/test/e2e/utils.py
@@ -1,10 +1,30 @@
 import logging
 
 from kubeflow.training import TrainingClient
-
+from kubeflow.training.constants import constants
+from test.e2e.constants import TEST_GANG_SCHEDULER_NAME_SCHEDULER_PLUGINS
+from test.e2e.constants import DEFAULT_SCHEDULER_PLUGINS_NAME
+from test.e2e.constants import TEST_GANG_SCHEDULER_NAME_VOLCANO
 
 logging.basicConfig(format="%(message)s")
 logging.getLogger().setLevel(logging.INFO)
+
+
+def verify_unschedulable_job_e2e(
+    client: TrainingClient, name: str, namespace: str, job_kind: str
+):
+    """Verify unschedulable Training Job e2e test."""
+    logging.info(f"\n\n\n{job_kind} is creating")
+    client.wait_for_job_conditions(name, namespace, job_kind, {constants.JOB_CONDITION_CREATED})
+
+    # Job should have Created conditions.
+    conditions = client.get_job_conditions(name, namespace, job_kind)
+    if len(conditions) != 1:
+        raise Exception(f"{job_kind} conditions are invalid: {conditions}")
+
+    # Job should have correct conditions.
+    if not client.is_job_created(name, namespace, job_kind):
+        raise Exception(f"{job_kind} should be in Created condition")
 
 
 def verify_job_e2e(
@@ -44,3 +64,12 @@ def verify_job_e2e(
     # Print Job logs.
     logging.info(f"\n\n\n{job_kind} logs")
     client.get_job_logs(name, namespace, container=container)
+
+
+def get_pod_spec_scheduler_name(gang_scheduler_name: str) -> str:
+    if gang_scheduler_name == TEST_GANG_SCHEDULER_NAME_SCHEDULER_PLUGINS:
+        return DEFAULT_SCHEDULER_PLUGINS_NAME
+    elif gang_scheduler_name == TEST_GANG_SCHEDULER_NAME_VOLCANO:
+        return ""
+
+    return ""


### PR DESCRIPTION
Signed-off-by: Yuki Iwai <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I added the E2E test for gang-scheduling.
Also, I added functions to apply patches to CustomJob resources to Python SDK.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Follow up on #1724.

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
