### PR TITLE
Improve E2E tests for the gang-scheduling

### DIFF
--- a/sdk/python/test/e2e/utils.py
+++ b/sdk/python/test/e2e/utils.py
@@ -17,14 +17,13 @@ def verify_unschedulable_job_e2e(
     logging.info(f"\n\n\n{job_kind} is creating")
     client.wait_for_job_conditions(name, namespace, job_kind, {constants.JOB_CONDITION_CREATED})
 
-    # Job should have Created conditions.
-    conditions = client.get_job_conditions(name, namespace, job_kind)
-    if len(conditions) != 1:
-        raise Exception(f"{job_kind} conditions are invalid: {conditions}")
-
-    # Job should have correct conditions.
+    # Job should have a Created condition.
     if not client.is_job_created(name, namespace, job_kind):
         raise Exception(f"{job_kind} should be in Created condition")
+
+    # Job shouldn't have a Running condition.
+    if client.is_job_running(name, namespace, job_kind):
+        raise Exception(f"{job_kind} shouldn't be in Running condition")
 
 
 def verify_job_e2e(


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
In E2E, after we created Jobs with unschedulable configurations, we verify the number of conditions is 1 when using scheduler plugins for gang scheduling.

But, the test seems flaky, as reported in #1779.

So, I modified the test to verify whether unschedulable Jobs have a `Created` condition and don't have a `Running` condition instead of the current way.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #1779 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
