### PR TITLE
make timeout configurable from e2e tests

### DIFF
--- a/sdk/python/test/e2e/test_e2e_pytorchjob.py
+++ b/sdk/python/test/e2e/test_e2e_pytorchjob.py
@@ -97,6 +97,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         job_namespace,
         constants.PYTORCHJOB_KIND,
         CONTAINER_NAME,
+        timeout=900,
     )
 
     TRAINING_CLIENT.delete_pytorchjob(JOB_NAME, job_namespace)
@@ -134,6 +135,7 @@ def test_sdk_e2e(job_namespace):
         job_namespace,
         constants.PYTORCHJOB_KIND,
         CONTAINER_NAME,
+        timeout=900,
     )
 
     TRAINING_CLIENT.delete_pytorchjob(JOB_NAME, job_namespace)

--- a/sdk/python/test/e2e/utils.py
+++ b/sdk/python/test/e2e/utils.py
@@ -28,13 +28,13 @@ def verify_unschedulable_job_e2e(
 
 
 def verify_job_e2e(
-    client: TrainingClient, name: str, namespace: str, job_kind: str, container: str
+    client: TrainingClient, name: str, namespace: str, job_kind: str, container: str, timeout: int = 600
 ):
     """Verify Training Job e2e test."""
 
     # Wait until Job is Succeeded.
     logging.info(f"\n\n\n{job_kind} is running")
-    client.wait_for_job_conditions(name, namespace, job_kind)
+    client.wait_for_job_conditions(name, namespace, job_kind, timeout=timeout)
 
     # Job should have Created, Running, and Succeeded conditions.
     conditions = client.get_job_conditions(name, namespace, job_kind)


### PR DESCRIPTION

**What this PR does / why we need it**:
* Due to the resources (CPU) crunch in the GitHub actions VM, we have limited CPUs in e2e tests. As a result of this, the execution time of jobs has increased.
* Currently PyTorch test job is taking around 10 mins to complete. Because of this PyTorch test job fails sometimes. We have a timeout period of 10 mins in the `wait_for_job_conditions` functions.
* One approach is if we somehow reduce the running time of the PyTorch job. But for this, we will need to build a new image and push it on docker. This can create issues in CI because of the docker pull rate limit.
* In this PR, I have made `timeout` configurable from the e2e test and increased the timeout to 15 mins for PyTorch job.


**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
