### PR TITLE
Fix XGBoost flaky e2e tests

### DIFF
--- a/sdk/python/test/e2e/test_e2e_xgboostjob.py
+++ b/sdk/python/test/e2e/test_e2e_xgboostjob.py
@@ -51,7 +51,7 @@ def test_sdk_e2e_with_gang_scheduling():
 
     master = V1ReplicaSpec(
         replicas=1,
-        restart_policy="Never",
+        restart_policy="OnFailure",
         template=V1PodTemplateSpec(spec=V1PodSpec(
             containers=[container],
             scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
@@ -60,7 +60,7 @@ def test_sdk_e2e_with_gang_scheduling():
 
     worker = V1ReplicaSpec(
         replicas=1,
-        restart_policy="Never",
+        restart_policy="OnFailure",
         template=V1PodTemplateSpec(spec=V1PodSpec(
             containers=[container],
             scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
@@ -104,13 +104,13 @@ def test_sdk_e2e():
 
     master = V1ReplicaSpec(
         replicas=1,
-        restart_policy="Never",
+        restart_policy="OnFailure",
         template=V1PodTemplateSpec(spec=V1PodSpec(containers=[container])),
     )
 
     worker = V1ReplicaSpec(
         replicas=1,
-        restart_policy="Never",
+        restart_policy="OnFailure",
         template=V1PodTemplateSpec(spec=V1PodSpec(containers=[container])),
     )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

* xgboost tests fails if the `worker` pod starts running before the `master` pod. This happens because the worker pod cannot obtain the address of the `master` pod. Logs of `worker` pod:
```
starting the train job
starting to extract system env
extract the Rabit env from cluster : xgboostjob-iris-ci-test-master-0, port: 9999, rank: 1, word_size: 2
##### Rabit rank setup with below envs #####
DMLC_NUM_WORKER=2
DMLC_TRACKER_URI=xgboostjob-iris-ci-test-master-0
DMLC_TRACKER_PORT=9999
DMLC_TASK_ID=1
cannot obtain address of xgboostjob-iris-ci-test-master-0
```

* Pod running status
```
ajaynagar@LJND24D43D python % k get pods xgboostjob-iris-ci-test-master-0 xgboostjob-iris-ci-test-worker-0
NAME                               READY   STATUS    RESTARTS   AGE
xgboostjob-iris-ci-test-master-0   1/1     Running   0          11m
xgboostjob-iris-ci-test-worker-0   0/1     Error     0          11m
```

* To fix the above-mentioned issue, enforce k8s to restart the pod on failure.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
