### PR TITLE
Use Cluster instead of sparseCluster in TFJob DynamicWorker

### DIFF
--- a/pkg/controller.v1/tensorflow/tensorflow.go
+++ b/pkg/controller.v1/tensorflow/tensorflow.go
@@ -67,7 +67,7 @@ type SparseClusterSpec struct {
 }
 
 type SparseTFConfig struct {
-	Cluster SparseClusterSpec `json:"sparseCluster"`
+	Cluster SparseClusterSpec `json:"cluster"`
 	Task    TaskSpec          `json:"task"`
 }
 
@@ -91,6 +91,20 @@ func convertClusterSpecToSparseClusterSpec(clusterSpec ClusterSpec, rtype string
 //	    },
 //	    "task": {
 //	        "type": "ps",
+//	        "index": 1
+//	        },
+//	    }
+//	}
+//
+// if EnableDynamicWorker set true
+//
+//	{
+//	    "cluster": {
+//	        "ps": ["ps1:2222", "ps2:2222"],
+//	        "worker": {"1":"worker1:2222"}
+//	    },
+//	    "task": {
+//	        "type": "worker",
 //	        "index": 1
 //	        },
 //	    }


### PR DESCRIPTION
**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes # https://github.com/kubeflow/training-operator/issues/1795

Use Cluster instead of sparseCluster in TFJob DynamicWorker.

I will try to add an example for this feature later. Ref: https://github.com/kubeflow/training-operator/issues/1200