### PR TITLE
Disable istio-sidecar injection

### DIFF
--- a/sdk/python/kubeflow/training/constants/constants.py
+++ b/sdk/python/kubeflow/training/constants/constants.py
@@ -20,6 +20,7 @@ DEFAULT_TIMEOUT = 120
 # Common constants.
 KUBEFLOW_GROUP = "kubeflow.org"
 OPERATOR_VERSION = "v1"
+ISTIO_SIDECAR_INJECTION = "sidecar.istio.io/inject"
 
 # Training Job conditions.
 JOB_CONDITION_CREATED = "Created"

--- a/sdk/python/kubeflow/training/utils/utils.py
+++ b/sdk/python/kubeflow/training/utils/utils.py
@@ -322,7 +322,7 @@ def get_pod_template_spec(
 
     # Create Pod template spec.
     pod_template_spec = client.V1PodTemplateSpec(
-        metadata=client.V1ObjectMeta(annotations={"sidecar.istio.io/inject": "false"}),
+        metadata=client.V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
         spec=client.V1PodSpec(
             containers=[
                 client.V1Container(

--- a/sdk/python/test/e2e/test_e2e_mpijob.py
+++ b/sdk/python/test/e2e/test_e2e_mpijob.py
@@ -52,19 +52,25 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
     launcher = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(spec=V1PodSpec(
-            containers=[launcher_container],
-            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
-        )),
+        template=V1PodTemplateSpec(
+            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            spec=V1PodSpec(
+                containers=[launcher_container],
+                scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+            )
+        ),
     )
 
     worker = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(spec=V1PodSpec(
-            containers=[worker_container],
-            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
-        )),
+        template=V1PodTemplateSpec(
+            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            spec=V1PodSpec(
+                containers=[worker_container],
+                scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+            )
+        ),
     )
 
     mpijob = generate_mpijob(launcher, worker, V1SchedulingPolicy(min_available=10), job_namespace)
@@ -105,13 +111,15 @@ def test_sdk_e2e(job_namespace):
     launcher = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(spec=V1PodSpec(containers=[launcher_container])),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+                                   spec=V1PodSpec(containers=[launcher_container])),
     )
 
     worker = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(spec=V1PodSpec(containers=[worker_container])),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+                                   spec=V1PodSpec(containers=[worker_container])),
     )
 
     mpijob = generate_mpijob(launcher, worker, job_namespace=job_namespace)

--- a/sdk/python/test/e2e/test_e2e_mpijob.py
+++ b/sdk/python/test/e2e/test_e2e_mpijob.py
@@ -53,7 +53,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         replicas=1,
         restart_policy="Never",
         template=V1PodTemplateSpec(
-            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
             spec=V1PodSpec(
                 containers=[launcher_container],
                 scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
@@ -65,7 +65,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         replicas=1,
         restart_policy="Never",
         template=V1PodTemplateSpec(
-            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
             spec=V1PodSpec(
                 containers=[worker_container],
                 scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
@@ -111,14 +111,14 @@ def test_sdk_e2e(job_namespace):
     launcher = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
                                    spec=V1PodSpec(containers=[launcher_container])),
     )
 
     worker = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
                                    spec=V1PodSpec(containers=[worker_container])),
     )
 

--- a/sdk/python/test/e2e/test_e2e_mxjob.py
+++ b/sdk/python/test/e2e/test_e2e_mxjob.py
@@ -54,7 +54,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         replicas=1,
         restart_policy="Never",
         template=V1PodTemplateSpec(
-            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
             spec=V1PodSpec(
                 containers=[worker_container],
                 scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
@@ -66,7 +66,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         replicas=1,
         restart_policy="Never",
         template=V1PodTemplateSpec(
-            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
             spec=V1PodSpec(
                 containers=[server_container],
                 scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
@@ -78,7 +78,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         replicas=1,
         restart_policy="Never",
         template=V1PodTemplateSpec(
-            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
             spec=V1PodSpec(
                 containers=[scheduler_container],
                 scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
@@ -124,21 +124,21 @@ def test_sdk_e2e(job_namespace):
     worker = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
                                    spec=V1PodSpec(containers=[worker_container])),
     )
 
     server = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
                                    spec=V1PodSpec(containers=[server_container])),
     )
 
     scheduler = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
                                    spec=V1PodSpec(containers=[scheduler_container])),
     )
 

--- a/sdk/python/test/e2e/test_e2e_mxjob.py
+++ b/sdk/python/test/e2e/test_e2e_mxjob.py
@@ -53,28 +53,37 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
     worker = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(spec=V1PodSpec(
-            containers=[worker_container],
-            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
-        )),
+        template=V1PodTemplateSpec(
+            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            spec=V1PodSpec(
+                containers=[worker_container],
+                scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+            )
+        ),
     )
 
     server = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(spec=V1PodSpec(
-            containers=[server_container],
-            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
-        )),
+        template=V1PodTemplateSpec(
+            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            spec=V1PodSpec(
+                containers=[server_container],
+                scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+            )
+        ),
     )
 
     scheduler = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(spec=V1PodSpec(
-            containers=[scheduler_container],
-            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
-        )),
+        template=V1PodTemplateSpec(
+            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            spec=V1PodSpec(
+                containers=[scheduler_container],
+                scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+            )
+        ),
     )
 
     unschedulable_mxjob = generate_mxjob(scheduler, server, worker, V1SchedulingPolicy(min_available=10), job_namespace)
@@ -115,19 +124,22 @@ def test_sdk_e2e(job_namespace):
     worker = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(spec=V1PodSpec(containers=[worker_container])),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+                                   spec=V1PodSpec(containers=[worker_container])),
     )
 
     server = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(spec=V1PodSpec(containers=[server_container])),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+                                   spec=V1PodSpec(containers=[server_container])),
     )
 
     scheduler = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(spec=V1PodSpec(containers=[scheduler_container])),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+                                   spec=V1PodSpec(containers=[scheduler_container])),
     )
 
     mxjob = generate_mxjob(scheduler, server, worker, job_namespace=job_namespace)

--- a/sdk/python/test/e2e/test_e2e_paddlejob.py
+++ b/sdk/python/test/e2e/test_e2e_paddlejob.py
@@ -51,10 +51,13 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
     worker = V1ReplicaSpec(
         replicas=2,
         restart_policy="OnFailure",
-        template=V1PodTemplateSpec(spec=V1PodSpec(
-            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
-            containers=[container],
-        )),
+        template=V1PodTemplateSpec(
+            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            spec=V1PodSpec(
+                scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+                containers=[container],
+            )
+        ),
     )
 
     unschedulable_paddlejob = generate_paddlejob(worker, V1SchedulingPolicy(min_available=10), job_namespace)
@@ -95,7 +98,8 @@ def test_sdk_e2e(job_namespace):
     worker = V1ReplicaSpec(
         replicas=2,
         restart_policy="OnFailure",
-        template=V1PodTemplateSpec(spec=V1PodSpec(containers=[container])),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+                                   spec=V1PodSpec(containers=[container])),
     )
 
     paddlejob = generate_paddlejob(worker, job_namespace=job_namespace)

--- a/sdk/python/test/e2e/test_e2e_paddlejob.py
+++ b/sdk/python/test/e2e/test_e2e_paddlejob.py
@@ -52,7 +52,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         replicas=2,
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
-            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
             spec=V1PodSpec(
                 scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
                 containers=[container],
@@ -98,7 +98,7 @@ def test_sdk_e2e(job_namespace):
     worker = V1ReplicaSpec(
         replicas=2,
         restart_policy="OnFailure",
-        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
                                    spec=V1PodSpec(containers=[container])),
     )
 

--- a/sdk/python/test/e2e/test_e2e_pytorchjob.py
+++ b/sdk/python/test/e2e/test_e2e_pytorchjob.py
@@ -52,7 +52,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         replicas=1,
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
-            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
             spec=V1PodSpec(
                 scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
                 containers=[container],
@@ -64,7 +64,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         replicas=1,
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
-            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
             spec=V1PodSpec(
                 scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
                 containers=[container],
@@ -110,14 +110,14 @@ def test_sdk_e2e(job_namespace):
     master = V1ReplicaSpec(
         replicas=1,
         restart_policy="OnFailure",
-        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
                                    spec=V1PodSpec(containers=[container])),
     )
 
     worker = V1ReplicaSpec(
         replicas=1,
         restart_policy="OnFailure",
-        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
                                    spec=V1PodSpec(containers=[container])),
     )
 

--- a/sdk/python/test/e2e/test_e2e_pytorchjob.py
+++ b/sdk/python/test/e2e/test_e2e_pytorchjob.py
@@ -51,19 +51,25 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
     master = V1ReplicaSpec(
         replicas=1,
         restart_policy="OnFailure",
-        template=V1PodTemplateSpec(spec=V1PodSpec(
-            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
-            containers=[container],
-        )),
+        template=V1PodTemplateSpec(
+            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            spec=V1PodSpec(
+                scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+                containers=[container],
+            )
+        ),
     )
 
     worker = V1ReplicaSpec(
         replicas=1,
         restart_policy="OnFailure",
-        template=V1PodTemplateSpec(spec=V1PodSpec(
-            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
-            containers=[container],
-        )),
+        template=V1PodTemplateSpec(
+            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            spec=V1PodSpec(
+                scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+                containers=[container],
+            )
+        ),
     )
 
     unschedulable_pytorchjob = generate_pytorchjob(master, worker, V1SchedulingPolicy(min_available=10), job_namespace)
@@ -104,13 +110,15 @@ def test_sdk_e2e(job_namespace):
     master = V1ReplicaSpec(
         replicas=1,
         restart_policy="OnFailure",
-        template=V1PodTemplateSpec(spec=V1PodSpec(containers=[container])),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+                                   spec=V1PodSpec(containers=[container])),
     )
 
     worker = V1ReplicaSpec(
         replicas=1,
         restart_policy="OnFailure",
-        template=V1PodTemplateSpec(spec=V1PodSpec(containers=[container])),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+                                   spec=V1PodSpec(containers=[container])),
     )
 
     pytorchjob = generate_pytorchjob(master, worker, job_namespace=job_namespace)

--- a/sdk/python/test/e2e/test_e2e_tfjob.py
+++ b/sdk/python/test/e2e/test_e2e_tfjob.py
@@ -52,7 +52,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         replicas=1,
         restart_policy="Never",
         template=V1PodTemplateSpec(
-            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
             spec=V1PodSpec(
                 containers=[container],
                 scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
@@ -98,7 +98,7 @@ def test_sdk_e2e(job_namespace):
     worker = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
                                    spec=V1PodSpec(containers=[container])),
     )
 

--- a/sdk/python/test/e2e/test_e2e_tfjob.py
+++ b/sdk/python/test/e2e/test_e2e_tfjob.py
@@ -51,10 +51,13 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
     worker = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(spec=V1PodSpec(
-            containers=[container],
-            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
-        )),
+        template=V1PodTemplateSpec(
+            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            spec=V1PodSpec(
+                containers=[container],
+                scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+            )
+        ),
     )
 
     unschedulable_tfjob = generate_tfjob(worker, V1SchedulingPolicy(min_available=10), job_namespace)
@@ -95,7 +98,8 @@ def test_sdk_e2e(job_namespace):
     worker = V1ReplicaSpec(
         replicas=1,
         restart_policy="Never",
-        template=V1PodTemplateSpec(spec=V1PodSpec(containers=[container])),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+                                   spec=V1PodSpec(containers=[container])),
     )
 
     tfjob = generate_tfjob(worker, job_namespace=job_namespace)

--- a/sdk/python/test/e2e/test_e2e_xgboostjob.py
+++ b/sdk/python/test/e2e/test_e2e_xgboostjob.py
@@ -51,19 +51,25 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
     master = V1ReplicaSpec(
         replicas=1,
         restart_policy="OnFailure",
-        template=V1PodTemplateSpec(spec=V1PodSpec(
-            containers=[container],
-            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
-        )),
+        template=V1PodTemplateSpec(
+            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            spec=V1PodSpec(
+                containers=[container],
+                scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+            )
+        ),
     )
 
     worker = V1ReplicaSpec(
         replicas=1,
         restart_policy="OnFailure",
-        template=V1PodTemplateSpec(spec=V1PodSpec(
-            containers=[container],
-            scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
-        )),
+        template=V1PodTemplateSpec(
+            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            spec=V1PodSpec(
+                containers=[container],
+                scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
+            )
+        ),
     )
 
     unschedulable_xgboostjob = generate_xgboostjob(master, worker, V1SchedulingPolicy(min_available=10), job_namespace)
@@ -104,13 +110,15 @@ def test_sdk_e2e(job_namespace):
     master = V1ReplicaSpec(
         replicas=1,
         restart_policy="OnFailure",
-        template=V1PodTemplateSpec(spec=V1PodSpec(containers=[container])),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+                                   spec=V1PodSpec(containers=[container])),
     )
 
     worker = V1ReplicaSpec(
         replicas=1,
         restart_policy="OnFailure",
-        template=V1PodTemplateSpec(spec=V1PodSpec(containers=[container])),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+                                   spec=V1PodSpec(containers=[container])),
     )
 
     xgboostjob = generate_xgboostjob(master, worker, job_namespace=job_namespace)

--- a/sdk/python/test/e2e/test_e2e_xgboostjob.py
+++ b/sdk/python/test/e2e/test_e2e_xgboostjob.py
@@ -52,7 +52,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         replicas=1,
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
-            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
             spec=V1PodSpec(
                 containers=[container],
                 scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
@@ -64,7 +64,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         replicas=1,
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
-            metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+            metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
             spec=V1PodSpec(
                 containers=[container],
                 scheduler_name=get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
@@ -110,14 +110,14 @@ def test_sdk_e2e(job_namespace):
     master = V1ReplicaSpec(
         replicas=1,
         restart_policy="OnFailure",
-        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
                                    spec=V1PodSpec(containers=[container])),
     )
 
     worker = V1ReplicaSpec(
         replicas=1,
         restart_policy="OnFailure",
-        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={'sidecar.istio.io/inject': "false"}),
+        template=V1PodTemplateSpec(metadata=V1ObjectMeta(annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}),
                                    spec=V1PodSpec(containers=[container])),
     )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: 

* Currently none of the e2e tests run successfully in `istio-enabled` namespaces. All training jobs (created by tests) get stuck in `Running` state and eventually these tests fail after timeout. I think it's because istio sidecar keeps running even after the main containers runs successfully.

* This is required as we want to run these tests as part of the training operator conformance test. As per the [design doc of training operator conformance test](https://docs.google.com/document/d/1TRUKUY1zCCMdgF-nJ7QtzRwifsoQop0V8UnRo-GWlpI/edit#heading=h.tubso4j7bqvw), all these tests will run in the namespace created by the Kubeflow profile resource which is istio-enabled by default.

* Disable Istio sidecar injection for training job containers.

* Testing: Tested updated tests in `default` namespace and a istio enabled namespace.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
