### PR TITLE
e2e testing support volcano gang-scheduler

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -44,6 +44,15 @@ jobs:
           - kubernetes-version: v1.25.2
             gang-scheduler-name: "scheduler-plugins"
             python-version: "3.10"
+          - kubernetes-version: v1.26.4
+            gang-scheduler-name: "volcano"
+            python-version: "3.9"
+          - kubernetes-version: v1.24.6
+            gang-scheduler-name: "volcano"
+            python-version: "3.10"
+          - kubernetes-version: v1.25.2
+            gang-scheduler-name: "volcano"
+            python-version: "3.10"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
add e2e test of volcano gang-schedule
1. put patching gang-scheduler-name before installing gang-scheduler-plugin
2. split version of volcano.sh/apis without relationship of k8s



**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #1736

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
