### PR TITLE
E2e test in k8s cluster and Namespace option

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -79,6 +79,6 @@ jobs:
       - name: Run tests
         run: |
           pip install pytest
-          python3 -m pip install -e sdk/python; pytest sdk/python/test --log-cli-level=info
+          python3 -m pip install -e sdk/python; pytest sdk/python/test --log-cli-level=info --namespace=default
         env:
           GANG_SCHEDULER_NAME: ${{ matrix.gang-scheduler-name }}

--- a/hack/python-sdk/gen-sdk.sh
+++ b/hack/python-sdk/gen-sdk.sh
@@ -43,7 +43,7 @@ echo "Generating swagger file ..."
 go run "${repo_root}"/hack/swagger/main.go ${VERSION} >"${SWAGGER_CODEGEN_FILE}"
 
 echo "Removing previously generated files ..."
-rm -rf "${SDK_OUTPUT_PATH}"/docs/V1*.md "${SDK_OUTPUT_PATH}"/kubeflow/training/models "${SDK_OUTPUT_PATH}"/kubeflow/training/*.py "${SDK_OUTPUT_PATH}"/test/*.py
+rm -rf "${SDK_OUTPUT_PATH}"/docs/V1*.md "${SDK_OUTPUT_PATH}"/kubeflow/training/models "${SDK_OUTPUT_PATH}"/kubeflow/training/*.py "${SDK_OUTPUT_PATH}"/test/test_*.py
 echo "Generating Python SDK for Training Operator ..."
 java -jar "${SWAGGER_CODEGEN_JAR}" generate -i "${repo_root}"/hack/python-sdk/swagger.json -g python -o "${SDK_OUTPUT_PATH}" -c "${SWAGGER_CODEGEN_CONF}"
 

--- a/sdk/python/test/conftest.py
+++ b/sdk/python/test/conftest.py
@@ -1,9 +1,4 @@
-import os
 import pytest
-
-from kubeflow.training.utils.utils import is_running_in_k8s
-from kubeflow.training import TrainingClient
-
 
 def pytest_addoption(parser):
     parser.addoption("--namespace", action="store", default="default")

--- a/sdk/python/test/e2e/conftest.py
+++ b/sdk/python/test/e2e/conftest.py
@@ -1,0 +1,21 @@
+import os
+import pytest
+
+from kubeflow.training.utils.utils import is_running_in_k8s
+from kubeflow.training import TrainingClient
+
+
+def pytest_addoption(parser):
+    parser.addoption("--namespace", action="store", default="default")
+
+
+@pytest.fixture
+def job_namespace(request):
+    return request.config.getoption("--namespace")
+
+@pytest.fixture
+def training_client():
+    if is_running_in_k8s():
+        return TrainingClient()
+    else:
+        return TrainingClient(config_file=os.getenv("KUBECONFIG", "~/.kube/config"))

--- a/sdk/python/test/e2e/conftest.py
+++ b/sdk/python/test/e2e/conftest.py
@@ -12,10 +12,3 @@ def pytest_addoption(parser):
 @pytest.fixture
 def job_namespace(request):
     return request.config.getoption("--namespace")
-
-@pytest.fixture
-def training_client():
-    if is_running_in_k8s():
-        return TrainingClient()
-    else:
-        return TrainingClient(config_file=os.getenv("KUBECONFIG", "~/.kube/config"))

--- a/sdk/python/test/e2e/test_e2e_mpijob.py
+++ b/sdk/python/test/e2e/test_e2e_mpijob.py
@@ -22,6 +22,7 @@ from kubernetes.client import V1ObjectMeta
 from kubernetes.client import V1PodSpec
 from kubernetes.client import V1Container
 
+from kubeflow.training import TrainingClient
 from kubeflow.training import V1ReplicaSpec
 from kubeflow.training import KubeflowOrgV1MPIJob
 from kubeflow.training import KubeflowOrgV1MPIJobSpec
@@ -36,6 +37,7 @@ from test.e2e.constants import GANG_SCHEDULERS, NONE_GANG_SCHEDULERS
 logging.basicConfig(format="%(message)s")
 logging.getLogger().setLevel(logging.INFO)
 
+TRAINING_CLIENT = TrainingClient()
 JOB_NAME = "mpijob-mxnet-ci-test"
 CONTAINER_NAME = "mpi"
 GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
@@ -44,7 +46,7 @@ GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 @pytest.mark.skipif(
     GANG_SCHEDULER_NAME in NONE_GANG_SCHEDULERS, reason="For gang-scheduling",
 )
-def test_sdk_e2e_with_gang_scheduling(job_namespace, training_client):
+def test_sdk_e2e_with_gang_scheduling(job_namespace):
     launcher_container, worker_container = generate_containers()
 
     launcher = V1ReplicaSpec(
@@ -68,36 +70,36 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace, training_client):
     mpijob = generate_mpijob(launcher, worker, V1SchedulingPolicy(min_available=10), job_namespace)
     patched_mpijob = generate_mpijob(launcher, worker, V1SchedulingPolicy(min_available=2), job_namespace)
 
-    training_client.create_mpijob(mpijob, job_namespace)
+    TRAINING_CLIENT.create_mpijob(mpijob, job_namespace)
     logging.info(f"List of created {constants.MPIJOB_KIND}s")
-    logging.info(training_client.list_mpijobs(job_namespace))
+    logging.info(TRAINING_CLIENT.list_mpijobs(job_namespace))
 
     verify_unschedulable_job_e2e(
-        training_client,
+        TRAINING_CLIENT,
         JOB_NAME,
         job_namespace,
         constants.MPIJOB_KIND,
     )
 
-    training_client.patch_mpijob(patched_mpijob, JOB_NAME, job_namespace)
+    TRAINING_CLIENT.patch_mpijob(patched_mpijob, JOB_NAME, job_namespace)
     logging.info(f"List of patched {constants.MPIJOB_KIND}s")
-    logging.info(training_client.list_mpijobs(job_namespace))
+    logging.info(TRAINING_CLIENT.list_mpijobs(job_namespace))
 
     verify_job_e2e(
-        training_client,
+        TRAINING_CLIENT,
         JOB_NAME,
         job_namespace,
         constants.MPIJOB_KIND,
         CONTAINER_NAME,
     )
 
-    training_client.delete_mpijob(JOB_NAME, job_namespace)
+    TRAINING_CLIENT.delete_mpijob(JOB_NAME, job_namespace)
 
 
 @pytest.mark.skipif(
     GANG_SCHEDULER_NAME in GANG_SCHEDULERS, reason="For plain scheduling",
 )
-def test_sdk_e2e(job_namespace, training_client):
+def test_sdk_e2e(job_namespace):
     launcher_container, worker_container = generate_containers()
 
     launcher = V1ReplicaSpec(
@@ -114,19 +116,19 @@ def test_sdk_e2e(job_namespace, training_client):
 
     mpijob = generate_mpijob(launcher, worker, job_namespace=job_namespace)
 
-    training_client.create_mpijob(mpijob, job_namespace)
+    TRAINING_CLIENT.create_mpijob(mpijob, job_namespace)
     logging.info(f"List of created {constants.MPIJOB_KIND}s")
-    logging.info(training_client.list_mpijobs(job_namespace))
+    logging.info(TRAINING_CLIENT.list_mpijobs(job_namespace))
 
     verify_job_e2e(
-        training_client,
+        TRAINING_CLIENT,
         JOB_NAME,
         job_namespace,
         constants.MPIJOB_KIND,
         CONTAINER_NAME,
     )
 
-    training_client.delete_mpijob(JOB_NAME, job_namespace)
+    TRAINING_CLIENT.delete_mpijob(JOB_NAME, job_namespace)
 
 
 def generate_mpijob(

--- a/sdk/python/test/e2e/test_e2e_mpijob.py
+++ b/sdk/python/test/e2e/test_e2e_mpijob.py
@@ -22,7 +22,6 @@ from kubernetes.client import V1ObjectMeta
 from kubernetes.client import V1PodSpec
 from kubernetes.client import V1Container
 
-from kubeflow.training import TrainingClient
 from kubeflow.training import V1ReplicaSpec
 from kubeflow.training import KubeflowOrgV1MPIJob
 from kubeflow.training import KubeflowOrgV1MPIJobSpec
@@ -37,9 +36,7 @@ from test.e2e.constants import GANG_SCHEDULERS, NONE_GANG_SCHEDULERS
 logging.basicConfig(format="%(message)s")
 logging.getLogger().setLevel(logging.INFO)
 
-TRAINING_CLIENT = TrainingClient(config_file=os.getenv("KUBECONFIG", "~/.kube/config"))
 JOB_NAME = "mpijob-mxnet-ci-test"
-JOB_NAMESPACE = "default"
 CONTAINER_NAME = "mpi"
 GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 
@@ -47,7 +44,7 @@ GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 @pytest.mark.skipif(
     GANG_SCHEDULER_NAME in NONE_GANG_SCHEDULERS, reason="For gang-scheduling",
 )
-def test_sdk_e2e_with_gang_scheduling():
+def test_sdk_e2e_with_gang_scheduling(job_namespace, training_client):
     launcher_container, worker_container = generate_containers()
 
     launcher = V1ReplicaSpec(
@@ -68,39 +65,39 @@ def test_sdk_e2e_with_gang_scheduling():
         )),
     )
 
-    mpijob = generate_mpijob(launcher, worker, V1SchedulingPolicy(min_available=10))
-    patched_mpijob = generate_mpijob(launcher, worker, V1SchedulingPolicy(min_available=2))
+    mpijob = generate_mpijob(launcher, worker, V1SchedulingPolicy(min_available=10), job_namespace)
+    patched_mpijob = generate_mpijob(launcher, worker, V1SchedulingPolicy(min_available=2), job_namespace)
 
-    TRAINING_CLIENT.create_mpijob(mpijob, JOB_NAMESPACE)
+    training_client.create_mpijob(mpijob, job_namespace)
     logging.info(f"List of created {constants.MPIJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_mpijobs(JOB_NAMESPACE))
+    logging.info(training_client.list_mpijobs(job_namespace))
 
     verify_unschedulable_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.MPIJOB_KIND,
     )
 
-    TRAINING_CLIENT.patch_mpijob(patched_mpijob, JOB_NAME, JOB_NAMESPACE)
+    training_client.patch_mpijob(patched_mpijob, JOB_NAME, job_namespace)
     logging.info(f"List of patched {constants.MPIJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_mpijobs(JOB_NAMESPACE))
+    logging.info(training_client.list_mpijobs(job_namespace))
 
     verify_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.MPIJOB_KIND,
         CONTAINER_NAME,
     )
 
-    TRAINING_CLIENT.delete_mpijob(JOB_NAME, JOB_NAMESPACE)
+    training_client.delete_mpijob(JOB_NAME, job_namespace)
 
 
 @pytest.mark.skipif(
     GANG_SCHEDULER_NAME in GANG_SCHEDULERS, reason="For plain scheduling",
 )
-def test_sdk_e2e():
+def test_sdk_e2e(job_namespace, training_client):
     launcher_container, worker_container = generate_containers()
 
     launcher = V1ReplicaSpec(
@@ -115,32 +112,33 @@ def test_sdk_e2e():
         template=V1PodTemplateSpec(spec=V1PodSpec(containers=[worker_container])),
     )
 
-    mpijob = generate_mpijob(launcher, worker, None)
+    mpijob = generate_mpijob(launcher, worker, job_namespace=job_namespace)
 
-    TRAINING_CLIENT.create_mpijob(mpijob, JOB_NAMESPACE)
+    training_client.create_mpijob(mpijob, job_namespace)
     logging.info(f"List of created {constants.MPIJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_mpijobs(JOB_NAMESPACE))
+    logging.info(training_client.list_mpijobs(job_namespace))
 
     verify_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.MPIJOB_KIND,
         CONTAINER_NAME,
     )
 
-    TRAINING_CLIENT.delete_mpijob(JOB_NAME, JOB_NAMESPACE)
+    training_client.delete_mpijob(JOB_NAME, job_namespace)
 
 
 def generate_mpijob(
     launcher: V1ReplicaSpec,
     worker: V1ReplicaSpec,
     scheduling_policy: V1SchedulingPolicy = None,
+    job_namespace: str = "default",
 ) -> KubeflowOrgV1MPIJob:
     return KubeflowOrgV1MPIJob(
         api_version="kubeflow.org/v1",
         kind="MPIJob",
-        metadata=V1ObjectMeta(name=JOB_NAME, namespace=JOB_NAMESPACE),
+        metadata=V1ObjectMeta(name=JOB_NAME, namespace=job_namespace),
         spec=KubeflowOrgV1MPIJobSpec(
             slots_per_worker=1,
             run_policy=V1RunPolicy(

--- a/sdk/python/test/e2e/test_e2e_mxjob.py
+++ b/sdk/python/test/e2e/test_e2e_mxjob.py
@@ -23,7 +23,6 @@ from kubernetes.client import V1PodSpec
 from kubernetes.client import V1Container
 from kubernetes.client import V1ContainerPort
 
-from kubeflow.training import TrainingClient
 from kubeflow.training import V1ReplicaSpec
 from kubeflow.training import KubeflowOrgV1MXJob
 from kubeflow.training import KubeflowOrgV1MXJobSpec
@@ -38,9 +37,7 @@ from test.e2e.constants import GANG_SCHEDULERS, NONE_GANG_SCHEDULERS
 logging.basicConfig(format="%(message)s")
 logging.getLogger().setLevel(logging.INFO)
 
-TRAINING_CLIENT = TrainingClient(config_file=os.getenv("KUBECONFIG", "~/.kube/config"))
 JOB_NAME = "mxjob-mnist-ci-test"
-JOB_NAMESPACE = "default"
 CONTAINER_NAME = "mxnet"
 GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 
@@ -48,7 +45,7 @@ GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 @pytest.mark.skipif(
     GANG_SCHEDULER_NAME in NONE_GANG_SCHEDULERS, reason="For gang-scheduling",
 )
-def test_sdk_e2e_with_gang_scheduling():
+def test_sdk_e2e_with_gang_scheduling(job_namespace, training_client):
     worker_container, server_container, scheduler_container = generate_containers()
 
     worker = V1ReplicaSpec(
@@ -78,39 +75,39 @@ def test_sdk_e2e_with_gang_scheduling():
         )),
     )
 
-    unschedulable_mxjob = generate_mxjob(scheduler, server, worker, V1SchedulingPolicy(min_available=10))
-    schedulable_mxjob = generate_mxjob(scheduler, server, worker, V1SchedulingPolicy(min_available=3))
+    unschedulable_mxjob = generate_mxjob(scheduler, server, worker, V1SchedulingPolicy(min_available=10), job_namespace)
+    schedulable_mxjob = generate_mxjob(scheduler, server, worker, V1SchedulingPolicy(min_available=3), job_namespace)
 
-    TRAINING_CLIENT.create_mxjob(unschedulable_mxjob, JOB_NAMESPACE)
+    training_client.create_mxjob(unschedulable_mxjob, job_namespace)
     logging.info(f"List of created {constants.MXJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_mxjobs(JOB_NAMESPACE))
+    logging.info(training_client.list_mxjobs(job_namespace))
 
     verify_unschedulable_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.MXJOB_KIND,
     )
 
-    TRAINING_CLIENT.patch_mxjob(schedulable_mxjob, JOB_NAME, JOB_NAMESPACE)
+    training_client.patch_mxjob(schedulable_mxjob, JOB_NAME, job_namespace)
     logging.info(f"List of patched {constants.MXJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_mxjobs(JOB_NAMESPACE))
+    logging.info(training_client.list_mxjobs(job_namespace))
 
     verify_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.MXJOB_KIND,
         CONTAINER_NAME,
     )
 
-    TRAINING_CLIENT.delete_mxjob(JOB_NAME, JOB_NAMESPACE)
+    training_client.delete_mxjob(JOB_NAME, job_namespace)
 
 
 @pytest.mark.skipif(
     GANG_SCHEDULER_NAME in GANG_SCHEDULERS, reason="For plain scheduling",
 )
-def test_sdk_e2e():
+def test_sdk_e2e(job_namespace, training_client):
     worker_container, server_container, scheduler_container = generate_containers()
 
     worker = V1ReplicaSpec(
@@ -131,21 +128,21 @@ def test_sdk_e2e():
         template=V1PodTemplateSpec(spec=V1PodSpec(containers=[scheduler_container])),
     )
 
-    mxjob = generate_mxjob(scheduler, server, worker)
+    mxjob = generate_mxjob(scheduler, server, worker, job_namespace=job_namespace)
 
-    TRAINING_CLIENT.create_mxjob(mxjob, JOB_NAMESPACE)
+    training_client.create_mxjob(mxjob, job_namespace)
     logging.info(f"List of created {constants.MXJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_mxjobs(JOB_NAMESPACE))
+    logging.info(training_client.list_mxjobs(job_namespace))
 
     verify_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.MXJOB_KIND,
         CONTAINER_NAME,
     )
 
-    TRAINING_CLIENT.delete_mxjob(JOB_NAME, JOB_NAMESPACE)
+    training_client.delete_mxjob(JOB_NAME, job_namespace)
 
 
 def generate_mxjob(
@@ -153,11 +150,12 @@ def generate_mxjob(
     server: V1ReplicaSpec,
     worker: V1ReplicaSpec,
     scheduling_policy: V1SchedulingPolicy = None,
+    job_namespace: str = "default",
 ) -> KubeflowOrgV1MXJob:
     return KubeflowOrgV1MXJob(
         api_version="kubeflow.org/v1",
         kind="MXJob",
-        metadata=V1ObjectMeta(name=JOB_NAME, namespace=JOB_NAMESPACE),
+        metadata=V1ObjectMeta(name=JOB_NAME, namespace=job_namespace),
         spec=KubeflowOrgV1MXJobSpec(
             job_mode="MXTrain",
             run_policy=V1RunPolicy(

--- a/sdk/python/test/e2e/test_e2e_paddlejob.py
+++ b/sdk/python/test/e2e/test_e2e_paddlejob.py
@@ -21,7 +21,6 @@ from kubernetes.client import V1ObjectMeta
 from kubernetes.client import V1PodSpec
 from kubernetes.client import V1Container
 
-from kubeflow.training import TrainingClient
 from kubeflow.training import V1ReplicaSpec
 from kubeflow.training import KubeflowOrgV1PaddleJob
 from kubeflow.training import KubeflowOrgV1PaddleJobSpec
@@ -36,9 +35,7 @@ from test.e2e.constants import GANG_SCHEDULERS, NONE_GANG_SCHEDULERS
 logging.basicConfig(format="%(message)s")
 logging.getLogger().setLevel(logging.INFO)
 
-TRAINING_CLIENT = TrainingClient(config_file=os.getenv("KUBECONFIG", "~/.kube/config"))
 JOB_NAME = "paddlejob-cpu-ci-test"
-JOB_NAMESPACE = "default"
 CONTAINER_NAME = "paddle"
 GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 
@@ -46,7 +43,7 @@ GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 @pytest.mark.skipif(
     GANG_SCHEDULER_NAME in NONE_GANG_SCHEDULERS, reason="For gang-scheduling",
 )
-def test_sdk_e2e_with_gang_scheduling():
+def test_sdk_e2e_with_gang_scheduling(job_namespace, training_client):
     container = generate_container()
 
     worker = V1ReplicaSpec(
@@ -58,39 +55,39 @@ def test_sdk_e2e_with_gang_scheduling():
         )),
     )
 
-    unschedulable_paddlejob = generate_paddlejob(worker, V1SchedulingPolicy(min_available=10))
-    schedulable_paddlejob = generate_paddlejob(worker, V1SchedulingPolicy(min_available=2))
+    unschedulable_paddlejob = generate_paddlejob(worker, V1SchedulingPolicy(min_available=10), job_namespace)
+    schedulable_paddlejob = generate_paddlejob(worker, V1SchedulingPolicy(min_available=2), job_namespace)
 
-    TRAINING_CLIENT.create_paddlejob(unschedulable_paddlejob, JOB_NAMESPACE)
+    training_client.create_paddlejob(unschedulable_paddlejob, job_namespace)
     logging.info(f"List of created {constants.PADDLEJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_paddlejobs(JOB_NAMESPACE))
+    logging.info(training_client.list_paddlejobs(job_namespace))
 
     verify_unschedulable_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.PADDLEJOB_KIND,
     )
 
-    TRAINING_CLIENT.patch_paddlejob(schedulable_paddlejob, JOB_NAME, JOB_NAMESPACE)
+    training_client.patch_paddlejob(schedulable_paddlejob, JOB_NAME, job_namespace)
     logging.info(f"List of patched {constants.PADDLEJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_paddlejobs(JOB_NAMESPACE))
+    logging.info(training_client.list_paddlejobs(job_namespace))
 
     verify_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.PADDLEJOB_KIND,
         CONTAINER_NAME,
     )
 
-    TRAINING_CLIENT.delete_paddlejob(JOB_NAME, JOB_NAMESPACE)
+    training_client.delete_paddlejob(JOB_NAME, job_namespace)
 
 
 @pytest.mark.skipif(
     GANG_SCHEDULER_NAME in GANG_SCHEDULERS, reason="For plain scheduling",
 )
-def test_sdk_e2e():
+def test_sdk_e2e(job_namespace, training_client):
     container = generate_container()
 
     worker = V1ReplicaSpec(
@@ -99,31 +96,32 @@ def test_sdk_e2e():
         template=V1PodTemplateSpec(spec=V1PodSpec(containers=[container])),
     )
 
-    paddlejob = generate_paddlejob(worker)
+    paddlejob = generate_paddlejob(worker, job_namespace=job_namespace)
 
-    TRAINING_CLIENT.create_paddlejob(paddlejob, JOB_NAMESPACE)
+    training_client.create_paddlejob(paddlejob, job_namespace)
     logging.info(f"List of created {constants.PADDLEJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_paddlejobs(JOB_NAMESPACE))
+    logging.info(training_client.list_paddlejobs(job_namespace))
 
     verify_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.PADDLEJOB_KIND,
         CONTAINER_NAME,
     )
 
-    TRAINING_CLIENT.delete_paddlejob(JOB_NAME, JOB_NAMESPACE)
+    training_client.delete_paddlejob(JOB_NAME, job_namespace)
 
 
 def generate_paddlejob(
     worker: V1ReplicaSpec,
     scheduling_policy: V1SchedulingPolicy = None,
+    job_namespace: str = "default",
 ) -> KubeflowOrgV1PaddleJob:
     return KubeflowOrgV1PaddleJob(
         api_version="kubeflow.org/v1",
         kind="PaddleJob",
-        metadata=V1ObjectMeta(name=JOB_NAME, namespace=JOB_NAMESPACE),
+        metadata=V1ObjectMeta(name=JOB_NAME, namespace=job_namespace),
         spec=KubeflowOrgV1PaddleJobSpec(
             run_policy=V1RunPolicy(
                 scheduling_policy=scheduling_policy,

--- a/sdk/python/test/e2e/test_e2e_paddlejob.py
+++ b/sdk/python/test/e2e/test_e2e_paddlejob.py
@@ -21,6 +21,7 @@ from kubernetes.client import V1ObjectMeta
 from kubernetes.client import V1PodSpec
 from kubernetes.client import V1Container
 
+from kubeflow.training import TrainingClient
 from kubeflow.training import V1ReplicaSpec
 from kubeflow.training import KubeflowOrgV1PaddleJob
 from kubeflow.training import KubeflowOrgV1PaddleJobSpec
@@ -35,6 +36,7 @@ from test.e2e.constants import GANG_SCHEDULERS, NONE_GANG_SCHEDULERS
 logging.basicConfig(format="%(message)s")
 logging.getLogger().setLevel(logging.INFO)
 
+TRAINING_CLIENT = TrainingClient()
 JOB_NAME = "paddlejob-cpu-ci-test"
 CONTAINER_NAME = "paddle"
 GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
@@ -43,7 +45,7 @@ GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 @pytest.mark.skipif(
     GANG_SCHEDULER_NAME in NONE_GANG_SCHEDULERS, reason="For gang-scheduling",
 )
-def test_sdk_e2e_with_gang_scheduling(job_namespace, training_client):
+def test_sdk_e2e_with_gang_scheduling(job_namespace):
     container = generate_container()
 
     worker = V1ReplicaSpec(
@@ -58,36 +60,36 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace, training_client):
     unschedulable_paddlejob = generate_paddlejob(worker, V1SchedulingPolicy(min_available=10), job_namespace)
     schedulable_paddlejob = generate_paddlejob(worker, V1SchedulingPolicy(min_available=2), job_namespace)
 
-    training_client.create_paddlejob(unschedulable_paddlejob, job_namespace)
+    TRAINING_CLIENT.create_paddlejob(unschedulable_paddlejob, job_namespace)
     logging.info(f"List of created {constants.PADDLEJOB_KIND}s")
-    logging.info(training_client.list_paddlejobs(job_namespace))
+    logging.info(TRAINING_CLIENT.list_paddlejobs(job_namespace))
 
     verify_unschedulable_job_e2e(
-        training_client,
+        TRAINING_CLIENT,
         JOB_NAME,
         job_namespace,
         constants.PADDLEJOB_KIND,
     )
 
-    training_client.patch_paddlejob(schedulable_paddlejob, JOB_NAME, job_namespace)
+    TRAINING_CLIENT.patch_paddlejob(schedulable_paddlejob, JOB_NAME, job_namespace)
     logging.info(f"List of patched {constants.PADDLEJOB_KIND}s")
-    logging.info(training_client.list_paddlejobs(job_namespace))
+    logging.info(TRAINING_CLIENT.list_paddlejobs(job_namespace))
 
     verify_job_e2e(
-        training_client,
+        TRAINING_CLIENT,
         JOB_NAME,
         job_namespace,
         constants.PADDLEJOB_KIND,
         CONTAINER_NAME,
     )
 
-    training_client.delete_paddlejob(JOB_NAME, job_namespace)
+    TRAINING_CLIENT.delete_paddlejob(JOB_NAME, job_namespace)
 
 
 @pytest.mark.skipif(
     GANG_SCHEDULER_NAME in GANG_SCHEDULERS, reason="For plain scheduling",
 )
-def test_sdk_e2e(job_namespace, training_client):
+def test_sdk_e2e(job_namespace):
     container = generate_container()
 
     worker = V1ReplicaSpec(
@@ -98,19 +100,19 @@ def test_sdk_e2e(job_namespace, training_client):
 
     paddlejob = generate_paddlejob(worker, job_namespace=job_namespace)
 
-    training_client.create_paddlejob(paddlejob, job_namespace)
+    TRAINING_CLIENT.create_paddlejob(paddlejob, job_namespace)
     logging.info(f"List of created {constants.PADDLEJOB_KIND}s")
-    logging.info(training_client.list_paddlejobs(job_namespace))
+    logging.info(TRAINING_CLIENT.list_paddlejobs(job_namespace))
 
     verify_job_e2e(
-        training_client,
+        TRAINING_CLIENT,
         JOB_NAME,
         job_namespace,
         constants.PADDLEJOB_KIND,
         CONTAINER_NAME,
     )
 
-    training_client.delete_paddlejob(JOB_NAME, job_namespace)
+    TRAINING_CLIENT.delete_paddlejob(JOB_NAME, job_namespace)
 
 
 def generate_paddlejob(

--- a/sdk/python/test/e2e/test_e2e_pytorchjob.py
+++ b/sdk/python/test/e2e/test_e2e_pytorchjob.py
@@ -21,7 +21,6 @@ from kubernetes.client import V1ObjectMeta
 from kubernetes.client import V1PodSpec
 from kubernetes.client import V1Container
 
-from kubeflow.training import TrainingClient
 from kubeflow.training import V1ReplicaSpec
 from kubeflow.training import KubeflowOrgV1PyTorchJob
 from kubeflow.training import KubeflowOrgV1PyTorchJobSpec
@@ -36,9 +35,7 @@ from test.e2e.constants import GANG_SCHEDULERS, NONE_GANG_SCHEDULERS
 logging.basicConfig(format="%(message)s")
 logging.getLogger().setLevel(logging.INFO)
 
-TRAINING_CLIENT = TrainingClient(config_file=os.getenv("KUBECONFIG", "~/.kube/config"))
 JOB_NAME = "pytorchjob-mnist-ci-test"
-JOB_NAMESPACE = "default"
 CONTAINER_NAME = "pytorch"
 GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 
@@ -46,7 +43,7 @@ GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 @pytest.mark.skipif(
     GANG_SCHEDULER_NAME in NONE_GANG_SCHEDULERS, reason="For gang-scheduling",
 )
-def test_sdk_e2e_with_gang_scheduling():
+def test_sdk_e2e_with_gang_scheduling(job_namespace, training_client):
     container = generate_container()
 
     master = V1ReplicaSpec(
@@ -67,39 +64,39 @@ def test_sdk_e2e_with_gang_scheduling():
         )),
     )
 
-    unschedulable_pytorchjob = generate_pytorchjob(master, worker, V1SchedulingPolicy(min_available=10))
-    schedulable_pytorchjob = generate_pytorchjob(master, worker, V1SchedulingPolicy(min_available=2))
+    unschedulable_pytorchjob = generate_pytorchjob(master, worker, V1SchedulingPolicy(min_available=10), job_namespace)
+    schedulable_pytorchjob = generate_pytorchjob(master, worker, V1SchedulingPolicy(min_available=2), job_namespace)
 
-    TRAINING_CLIENT.create_pytorchjob(unschedulable_pytorchjob, JOB_NAMESPACE)
+    training_client.create_pytorchjob(unschedulable_pytorchjob, job_namespace)
     logging.info(f"List of created {constants.PYTORCHJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_pytorchjobs(JOB_NAMESPACE))
+    logging.info(training_client.list_pytorchjobs(job_namespace))
 
     verify_unschedulable_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.PYTORCHJOB_KIND,
     )
 
-    TRAINING_CLIENT.patch_pytorchjob(schedulable_pytorchjob, JOB_NAME, JOB_NAMESPACE)
+    training_client.patch_pytorchjob(schedulable_pytorchjob, JOB_NAME, job_namespace)
     logging.info(f"List of patched {constants.PYTORCHJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_pytorchjobs(JOB_NAMESPACE))
+    logging.info(training_client.list_pytorchjobs(job_namespace))
 
     verify_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.PYTORCHJOB_KIND,
         CONTAINER_NAME,
     )
 
-    TRAINING_CLIENT.delete_pytorchjob(JOB_NAME, JOB_NAMESPACE)
+    training_client.delete_pytorchjob(JOB_NAME, job_namespace)
 
 
 @pytest.mark.skipif(
     GANG_SCHEDULER_NAME in GANG_SCHEDULERS, reason="For plain scheduling",
 )
-def test_sdk_e2e():
+def test_sdk_e2e(job_namespace, training_client):
     container = generate_container()
 
     master = V1ReplicaSpec(
@@ -114,32 +111,33 @@ def test_sdk_e2e():
         template=V1PodTemplateSpec(spec=V1PodSpec(containers=[container])),
     )
 
-    pytorchjob = generate_pytorchjob(master, worker)
+    pytorchjob = generate_pytorchjob(master, worker, job_namespace=job_namespace)
 
-    TRAINING_CLIENT.create_pytorchjob(pytorchjob, JOB_NAMESPACE)
+    training_client.create_pytorchjob(pytorchjob, job_namespace)
     logging.info(f"List of created {constants.PYTORCHJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_pytorchjobs(JOB_NAMESPACE))
+    logging.info(training_client.list_pytorchjobs(job_namespace))
 
     verify_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.PYTORCHJOB_KIND,
         CONTAINER_NAME,
     )
 
-    TRAINING_CLIENT.delete_pytorchjob(JOB_NAME, JOB_NAMESPACE)
+    training_client.delete_pytorchjob(JOB_NAME, job_namespace)
 
 
 def generate_pytorchjob(
     master: V1ReplicaSpec,
     worker: V1ReplicaSpec,
     scheduling_policy: V1SchedulingPolicy = None,
+    job_namespace: str = "default",
 ) -> KubeflowOrgV1PyTorchJob:
     return KubeflowOrgV1PyTorchJob(
         api_version="kubeflow.org/v1",
         kind="PyTorchJob",
-        metadata=V1ObjectMeta(name=JOB_NAME, namespace=JOB_NAMESPACE),
+        metadata=V1ObjectMeta(name=JOB_NAME, namespace=job_namespace),
         spec=KubeflowOrgV1PyTorchJobSpec(
             run_policy=V1RunPolicy(
                 clean_pod_policy="None",

--- a/sdk/python/test/e2e/test_e2e_tfjob.py
+++ b/sdk/python/test/e2e/test_e2e_tfjob.py
@@ -21,7 +21,6 @@ from kubernetes.client import V1ObjectMeta
 from kubernetes.client import V1PodSpec
 from kubernetes.client import V1Container
 
-from kubeflow.training import TrainingClient
 from kubeflow.training import V1ReplicaSpec
 from kubeflow.training import V1RunPolicy
 from kubeflow.training import KubeflowOrgV1TFJob
@@ -36,9 +35,7 @@ from test.e2e.constants import GANG_SCHEDULERS, NONE_GANG_SCHEDULERS
 logging.basicConfig(format="%(message)s")
 logging.getLogger().setLevel(logging.INFO)
 
-TRAINING_CLIENT = TrainingClient(config_file=os.getenv("KUBECONFIG", "~/.kube/config"))
 JOB_NAME = "tfjob-mnist-ci-test"
-JOB_NAMESPACE = "default"
 CONTAINER_NAME = "tensorflow"
 GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 
@@ -46,7 +43,7 @@ GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 @pytest.mark.skipif(
     GANG_SCHEDULER_NAME in NONE_GANG_SCHEDULERS, reason="For gang-scheduling",
 )
-def test_sdk_e2e_with_gang_scheduling():
+def test_sdk_e2e_with_gang_scheduling(job_namespace, training_client):
     container = generate_container()
 
     worker = V1ReplicaSpec(
@@ -58,39 +55,39 @@ def test_sdk_e2e_with_gang_scheduling():
         )),
     )
 
-    unschedulable_tfjob = generate_tfjob(worker, V1SchedulingPolicy(min_available=10))
-    schedulable_tfjob = generate_tfjob(worker, V1SchedulingPolicy(min_available=1))
+    unschedulable_tfjob = generate_tfjob(worker, V1SchedulingPolicy(min_available=10), job_namespace)
+    schedulable_tfjob = generate_tfjob(worker, V1SchedulingPolicy(min_available=1), job_namespace)
 
-    TRAINING_CLIENT.create_tfjob(unschedulable_tfjob, JOB_NAMESPACE)
+    training_client.create_tfjob(unschedulable_tfjob, job_namespace)
     logging.info(f"List of created {constants.TFJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_tfjobs(JOB_NAMESPACE))
+    logging.info(training_client.list_tfjobs(job_namespace))
 
     verify_unschedulable_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.TFJOB_KIND,
     )
 
-    TRAINING_CLIENT.patch_tfjob(schedulable_tfjob, JOB_NAME, JOB_NAMESPACE)
+    training_client.patch_tfjob(schedulable_tfjob, JOB_NAME, job_namespace)
     logging.info(f"List of patched {constants.TFJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_tfjobs(JOB_NAMESPACE))
+    logging.info(training_client.list_tfjobs(job_namespace))
 
     verify_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.TFJOB_KIND,
         CONTAINER_NAME,
     )
 
-    TRAINING_CLIENT.delete_tfjob(JOB_NAME, JOB_NAMESPACE)
+    training_client.delete_tfjob(JOB_NAME, job_namespace)
 
 
 @pytest.mark.skipif(
     GANG_SCHEDULER_NAME in GANG_SCHEDULERS, reason="For plain scheduling",
 )
-def test_sdk_e2e():
+def test_sdk_e2e(job_namespace, training_client):
     container = generate_container()
 
     worker = V1ReplicaSpec(
@@ -99,27 +96,28 @@ def test_sdk_e2e():
         template=V1PodTemplateSpec(spec=V1PodSpec(containers=[container])),
     )
 
-    tfjob = generate_tfjob(worker)
+    tfjob = generate_tfjob(worker, job_namespace=job_namespace)
 
-    TRAINING_CLIENT.create_tfjob(tfjob, JOB_NAMESPACE)
+    training_client.create_tfjob(tfjob, job_namespace)
     logging.info(f"List of created {constants.TFJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_tfjobs(JOB_NAMESPACE))
+    logging.info(training_client.list_tfjobs(job_namespace))
 
     verify_job_e2e(
-        TRAINING_CLIENT, JOB_NAME, JOB_NAMESPACE, constants.TFJOB_KIND, CONTAINER_NAME,
+        training_client, JOB_NAME, job_namespace, constants.TFJOB_KIND, CONTAINER_NAME,
     )
 
-    TRAINING_CLIENT.delete_tfjob(JOB_NAME, JOB_NAMESPACE)
+    training_client.delete_tfjob(JOB_NAME, job_namespace)
 
 
 def generate_tfjob(
     worker: V1ReplicaSpec,
     scheduling_policy: V1SchedulingPolicy = None,
+    job_namespace: str = "default",
 ) -> KubeflowOrgV1TFJob:
     return KubeflowOrgV1TFJob(
         api_version="kubeflow.org/v1",
         kind="TFJob",
-        metadata=V1ObjectMeta(name=JOB_NAME, namespace=JOB_NAMESPACE),
+        metadata=V1ObjectMeta(name=JOB_NAME, namespace=job_namespace),
         spec=KubeflowOrgV1TFJobSpec(
             run_policy=V1RunPolicy(
                 clean_pod_policy="None",

--- a/sdk/python/test/e2e/test_e2e_xgboostjob.py
+++ b/sdk/python/test/e2e/test_e2e_xgboostjob.py
@@ -21,7 +21,6 @@ from kubernetes.client import V1ObjectMeta
 from kubernetes.client import V1PodSpec
 from kubernetes.client import V1Container
 
-from kubeflow.training import TrainingClient
 from kubeflow.training import V1ReplicaSpec
 from kubeflow.training import KubeflowOrgV1XGBoostJob
 from kubeflow.training import KubeflowOrgV1XGBoostJobSpec
@@ -36,9 +35,7 @@ from test.e2e.constants import GANG_SCHEDULERS, NONE_GANG_SCHEDULERS
 logging.basicConfig(format="%(message)s")
 logging.getLogger().setLevel(logging.INFO)
 
-TRAINING_CLIENT = TrainingClient(config_file=os.getenv("KUBECONFIG", "~/.kube/config"))
 JOB_NAME = "xgboostjob-iris-ci-test"
-JOB_NAMESPACE = "default"
 CONTAINER_NAME = "xgboost"
 GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 
@@ -46,7 +43,7 @@ GANG_SCHEDULER_NAME = os.getenv(TEST_GANG_SCHEDULER_NAME_ENV_KEY)
 @pytest.mark.skipif(
     GANG_SCHEDULER_NAME in NONE_GANG_SCHEDULERS, reason="For gang-scheduling",
 )
-def test_sdk_e2e_with_gang_scheduling():
+def test_sdk_e2e_with_gang_scheduling(job_namespace, training_client):
     container = generate_container()
 
     master = V1ReplicaSpec(
@@ -67,39 +64,39 @@ def test_sdk_e2e_with_gang_scheduling():
         )),
     )
 
-    unschedulable_xgboostjob = generate_xgboostjob(master, worker, V1SchedulingPolicy(min_available=10))
-    schedulable_xgboostjob = generate_xgboostjob(master, worker, V1SchedulingPolicy(min_available=2))
+    unschedulable_xgboostjob = generate_xgboostjob(master, worker, V1SchedulingPolicy(min_available=10), job_namespace)
+    schedulable_xgboostjob = generate_xgboostjob(master, worker, V1SchedulingPolicy(min_available=2), job_namespace)
 
-    TRAINING_CLIENT.create_xgboostjob(unschedulable_xgboostjob, JOB_NAMESPACE)
+    training_client.create_xgboostjob(unschedulable_xgboostjob, job_namespace)
     logging.info(f"List of created {constants.XGBOOSTJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_xgboostjobs(JOB_NAMESPACE))
+    logging.info(training_client.list_xgboostjobs(job_namespace))
 
     verify_unschedulable_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.XGBOOSTJOB_KIND,
     )
 
-    TRAINING_CLIENT.patch_xgboostjob(schedulable_xgboostjob, JOB_NAME, JOB_NAMESPACE)
+    training_client.patch_xgboostjob(schedulable_xgboostjob, JOB_NAME, job_namespace)
     logging.info(f"List of patched {constants.XGBOOSTJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_xgboostjobs(JOB_NAMESPACE))
+    logging.info(training_client.list_xgboostjobs(job_namespace))
 
     verify_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.XGBOOSTJOB_KIND,
         CONTAINER_NAME,
     )
 
-    TRAINING_CLIENT.delete_xgboostjob(JOB_NAME, JOB_NAMESPACE)
+    training_client.delete_xgboostjob(JOB_NAME, job_namespace)
 
 
 @pytest.mark.skipif(
     GANG_SCHEDULER_NAME in GANG_SCHEDULERS, reason="For plain scheduling",
 )
-def test_sdk_e2e():
+def test_sdk_e2e(job_namespace, training_client):
     container = generate_container()
 
     master = V1ReplicaSpec(
@@ -114,32 +111,33 @@ def test_sdk_e2e():
         template=V1PodTemplateSpec(spec=V1PodSpec(containers=[container])),
     )
 
-    xgboostjob = generate_xgboostjob(master, worker)
+    xgboostjob = generate_xgboostjob(master, worker, job_namespace=job_namespace)
 
-    TRAINING_CLIENT.create_xgboostjob(xgboostjob, JOB_NAMESPACE)
+    training_client.create_xgboostjob(xgboostjob, job_namespace)
     logging.info(f"List of created {constants.XGBOOSTJOB_KIND}s")
-    logging.info(TRAINING_CLIENT.list_xgboostjobs(JOB_NAMESPACE))
+    logging.info(training_client.list_xgboostjobs(job_namespace))
 
     verify_job_e2e(
-        TRAINING_CLIENT,
+        training_client,
         JOB_NAME,
-        JOB_NAMESPACE,
+        job_namespace,
         constants.XGBOOSTJOB_KIND,
         CONTAINER_NAME,
     )
 
-    TRAINING_CLIENT.delete_xgboostjob(JOB_NAME, JOB_NAMESPACE)
+    training_client.delete_xgboostjob(JOB_NAME, job_namespace)
 
 
 def generate_xgboostjob(
     master: V1ReplicaSpec,
     worker: V1ReplicaSpec,
     scheduling_policy: V1SchedulingPolicy = None,
+    job_namespace: str = "default",
 ) -> KubeflowOrgV1XGBoostJob:
     return KubeflowOrgV1XGBoostJob(
         api_version="kubeflow.org/v1",
         kind="XGBoostJob",
-        metadata=V1ObjectMeta(name=JOB_NAME, namespace=JOB_NAMESPACE),
+        metadata=V1ObjectMeta(name=JOB_NAME, namespace=job_namespace),
         spec=KubeflowOrgV1XGBoostJobSpec(
             run_policy=V1RunPolicy(
                 clean_pod_policy="None",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

* Currently, the `JOB_NAMESPACE` is hardcoded in e2e test files. This limits a user to run these tests in the `default` namespace. A user might want to run these tests in a different namespace instead of the default namespace. One use case is using these tests in Kubeflow mode for training-operator conformance tests (or some other testing). As per the [design doc of the conformance test](https://docs.google.com/document/d/1TRUKUY1zCCMdgF-nJ7QtzRwifsoQop0V8UnRo-GWlpI/edit#heading=h.tubso4j7bqvw), it seems we want to run these tests in `kf-conformance` namespace.

* Currently, the training client initialization code looks for Kube config which may not be present if these tests are running inside k8s cluster. Fix training client initialization code to run inside and outside of k8s cluster.

* Created `conftest.py` for [pytest fixtures](https://docs.pytest.org/en/6.2.x/fixture.html). Make job namespace a fixture. After this PR, users can pass the `--namespace` option from the command line to run e2e tests in a specific namespace.

* As part of `hack/python-sdk/gen-sdk.sh` all the python files under the test directory gets deleted. We need to delete only autogenerated test files, not every file. Updated the code in the `gen-sdk.sh` file to delete python files that start with `test_`.

* Testing: Tested modified tests on the NKE cluster from local.
  - without any namespace option 
```
(kserve-env) ajaynagar@LJND24D43D python % pytest test/e2e -v
================================================================ test session starts =================================================================
platform darwin -- Python 3.9.6, pytest-7.2.1, pluggy-1.0.0 -- /Users/ajaynagar/venv/kserve-env/bin/python3
cachedir: .pytest_cache
rootdir: /Users/ajaynagar/work/training-operator/sdk/python
collected 12 items

test/e2e/test_e2e_mpijob.py::test_sdk_e2e_with_gang_scheduling PASSED                                                                          [  8%]
test/e2e/test_e2e_mpijob.py::test_sdk_e2e PASSED                                                                                               [ 16%]
test/e2e/test_e2e_mxjob.py::test_sdk_e2e_with_gang_scheduling PASSED                                                                           [ 25%]
test/e2e/test_e2e_mxjob.py::test_sdk_e2e PASSED                                                                                                [ 33%]
test/e2e/test_e2e_paddlejob.py::test_sdk_e2e_with_gang_scheduling PASSED                                                                       [ 41%]
test/e2e/test_e2e_paddlejob.py::test_sdk_e2e PASSED                                                                                            [ 50%]
test/e2e/test_e2e_pytorchjob.py::test_sdk_e2e_with_gang_scheduling PASSED                                                                      [ 58%]
test/e2e/test_e2e_pytorchjob.py::test_sdk_e2e PASSED                                                                                           [ 66%]
test/e2e/test_e2e_tfjob.py::test_sdk_e2e_with_gang_scheduling PASSED                                                                           [ 75%]
test/e2e/test_e2e_tfjob.py::test_sdk_e2e PASSED                                                                                                [ 83%]
test/e2e/test_e2e_xgboostjob.py::test_sdk_e2e_with_gang_scheduling PASSED                                                                      [ 91%]
test/e2e/test_e2e_xgboostjob.py::test_sdk_e2e PASSED                                                                                           [100%]

========================================================== 12 passed in 1094.55s (0:18:14) ===========================================================
  ```
   - with the given namespace option  
```
(kserve-env) ajaynagar@LJND24D43D python % pytest test/e2e -v --namespace=kf-conformance-test
================================================================ test session starts =================================================================
platform darwin -- Python 3.9.6, pytest-7.2.1, pluggy-1.0.0 -- /Users/ajaynagar/venv/kserve-env/bin/python3
cachedir: .pytest_cache
rootdir: /Users/ajaynagar/work/training-operator/sdk/python
collected 12 items

test/e2e/test_e2e_mpijob.py::test_sdk_e2e_with_gang_scheduling PASSED                                                                          [  8%]
test/e2e/test_e2e_mpijob.py::test_sdk_e2e PASSED                                                                                               [ 16%]
test/e2e/test_e2e_mxjob.py::test_sdk_e2e_with_gang_scheduling PASSED                                                                           [ 25%]
test/e2e/test_e2e_mxjob.py::test_sdk_e2e PASSED                                                                                                [ 33%]
test/e2e/test_e2e_paddlejob.py::test_sdk_e2e_with_gang_scheduling PASSED                                                                       [ 41%]
test/e2e/test_e2e_paddlejob.py::test_sdk_e2e PASSED                                                                                            [ 50%]
test/e2e/test_e2e_pytorchjob.py::test_sdk_e2e_with_gang_scheduling PASSED                                                                      [ 58%]
test/e2e/test_e2e_pytorchjob.py::test_sdk_e2e PASSED                                                                                           [ 66%]
test/e2e/test_e2e_tfjob.py::test_sdk_e2e_with_gang_scheduling PASSED                                                                           [ 75%]
test/e2e/test_e2e_tfjob.py::test_sdk_e2e PASSED                                                                                                [ 83%]
test/e2e/test_e2e_xgboostjob.py::test_sdk_e2e_with_gang_scheduling PASSED                                                                      [ 91%]
test/e2e/test_e2e_xgboostjob.py::test_sdk_e2e PASSED                                                                                           [100%]

========================================================== 12 passed in 1052.87s (0:17:32) ===========================================================
```

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
