### PR TITLE
Add validation for verifying that the CustomJob (e.g., TFJob) name meets DNS1035

### DIFF
--- a/pkg/apis/kubeflow.org/v1/mxnet_validation.go
+++ b/pkg/apis/kubeflow.org/v1/mxnet_validation.go
@@ -16,14 +16,21 @@ package v1
 
 import (
 	"fmt"
-	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 
+	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 	log "github.com/sirupsen/logrus"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 )
 
-// ValidateV1MXJobSpec checks that the kubeflowv1.MXJobSpec is valid.
-func ValidateV1MXJobSpec(c *MXJobSpec) error {
-	return validateMXNetReplicaSpecs(c.MXReplicaSpecs)
+// ValidateV1MXJob checks that the kubeflowv1.MXJobSpec is valid.
+func ValidateV1MXJob(mxJob *MXJob) error {
+	if errors := apimachineryvalidation.NameIsDNS1035Label(mxJob.ObjectMeta.Name, false); errors != nil {
+		return fmt.Errorf("MXJob name is invalid: %v", errors)
+	}
+	if err := validateMXReplicaSpecs(mxJob.Spec.MXReplicaSpecs); err != nil {
+		return err
+	}
+	return nil
 }
 
 // IsScheduler returns true if the type is Scheduler.
@@ -31,7 +38,7 @@ func IsScheduler(typ commonv1.ReplicaType) bool {
 	return typ == MXJobReplicaTypeScheduler
 }
 
-func validateMXNetReplicaSpecs(specs map[commonv1.ReplicaType]*commonv1.ReplicaSpec) error {
+func validateMXReplicaSpecs(specs map[commonv1.ReplicaType]*commonv1.ReplicaSpec) error {
 	if specs == nil {
 		return fmt.Errorf("MXJobSpec is not valid")
 	}

--- a/pkg/apis/kubeflow.org/v1/paddlepaddle_validation_test.go
+++ b/pkg/apis/kubeflow.org/v1/paddlepaddle_validation_test.go
@@ -18,61 +18,150 @@ import (
 	"testing"
 
 	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
-func TestValidateV1PaddleJobSpec(t *testing.T) {
-	testCases := []PaddleJobSpec{
-		{
-			PaddleReplicaSpecs: nil,
-		},
-		{
-			PaddleReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
-				PaddleJobReplicaTypeWorker: {
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{},
+func TestValidateV1PaddleJob(t *testing.T) {
+	validPaddleReplicaSpecs := map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+		PaddleJobReplicaTypeWorker: {
+			Replicas:      pointer.Int32(2),
+			RestartPolicy: commonv1.RestartPolicyNever,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:    "paddle",
+						Image:   "registry.baidubce.com/paddlepaddle/paddle:2.4.0rc0-cpu",
+						Command: []string{"python"},
+						Args: []string{
+							"-m",
+							"paddle.distributed.launch",
+							"run_check",
 						},
-					},
-				},
-			},
-		},
-		{
-			PaddleReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
-				PaddleJobReplicaTypeWorker: {
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
-								{
-									Image: "",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			PaddleReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
-				PaddleJobReplicaTypeWorker: {
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
-								{
-									Name:  "",
-									Image: "gcr.io/kubeflow-ci/paddle-dist-mnist_test:1.0",
-								},
-							},
-						},
-					},
+						Ports: []corev1.ContainerPort{{
+							Name:          "master",
+							ContainerPort: int32(37777),
+						}},
+						ImagePullPolicy: corev1.PullAlways,
+					}},
 				},
 			},
 		},
 	}
-	for _, c := range testCases {
-		err := ValidateV1PaddleJobSpec(&c)
-		if err == nil {
-			t.Error("Failed validate the v1.PaddleJobSpec")
-		}
+
+	testCases := map[string]struct {
+		paddleJob *PaddleJob
+		wantErr   bool
+	}{
+		"valid paddleJob": {
+			paddleJob: &PaddleJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: PaddleJobSpec{
+					PaddleReplicaSpecs: validPaddleReplicaSpecs,
+				},
+			},
+			wantErr: false,
+		},
+		"paddleJob name does not meet DNS1035": {
+			paddleJob: &PaddleJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "__test",
+				},
+				Spec: PaddleJobSpec{
+					PaddleReplicaSpecs: validPaddleReplicaSpecs,
+				},
+			},
+			wantErr: true,
+		},
+		"no containers": {
+			paddleJob: &PaddleJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: PaddleJobSpec{
+					PaddleReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+						PaddleJobReplicaTypeWorker: {
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		"image is empty": {
+			paddleJob: &PaddleJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: PaddleJobSpec{
+					PaddleReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+						PaddleJobReplicaTypeWorker: {
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  "paddle",
+											Image: "",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		"paddle default container name doesn't find": {
+			paddleJob: &PaddleJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: PaddleJobSpec{
+					PaddleReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+						PaddleJobReplicaTypeWorker: {
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  "",
+											Image: "gcr.io/kubeflow-ci/paddle-dist-mnist_test:1.0",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		"replicaSpec is nil": {
+			paddleJob: &PaddleJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: PaddleJobSpec{
+					PaddleReplicaSpecs: nil,
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := ValidateV1PaddleJob(tc.paddleJob)
+			if (got != nil) != tc.wantErr {
+				t.Fatalf("ValidateV1PaddleJob() error = %v, wantErr %v", got, tc.wantErr)
+			}
+		})
 	}
 }

--- a/pkg/apis/kubeflow.org/v1/tensorflow_validation.go
+++ b/pkg/apis/kubeflow.org/v1/tensorflow_validation.go
@@ -17,10 +17,20 @@ package v1
 import (
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
-
 	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
+	log "github.com/sirupsen/logrus"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 )
+
+func ValidateV1TFJob(tfjob *TFJob) error {
+	if errors := apimachineryvalidation.NameIsDNS1035Label(tfjob.ObjectMeta.Name, false); errors != nil {
+		return fmt.Errorf("TFJob name is invalid: %v", errors)
+	}
+	if err := validateV1TFReplicaSpecs(tfjob.Spec.TFReplicaSpecs); err != nil {
+		return err
+	}
+	return nil
+}
 
 // IsChieforMaster returns true if the type is Master or Chief.
 func IsChieforMaster(typ commonv1.ReplicaType) bool {
@@ -37,12 +47,7 @@ func IsEvaluator(typ commonv1.ReplicaType) bool {
 	return typ == TFJobReplicaTypeEval
 }
 
-// ValidateV1TFJobSpec checks that the v1.TFJobSpec is valid.
-func ValidateV1TFJobSpec(c *TFJobSpec) error {
-	return validateV1ReplicaSpecs(c.TFReplicaSpecs)
-}
-
-func validateV1ReplicaSpecs(specs map[commonv1.ReplicaType]*commonv1.ReplicaSpec) error {
+func validateV1TFReplicaSpecs(specs map[commonv1.ReplicaType]*commonv1.ReplicaSpec) error {
 	if specs == nil {
 		return fmt.Errorf("TFJobSpec is not valid")
 	}

--- a/pkg/apis/kubeflow.org/v1/tensorflow_validation_test.go
+++ b/pkg/apis/kubeflow.org/v1/tensorflow_validation_test.go
@@ -19,79 +19,154 @@ import (
 
 	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
-func TestValidateV1TFJobSpec(t *testing.T) {
-	testCases := []TFJobSpec{
-		{
-			TFReplicaSpecs: nil,
-		},
-		{
-			TFReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
-				TFJobReplicaTypeWorker: &commonv1.ReplicaSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{},
+func TestValidateV1TFJob(t *testing.T) {
+	validTFReplicaSpecs := map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+		TFJobReplicaTypeWorker: {
+			Replicas:      pointer.Int32(2),
+			RestartPolicy: commonv1.RestartPolicyOnFailure,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "tensorflow",
+						Image: "kubeflow/tf-mnist-with-summaries:latest",
+						Command: []string{
+							"python",
+							"/var/tf_mnist/mnist_with_summaries.py",
 						},
-					},
-				},
-			},
-		},
-		{
-			TFReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
-				TFJobReplicaTypeWorker: &commonv1.ReplicaSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								corev1.Container{
-									Image: "",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			TFReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
-				TFJobReplicaTypeWorker: &commonv1.ReplicaSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								corev1.Container{
-									Name:  "",
-									Image: "kubeflow/tf-dist-mnist-test:1.0",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			TFReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
-				TFJobReplicaTypeChief: &commonv1.ReplicaSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{},
-						},
-					},
-				},
-				TFJobReplicaTypeMaster: &commonv1.ReplicaSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{},
-						},
-					},
+					}},
 				},
 			},
 		},
 	}
-	for _, c := range testCases {
-		err := ValidateV1TFJobSpec(&c)
-		if err == nil {
-			t.Error("Expected error got nil")
-		}
+
+	testCases := map[string]struct {
+		tfJob   *TFJob
+		wantErr bool
+	}{
+		"valid tfJob": {
+			tfJob: &TFJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: TFJobSpec{
+					TFReplicaSpecs: validTFReplicaSpecs,
+				},
+			},
+			wantErr: false,
+		},
+		"TFJob name does not meet DNS1035": {
+			tfJob: &TFJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "00test",
+				},
+				Spec: TFJobSpec{
+					TFReplicaSpecs: validTFReplicaSpecs,
+				},
+			},
+			wantErr: true,
+		},
+		"no containers": {
+			tfJob: &TFJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: TFJobSpec{
+					TFReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+						TFJobReplicaTypeWorker: {
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		"empty image": {
+			tfJob: &TFJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: TFJobSpec{
+					TFReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+						TFJobReplicaTypeWorker: {
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Name:  "tensorflow",
+										Image: "",
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		"tfJob default container name doesn't present": {
+			tfJob: &TFJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: TFJobSpec{
+					TFReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+						TFJobReplicaTypeWorker: {
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Name:  "",
+										Image: "kubeflow/tf-dist-mnist-test:1.0",
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		"there are more than 2 masterReplica's or ChiefReplica's": {
+			tfJob: &TFJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: TFJobSpec{
+					TFReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+						TFJobReplicaTypeChief: {
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{},
+								},
+							},
+						},
+						TFJobReplicaTypeMaster: {
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := ValidateV1TFJob(tc.tfJob)
+			if (got != nil) != tc.wantErr {
+				t.Fatalf("ValidateV1TFJob() error = %v, wantErr %v", got, tc.wantErr)
+			}
+		})
 	}
 }
 

--- a/pkg/apis/kubeflow.org/v1/xgboost_validation_test.go
+++ b/pkg/apis/kubeflow.org/v1/xgboost_validation_test.go
@@ -15,99 +15,209 @@
 package v1
 
 import (
-	"k8s.io/utils/pointer"
 	"testing"
 
 	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
-func TestValidateXGBoostJobSpec(t *testing.T) {
-	testCases := []XGBoostJobSpec{
-		{
-			XGBReplicaSpecs: nil,
-		},
-		{
-			XGBReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
-				XGBoostJobReplicaTypeWorker: &commonv1.ReplicaSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{},
+func TestValidateV1XGBoostJob(t *testing.T) {
+	validXGBoostReplicaSpecs := map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+		XGBoostJobReplicaTypeMaster: {
+			Replicas:      pointer.Int32(1),
+			RestartPolicy: commonv1.RestartPolicyNever,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "xgboost",
+						Image: "docker.io/merlintang/xgboost-dist-iris:1.1",
+						Ports: []corev1.ContainerPort{{
+							Name:          "xgboostjob-port",
+							ContainerPort: 9991,
+						}},
+						ImagePullPolicy: corev1.PullAlways,
+						Args: []string{
+							"--job_type=Train",
+							"--xgboost_parameter=objective:multi:softprob,num_class:3",
+							"--n_estimators=10",
+							"--learning_rate=0.1",
+							"--model_path=/tmp/xgboost-model",
+							"--model_storage_type=local",
 						},
-					},
+					}},
 				},
 			},
 		},
-		{
-			XGBReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
-				XGBoostJobReplicaTypeWorker: &commonv1.ReplicaSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								corev1.Container{
-									Image: "",
-								},
-							},
+		XGBoostJobReplicaTypeWorker: {
+			Replicas:      pointer.Int32(2),
+			RestartPolicy: commonv1.RestartPolicyExitCode,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "xgboost",
+						Image: "docker.io/merlintang/xgboost-dist-iris:1.",
+						Ports: []corev1.ContainerPort{{
+							Name:          "xgboostjob-port",
+							ContainerPort: 9991,
+						}},
+						ImagePullPolicy: corev1.PullAlways,
+						Args: []string{
+							"--job_type=Train",
+							"--xgboost_parameter=objective:multi:softprob,num_class:3",
+							"--n_estimators=10",
+							"--learning_rate=0.1",
 						},
-					},
-				},
-			},
-		},
-		{
-			XGBReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
-				XGBoostJobReplicaTypeWorker: &commonv1.ReplicaSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								corev1.Container{
-									Name:  "",
-									Image: "gcr.io/kubeflow-ci/xgboost-dist-mnist_test:1.0",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			XGBReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
-				XGBoostJobReplicaTypeMaster: &commonv1.ReplicaSpec{
-					Replicas: pointer.Int32(2),
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								corev1.Container{
-									Name:  "xgboost",
-									Image: "gcr.io/kubeflow-ci/xgboost-dist-mnist_test:1.0",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			XGBReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
-				XGBoostJobReplicaTypeWorker: &commonv1.ReplicaSpec{
-					Replicas: pointer.Int32(1),
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								corev1.Container{
-									Name:  "xgboost",
-									Image: "gcr.io/kubeflow-ci/xgboost-dist-mnist_test:1.0",
-								},
-							},
-						},
-					},
+					}},
 				},
 			},
 		},
 	}
-	for _, c := range testCases {
-		err := ValidateXGBoostJobSpec(&c)
-		if err == nil {
-			t.Error("Failed validate the corev1.XGBoostJobSpec")
-		}
+
+	testCases := map[string]struct {
+		xgboostJob *XGBoostJob
+		wantErr    bool
+	}{
+		"valid XGBoostJob": {
+			xgboostJob: &XGBoostJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: XGBoostJobSpec{
+					XGBReplicaSpecs: validXGBoostReplicaSpecs,
+				},
+			},
+			wantErr: false,
+		},
+		"XGBoostJob name does not meet DNS1035": {
+			xgboostJob: &XGBoostJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "-test",
+				},
+				Spec: XGBoostJobSpec{
+					XGBReplicaSpecs: validXGBoostReplicaSpecs,
+				},
+			},
+			wantErr: true,
+		},
+		"empty containers": {
+			xgboostJob: &XGBoostJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: XGBoostJobSpec{
+					XGBReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+						XGBoostJobReplicaTypeWorker: {
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		"image is empty": {
+			xgboostJob: &XGBoostJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: XGBoostJobSpec{
+					XGBReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+						XGBoostJobReplicaTypeWorker: {
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Name:  "xgboost",
+										Image: "",
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		"xgboostJob default container name doesn't present": {
+			xgboostJob: &XGBoostJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: XGBoostJobSpec{
+					XGBReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+						XGBoostJobReplicaTypeWorker: {
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Name:  "",
+										Image: "gcr.io/kubeflow-ci/xgboost-dist-mnist_test:1.0",
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		"the number of replicas in masterReplica is other than 1": {
+			xgboostJob: &XGBoostJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: XGBoostJobSpec{
+					XGBReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+						XGBoostJobReplicaTypeMaster: {
+							Replicas: pointer.Int32(2),
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Name:  "xgboost",
+										Image: "gcr.io/kubeflow-ci/xgboost-dist-mnist_test:1.0",
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		"masterReplica does not exist": {
+			xgboostJob: &XGBoostJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: XGBoostJobSpec{
+					XGBReplicaSpecs: map[commonv1.ReplicaType]*commonv1.ReplicaSpec{
+						XGBoostJobReplicaTypeWorker: {
+							Replicas: pointer.Int32(1),
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Name:  "xgboost",
+										Image: "gcr.io/kubeflow-ci/xgboost-dist-mnist_test:1.0",
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := ValidateV1XGBoostJob(tc.xgboostJob)
+			if (got != nil) != tc.wantErr {
+				t.Fatalf("ValidateV1XGBoostJob() error = %v, wantErr %v", got, tc.wantErr)
+			}
+		})
 	}
 }

--- a/pkg/controller.v1/mxnet/mxjob_controller.go
+++ b/pkg/controller.v1/mxnet/mxjob_controller.go
@@ -128,7 +128,7 @@ func (r *MXJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if err = kubeflowv1.ValidateV1MXJobSpec(&mxjob.Spec); err != nil {
+	if err = kubeflowv1.ValidateV1MXJob(mxjob); err != nil {
 		logger.Error(err, "MXJob failed validation")
 		r.Recorder.Eventf(mxjob, corev1.EventTypeWarning, commonutil.JobFailedValidationReason, "MXJob failed validation because %s", err)
 		return ctrl.Result{}, err

--- a/pkg/controller.v1/paddlepaddle/paddlepaddle_controller.go
+++ b/pkg/controller.v1/paddlepaddle/paddlepaddle_controller.go
@@ -129,7 +129,7 @@ func (r *PaddleJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if err = kubeflowv1.ValidateV1PaddleJobSpec(&paddlejob.Spec); err != nil {
+	if err = kubeflowv1.ValidateV1PaddleJob(paddlejob); err != nil {
 		logger.Error(err, "PaddleJob failed validation")
 		r.Recorder.Eventf(paddlejob, corev1.EventTypeWarning, commonutil.JobFailedValidationReason, "PaddleJob failed validation because %s", err)
 		return ctrl.Result{}, err

--- a/pkg/controller.v1/pytorch/pytorchjob_controller.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller.go
@@ -129,7 +129,7 @@ func (r *PyTorchJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if err = kubeflowv1.ValidateV1PyTorchJobSpec(&pytorchjob.Spec); err != nil {
+	if err = kubeflowv1.ValidateV1PyTorchJob(pytorchjob); err != nil {
 		logger.Error(err, "PyTorchJob failed validation")
 		r.Recorder.Eventf(pytorchjob, corev1.EventTypeWarning, commonutil.JobFailedValidationReason, "PyTorchJob failed validation because %s", err)
 		return ctrl.Result{}, err

--- a/pkg/controller.v1/tensorflow/tfjob_controller.go
+++ b/pkg/controller.v1/tensorflow/tfjob_controller.go
@@ -147,7 +147,7 @@ func (r *TFJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if err = kubeflowv1.ValidateV1TFJobSpec(&tfjob.Spec); err != nil {
+	if err = kubeflowv1.ValidateV1TFJob(tfjob); err != nil {
 		logger.Error(err, "TFJob failed validation")
 		r.Recorder.Eventf(tfjob, corev1.EventTypeWarning, commonutil.JobFailedValidationReason, "TFJob failed validation because %s", err)
 		return ctrl.Result{}, err

--- a/pkg/controller.v1/xgboost/xgboostjob_controller.go
+++ b/pkg/controller.v1/xgboost/xgboostjob_controller.go
@@ -139,7 +139,7 @@ func (r *XGBoostJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if err = kubeflowv1.ValidateXGBoostJobSpec(&xgboostjob.Spec); err != nil {
+	if err = kubeflowv1.ValidateV1XGBoostJob(xgboostjob); err != nil {
 		logger.Error(err, "XGBoostJob failed validation")
 		r.Recorder.Eventf(xgboostjob, corev1.EventTypeWarning, commonutil.JobFailedValidationReason, "XGBoostJob failed validation because %s", err)
 		return ctrl.Result{}, err


### PR DESCRIPTION
Signed-off-by: Yuki Iwai <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I added validation for verifying that the CustomJob (e.g., TFJob) name meets DNS1035.
Also, I refactored unit tests for validation.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #1745

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
