### PR TITLE
[WIP] add Elastic feature for PaddleJob

### DIFF
--- a/cmd/training-operator.v1/main.go
+++ b/cmd/training-operator.v1/main.go
@@ -92,6 +92,10 @@ func main() {
 	flag.StringVar(&config.Config.MPIKubectlDeliveryImage, "mpi-kubectl-delivery-image",
 		config.MPIKubectlDeliveryImageDefault, "The image for mpi launcher init container")
 
+	// Paddle related flags
+	flag.StringVar(&config.Config.PaddleElasticMedium, "paddle-elastic-medium",
+		config.PaddleElasticDefaultImage, "The image to start etcd server or external etcd endpoint (e.g. etcd://1.1.1.1:2379).")
+
 	opts := zap.Options{
 		Development:     true,
 		StacktraceLevel: zapcore.DPanicLevel,

--- a/cmd/training-operator.v1/main.go
+++ b/cmd/training-operator.v1/main.go
@@ -93,8 +93,7 @@ func main() {
 		config.MPIKubectlDeliveryImageDefault, "The image for mpi launcher init container")
 
 	// Paddle related flags
-	flag.StringVar(&config.Config.PaddleElasticMedium, "paddle-elastic-medium",
-		config.PaddleElasticDefaultImage, "The image to start etcd server or external etcd endpoint (e.g. etcd://1.1.1.1:2379).")
+	flag.StringVar(&config.Config.PaddleElasticMedium, "paddle-elastic-medium", "", "The etcd endpoint (e.g. etcd://1.1.1.1:2379).")
 
 	opts := zap.Options{
 		Development:     true,

--- a/pkg/apis/kubeflow.org/v1/paddlepaddle_types.go
+++ b/pkg/apis/kubeflow.org/v1/paddlepaddle_types.go
@@ -101,6 +101,10 @@ type PaddleElasticPolicy struct {
 	// +optional
 	MaxRestarts *int32 `json:"maxRestarts,omitempty"`
 
+	// Master is the rendezvous endpoint with protocol, e.g. etcd://1.2.3.4:2379
+	// +optional
+	Master *string `json:"master,omitempty"`
+
 	// Metrics contains the specifications which are used to calculate the
 	// desired replica count (the maximum replica count across all metrics will
 	// be used).  The desired replica count is calculated with multiplying the

--- a/pkg/apis/kubeflow.org/v1/paddlepaddle_types.go
+++ b/pkg/apis/kubeflow.org/v1/paddlepaddle_types.go
@@ -97,13 +97,18 @@ type PaddleElasticPolicy struct {
 	// +optional
 	MaxReplicas *int32 `json:"maxReplicas,omitempty"`
 
+	RDZVBackend *RDZVBackend `json:"rdzvBackend,omitempty"`
+	RDZVPort    *int32       `json:"rdzvPort,omitempty"`
+	RDZVHost    *string      `json:"rdzvHost,omitempty"`
+	RDZVID      *string      `json:"rdzvId,omitempty"`
+	// RDZVConf contains additional rendezvous configuration (<key1>=<value1>,<key2>=<value2>,...).
+	RDZVConf []RDZVConf `json:"rdzvConf,omitempty"`
+	// Number of workers per node; supported values: [auto, cpu, gpu, int].
+	NProcPerNode *int32 `json:"nProcPerNode,omitempty"`
+
 	// MaxRestarts is the limit for restart times of pods in elastic mode.
 	// +optional
 	MaxRestarts *int32 `json:"maxRestarts,omitempty"`
-
-	// Master is the rendezvous endpoint with protocol, e.g. etcd://1.2.3.4:2379
-	// +optional
-	Master *string `json:"master,omitempty"`
 
 	// Metrics contains the specifications which are used to calculate the
 	// desired replica count (the maximum replica count across all metrics will
@@ -116,6 +121,10 @@ type PaddleElasticPolicy struct {
 	// +optional
 	Metrics []autoscalingv2.MetricSpec `json:"metrics,omitempty"`
 }
+
+const (
+	BackendHTTP RDZVBackend = "http"
+)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +resource:path=paddlejobs

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ var Config struct {
 	PyTorchInitContainerImage        string
 	MPIKubectlDeliveryImage          string
 	PyTorchInitContainerMaxTries     int
+	PaddleElasticMedium              string
 }
 
 const (
@@ -33,4 +34,6 @@ const (
 	PyTorchInitContainerMaxTriesDefault = 100
 	// MPIKubectlDeliveryImageDefault is the default image for launcher pod in MPIJob init container.
 	MPIKubectlDeliveryImageDefault = "mpioperator/kubectl-delivery:latest"
+	// PaddleElasticDefaultImage is the default image for PaddleElasticMedium, to start etcd server
+	PaddleElasticDefaultImage = "bitnami/etcd:3.5"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,4 @@ const (
 	PyTorchInitContainerMaxTriesDefault = 100
 	// MPIKubectlDeliveryImageDefault is the default image for launcher pod in MPIJob init container.
 	MPIKubectlDeliveryImageDefault = "mpioperator/kubectl-delivery:latest"
-	// PaddleElasticDefaultImage is the default image for PaddleElasticMedium, to start etcd server
-	PaddleElasticDefaultImage = "bitnami/etcd:3.5"
 )

--- a/pkg/controller.v1/paddlepaddle/envvar.go
+++ b/pkg/controller.v1/paddlepaddle/envvar.go
@@ -44,9 +44,7 @@ func setPodEnv(obj interface{}, podTemplateSpec *corev1.PodTemplateSpec, rtype, 
 	if !ok {
 		return fmt.Errorf("%+v is not a type of PaddleJob", obj)
 	}
-	if job.Spec.ElasticPolicy == nil ||
-		job.Spec.ElasticPolicy.MinReplicas == nil ||
-		job.Spec.ElasticPolicy.MaxReplicas == nil {
+	if job.Spec.ElasticPolicy == nil {
 		return setStaticPodEnv(job, podTemplateSpec, rtype, index)
 	} else {
 		return setElasticPodEnv(job, podTemplateSpec, rtype, index)

--- a/pkg/controller.v1/paddlepaddle/envvar.go
+++ b/pkg/controller.v1/paddlepaddle/envvar.go
@@ -32,8 +32,7 @@ const (
 	EnvJobID          = "PADDLE_JOB_ID"
 	EnvServerNum      = "PADDLE_SERVER_NUM"
 	EnvTrainerNum     = "PADDLE_TRAINER_NUM"
-
-	ETCD_POTOCAL = "etcd://"
+	EtcdPotocol       = "etcd://"
 )
 
 // EnvVarGenerator is the environment variable generator interface.
@@ -72,7 +71,7 @@ func setStaticPodEnv(paddlejob *kubeflowv1.PaddleJob, podTemplateSpec *corev1.Po
 		// Ref https://stackoverflow.com/questions/59812009/what-is-the-use-of-pythonunbuffered-in-docker-file.
 		podTemplateSpec.Spec.Containers[i].Env = append(podTemplateSpec.Spec.Containers[i].Env, corev1.EnvVar{
 			Name:  "PYTHONUNBUFFERED",
-			Value: "0",
+			Value: "1",
 		})
 
 		podTemplateSpec.Spec.Containers[i].Env = append(podTemplateSpec.Spec.Containers[i].Env, corev1.EnvVar{
@@ -158,7 +157,9 @@ func setStaticPodEnv(paddlejob *kubeflowv1.PaddleJob, podTemplateSpec *corev1.Po
 
 func setElasticPodEnv(paddlejob *kubeflowv1.PaddleJob, podTemplateSpec *corev1.PodTemplateSpec, rtype, index string) error {
 	var masterEndpoint string
-	if strings.HasPrefix(config.Config.PaddleElasticMedium, ETCD_POTOCAL) {
+	if paddlejob.Spec.ElasticPolicy.Master != nil {
+		masterEndpoint = *paddlejob.Spec.ElasticPolicy.Master
+	} else if strings.HasPrefix(config.Config.PaddleElasticMedium, EtcdPotocol) {
 		masterEndpoint = config.Config.PaddleElasticMedium
 	}
 
@@ -171,7 +172,7 @@ func setElasticPodEnv(paddlejob *kubeflowv1.PaddleJob, podTemplateSpec *corev1.P
 		// Ref https://stackoverflow.com/questions/59812009/what-is-the-use-of-pythonunbuffered-in-docker-file.
 		podTemplateSpec.Spec.Containers[i].Env = append(podTemplateSpec.Spec.Containers[i].Env, corev1.EnvVar{
 			Name:  "PYTHONUNBUFFERED",
-			Value: "0",
+			Value: "1",
 		})
 
 		podTemplateSpec.Spec.Containers[i].Env = append(podTemplateSpec.Spec.Containers[i].Env, corev1.EnvVar{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR aim to add Elastic/Fault tolerant feature for PaddleJob.

This elastic mode of PaddleJob depends on an external etcd service, so we add `paddle-elastic-medium` arg to indicate either 

* external service, e.g. `etcd://1.1.1.1:2379`
* image to start etcd service, e.g. `bitnami/etcd:3.5`

In elastic mode, the runtime ENV `MASTER` will be different from before, which is the etcd service endpoint.

TODO:

- [x] support setting external etcd service.
- [ ] support setting image.
- [ ] support HPA (MAY not in this PR).
- [ ] add UT



**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
