### PR TITLE
fetch volcano log when e2e failed

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -96,3 +96,15 @@ jobs:
           python3 -m pip install -e sdk/python; pytest sdk/python/test --log-cli-level=info --namespace=default
         env:
           GANG_SCHEDULER_NAME: ${{ matrix.gang-scheduler-name }}
+
+      - name: Collect volcano logs
+        if: ${{ failure() &&  matrix.gang-scheduler-name == 'volcano' }}
+        run: |
+          echo "dump volcano-scheduler logs..."
+          kubectl logs -n volcano-system -l app=volcano-scheduler --tail=-1
+          echo "dump volcano-admission logs..."
+          kubectl logs -n volcano-system -l app=volcano-admission --tail=-1
+          echo "dump volcano-controllers logs..."
+          kubectl logs -n volcano-system -l app=volcano-controller --tail=-1
+          echo "dump podgroups description..."
+          kubectl describe podgroups.scheduling.volcano.sh -A


### PR DESCRIPTION


**What this PR does / why we need it**:

get volcano scheduler log and describe podgroup when e2e test failed

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
