### PR TITLE
[Bugfix][SDK] pod has no metadata attr anymore in the get_job_logs() …

### DIFF
--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -577,7 +577,7 @@ class TrainingClient(object):
                     logging.info("The logs of pod %s:\n %s", pod, pod_logs)
                 except Exception:
                     raise RuntimeError(
-                        f"Failed to read logs for pod {namespace}/{pod.metadata.name}"
+                        f"Failed to read logs for pod {namespace}/{pod}"
                     )
 
     # ------------------------------------------------------------------------ #


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

In the `get_job_logs()` func of the newly unified Training Client of python sdk, as the return type of `get_job_pod_names()` is [str] now, no metadata attr for log anymore.

A careless bug I believe, just found it when I was testing my own proj.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
