### PR TITLE
Run E2E with various Python versions to verify Python SDK

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -12,13 +12,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.23.12", "v1.24.6", "v1.25.2"]
         # TODO (tenzen-y): Add volcano.
-        gang-scheduler-name: ["none", "scheduler-plugins"]
+        include:
+          - kubernetes-version: v1.23.12
+            gang-scheduler-name: "none"
+            python-version: "3.10"
+          - kubernetes-version: v1.24.6
+            gang-scheduler-name: "none"
+            python-version: "3.7"
+          - kubernetes-version: v1.25.2
+            gang-scheduler-name: "none"
+            python-version: "3.8"
+          - kubernetes-version: v1.23.12
+            gang-scheduler-name: "scheduler-plugins"
+            python-version: "3.9"
+          - kubernetes-version: v1.24.6
+            gang-scheduler-name: "scheduler-plugins"
+            python-version: "3.10"
+          - kubernetes-version: v1.25.2
+            gang-scheduler-name: "scheduler-plugins"
+            python-version: "3.10"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
 
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.3.0


### PR DESCRIPTION
Signed-off-by: Yuki Iwai <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
As with https://github.com/kubeflow/katib/pull/2092, run E2E with various Python versions to verify Python SDK.

/assign @andreyvelich @johnugeorge @terrytangyuan 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
