### PR TITLE
Find defaulter-gen in $(go env GOPATH) instead of ${GOPATH}

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -83,9 +83,9 @@ ${CODEGEN_PKG}/generate-groups.sh "all" \
 #echo "Building defaulter-gen"
 #go build -o defaulter-gen ${CODEGEN_PKG}/cmd/defaulter-gen
 
-# ${GOPATH}/bin/defaulter-gen is automatically built from ${CODEGEN_PKG}/generate-groups.sh
+# $(go env GOPATH)/bin/defaulter-gen is automatically built from ${CODEGEN_PKG}/generate-groups.sh
 echo "Generating defaulters for kubeflow.org/v1"
-${GOPATH}/bin/defaulter-gen --input-dirs github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1 \
+$(go env GOPATH)/bin/defaulter-gen --input-dirs github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1 \
     -O zz_generated.defaults \
     --output-package github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1 \
     --go-header-file hack/boilerplate/boilerplate.go.txt "$@" \


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Unify the access to $(go env GOPATH) when generating code.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #1783

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
