### PR TITLE
Use the same reasons for Condition and Event

### DIFF
--- a/pkg/controller.v1/common/job.go
+++ b/pkg/controller.v1/common/job.go
@@ -93,6 +93,7 @@ func (jc *JobController) ReconcileJobs(
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for job object %#v: %v", job, err))
 		return err
 	}
+	jobKind := jc.Controller.GetAPIGroupVersionKind().Kind
 	// Reset expectations
 	// 1. Since `ReconcileJobs` is called, we expect that previous expectations are all satisfied,
 	//    and it's safe to reset the expectations
@@ -222,9 +223,9 @@ func (jc *JobController) ReconcileJobs(
 			}
 		}
 
-		jc.Recorder.Event(runtimeObject, corev1.EventTypeNormal, commonutil.JobFailedReason, failureMessage)
+		jc.Recorder.Event(runtimeObject, corev1.EventTypeNormal, commonutil.NewReason(jobKind, commonutil.JobFailedReason), failureMessage)
 
-		if err := commonutil.UpdateJobConditions(&jobStatus, apiv1.JobFailed, commonutil.JobFailedReason, failureMessage); err != nil {
+		if err = commonutil.UpdateJobConditions(&jobStatus, apiv1.JobFailed, commonutil.NewReason(jobKind, commonutil.JobFailedReason), failureMessage); err != nil {
 			log.Infof("Append job condition error: %v", err)
 			return err
 		}

--- a/pkg/controller.v1/common/pod.go
+++ b/pkg/controller.v1/common/pod.go
@@ -359,8 +359,10 @@ func (jc *JobController) ReconcilePods(
 
 				msg := fmt.Sprintf("job %s is restarting because %s replica(s) failed.",
 					metaObject.GetName(), rType)
-				jc.Recorder.Event(runtimeObject, v1.EventTypeWarning, "JobRestarting", msg)
-				if err := commonutil.UpdateJobConditions(jobStatus, apiv1.JobRestarting, "JobRestarting", msg); err != nil {
+				jc.Recorder.Event(runtimeObject, v1.EventTypeWarning,
+					commonutil.NewReason(jc.Controller.GetAPIGroupVersionKind().Kind, commonutil.JobRestartingReason), msg)
+				if err := commonutil.UpdateJobConditions(jobStatus, apiv1.JobRestarting,
+					commonutil.NewReason(jc.Controller.GetAPIGroupVersionKind().Kind, commonutil.JobRestartingReason), msg); err != nil {
 					commonutil.LoggerForJob(metaObject).Infof("Append job condition error: %v", err)
 					return err
 				}

--- a/pkg/controller.v1/mpi/mpijob.go
+++ b/pkg/controller.v1/mpi/mpijob.go
@@ -72,17 +72,7 @@ const (
 	// podTemplateSchedulerNameReason is the warning reason when other scheduler name is set
 	// in pod templates with gang-scheduling enabled
 	podTemplateSchedulerNameReason = "SettedPodTemplateSchedulerName"
-)
 
-const (
-	// mpiJobCreatedReason is added in a mpijob when it is created.
-	mpiJobCreatedReason = "MPIJobCreated"
-	// mpiJobSucceededReason is added in a mpijob when it is succeeded.
-	mpiJobSucceededReason = "MPIJobSucceeded"
-	// mpiJobRunningReason is added in a mpijob when it is running.
-	mpiJobRunningReason = "MPIJobRunning"
-	// mpiJobFailedReason is added in a mpijob when it is failed.
-	mpiJobFailedReason = "MPIJobFailed"
 	// mpiJobEvict
 	mpiJobEvict = "MPIJobEvicted"
 )

--- a/pkg/controller.v1/paddlepaddle/paddlepaddle_controller.go
+++ b/pkg/controller.v1/paddlepaddle/paddlepaddle_controller.go
@@ -133,7 +133,8 @@ func (r *PaddleJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	if err = kubeflowv1.ValidateV1PaddleJob(paddlejob); err != nil {
 		logger.Error(err, "PaddleJob failed validation")
-		r.Recorder.Eventf(paddlejob, corev1.EventTypeWarning, commonutil.JobFailedValidationReason, "PaddleJob failed validation because %s", err)
+		r.Recorder.Eventf(paddlejob, corev1.EventTypeWarning, commonutil.NewReason(kubeflowv1.PaddleJobKind, commonutil.JobFailedValidationReason),
+			"PaddleJob failed validation because %s", err)
 		return ctrl.Result{}, err
 	}
 
@@ -392,7 +393,7 @@ func (r *PaddleJobReconciler) UpdateJobStatus(job interface{},
 			if rtype == kubeflowv1.PaddleJobReplicaTypeMaster {
 				if running > 0 {
 					msg := fmt.Sprintf("PaddleJob %s is running.", paddlejob.Name)
-					err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobRunning, commonutil.JobRunningReason, msg)
+					err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobRunning, commonutil.NewReason(kubeflowv1.PaddleJobKind, commonutil.JobRunningReason), msg)
 					if err != nil {
 						commonutil.LoggerForJob(paddlejob).Infof("Append job condition error: %v", err)
 						return err
@@ -402,12 +403,12 @@ func (r *PaddleJobReconciler) UpdateJobStatus(job interface{},
 				if expected == 0 {
 					msg := fmt.Sprintf("PaddleJob %s is successfully completed.", paddlejob.Name)
 					logrus.Info(msg)
-					r.Recorder.Event(paddlejob, corev1.EventTypeNormal, commonutil.JobSucceededReason, msg)
+					r.Recorder.Event(paddlejob, corev1.EventTypeNormal, commonutil.NewReason(kubeflowv1.PaddleJobKind, commonutil.JobSucceededReason), msg)
 					if jobStatus.CompletionTime == nil {
 						now := metav1.Now()
 						jobStatus.CompletionTime = &now
 					}
-					err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobSucceeded, commonutil.JobSucceededReason, msg)
+					err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobSucceeded, commonutil.NewReason(kubeflowv1.PaddleJobKind, commonutil.JobSucceededReason), msg)
 					if err != nil {
 						commonutil.LoggerForJob(paddlejob).Infof("Append job condition error: %v", err)
 						return err
@@ -422,13 +423,13 @@ func (r *PaddleJobReconciler) UpdateJobStatus(job interface{},
 				if expected == 0 {
 					msg := fmt.Sprintf("PaddleJob %s/%s successfully completed.",
 						paddlejob.Namespace, paddlejob.Name)
-					r.recorder.Event(paddlejob, corev1.EventTypeNormal, commonutil.JobSucceededReason, msg)
+					r.recorder.Event(paddlejob, corev1.EventTypeNormal, commonutil.NewReason(kubeflowv1.PaddleJobKind, commonutil.JobSucceededReason), msg)
 					if jobStatus.CompletionTime == nil {
 						now := metav1.Now()
 						jobStatus.CompletionTime = &now
 					}
 					err := commonutil.UpdateJobConditions(jobStatus,
-						kubeflowv1.JobSucceeded, commonutil.JobSucceededReason, msg)
+						kubeflowv1.JobSucceeded, commonutil.NewReason(kubeflowv1.PaddleJobKind, commonutil.JobSucceededReason), msg)
 					if err != nil {
 						commonutil.LoggerForJob(paddlejob).Infof("Append paddlejob condition error: %v", err)
 						return err
@@ -438,7 +439,7 @@ func (r *PaddleJobReconciler) UpdateJobStatus(job interface{},
 					// Some workers are still running, leave a running condition.
 					msg := fmt.Sprintf("PaddleJob %s/%s is running.",
 						paddlejob.Namespace, paddlejob.Name)
-					err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobRunning, commonutil.JobRunningReason, msg)
+					err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobRunning, commonutil.NewReason(kubeflowv1.PaddleJobKind, commonutil.JobRunningReason), msg)
 					if err != nil {
 						commonutil.LoggerForJob(paddlejob).Infof("Append paddlejob condition error: %v", err)
 						return err
@@ -450,8 +451,8 @@ func (r *PaddleJobReconciler) UpdateJobStatus(job interface{},
 		if failed > 0 && (specReplicas > succeeded+running) {
 			if spec.RestartPolicy != kubeflowv1.RestartPolicyNever {
 				msg := fmt.Sprintf("PaddleJob %s is restarting because %d %s replica(s) failed.", paddlejob.Name, failed, rtype)
-				r.Recorder.Event(paddlejob, corev1.EventTypeWarning, commonutil.JobRestartingReason, msg)
-				err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobRestarting, commonutil.JobRestartingReason, msg)
+				r.Recorder.Event(paddlejob, corev1.EventTypeWarning, commonutil.NewReason(kubeflowv1.PaddleJobKind, commonutil.JobRestartingReason), msg)
+				err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobRestarting, commonutil.NewReason(kubeflowv1.PaddleJobKind, commonutil.JobRestartingReason), msg)
 				if err != nil {
 					commonutil.LoggerForJob(paddlejob).Infof("Append job condition error: %v", err)
 					return err
@@ -459,12 +460,12 @@ func (r *PaddleJobReconciler) UpdateJobStatus(job interface{},
 				trainingoperatorcommon.RestartedJobsCounterInc(paddlejob.Namespace, r.GetFrameworkName())
 			} else {
 				msg := fmt.Sprintf("PaddleJob %s is failed because %d %s replica(s) failed.", paddlejob.Name, failed, rtype)
-				r.Recorder.Event(paddlejob, corev1.EventTypeNormal, commonutil.JobFailedReason, msg)
+				r.Recorder.Event(paddlejob, corev1.EventTypeNormal, commonutil.NewReason(kubeflowv1.PaddleJobKind, commonutil.JobFailedReason), msg)
 				if jobStatus.CompletionTime == nil {
 					now := metav1.Now()
 					jobStatus.CompletionTime = &now
 				}
-				err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobFailed, commonutil.JobFailedReason, msg)
+				err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobFailed, commonutil.NewReason(kubeflowv1.PaddleJobKind, commonutil.JobFailedReason), msg)
 				if err != nil {
 					commonutil.LoggerForJob(paddlejob).Infof("Append job condition error: %v", err)
 					return err
@@ -549,7 +550,7 @@ func (r *PaddleJobReconciler) onOwnerCreateFunc() func(event.CreateEvent) bool {
 		msg := fmt.Sprintf("PaddleJob %s is created.", e.Object.GetName())
 		logrus.Info(msg)
 		trainingoperatorcommon.CreatedJobsCounterInc(paddlejob.Namespace, r.GetFrameworkName())
-		if err := commonutil.UpdateJobConditions(&paddlejob.Status, kubeflowv1.JobCreated, "PaddleJobCreated", msg); err != nil {
+		if err := commonutil.UpdateJobConditions(&paddlejob.Status, kubeflowv1.JobCreated, commonutil.NewReason(kubeflowv1.PaddleJobKind, commonutil.JobCreatedReason), msg); err != nil {
 			logrus.Error(err, "append job condition error")
 			return false
 		}

--- a/pkg/controller.v1/pytorch/pytorchjob_controller.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller.go
@@ -134,7 +134,8 @@ func (r *PyTorchJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	if err = kubeflowv1.ValidateV1PyTorchJob(pytorchjob); err != nil {
 		logger.Error(err, "PyTorchJob failed validation")
-		r.Recorder.Eventf(pytorchjob, corev1.EventTypeWarning, commonutil.JobFailedValidationReason, "PyTorchJob failed validation because %s", err)
+		r.Recorder.Eventf(pytorchjob, corev1.EventTypeWarning, commonutil.NewReason(kubeflowv1.PytorchJobKind, commonutil.JobFailedValidationReason),
+			"PyTorchJob failed validation because %s", err)
 		return ctrl.Result{}, err
 	}
 
@@ -391,7 +392,7 @@ func (r *PyTorchJobReconciler) UpdateJobStatus(job interface{},
 			if rtype == kubeflowv1.PyTorchJobReplicaTypeMaster {
 				if running > 0 {
 					msg := fmt.Sprintf("PyTorchJob %s is running.", pytorchjob.Name)
-					err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobRunning, commonutil.JobRunningReason, msg)
+					err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobRunning, commonutil.NewReason(kubeflowv1.PytorchJobKind, commonutil.JobRunningReason), msg)
 					if err != nil {
 						commonutil.LoggerForJob(pytorchjob).Infof("Append job condition error: %v", err)
 						return err
@@ -401,12 +402,12 @@ func (r *PyTorchJobReconciler) UpdateJobStatus(job interface{},
 				if expected == 0 {
 					msg := fmt.Sprintf("PyTorchJob %s is successfully completed.", pytorchjob.Name)
 					logrus.Info(msg)
-					r.Recorder.Event(pytorchjob, corev1.EventTypeNormal, commonutil.JobSucceededReason, msg)
+					r.Recorder.Event(pytorchjob, corev1.EventTypeNormal, commonutil.NewReason(kubeflowv1.PytorchJobKind, commonutil.JobSucceededReason), msg)
 					if jobStatus.CompletionTime == nil {
 						now := metav1.Now()
 						jobStatus.CompletionTime = &now
 					}
-					err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobSucceeded, commonutil.JobSucceededReason, msg)
+					err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobSucceeded, commonutil.NewReason(kubeflowv1.PytorchJobKind, commonutil.JobSucceededReason), msg)
 					if err != nil {
 						commonutil.LoggerForJob(pytorchjob).Infof("Append job condition error: %v", err)
 						return err
@@ -424,13 +425,13 @@ func (r *PyTorchJobReconciler) UpdateJobStatus(job interface{},
 				if expected == 0 || (pytorchjob.Spec.ElasticPolicy != nil && succeeded > 0) {
 					msg := fmt.Sprintf("PyTorchJob %s/%s successfully completed.",
 						pytorchjob.Namespace, pytorchjob.Name)
-					r.recorder.Event(pytorchjob, corev1.EventTypeNormal, commonutil.JobSucceededReason, msg)
+					r.recorder.Event(pytorchjob, corev1.EventTypeNormal, commonutil.NewReason(kubeflowv1.PytorchJobKind, commonutil.JobSucceededReason), msg)
 					if jobStatus.CompletionTime == nil {
 						now := metav1.Now()
 						jobStatus.CompletionTime = &now
 					}
 					err := commonutil.UpdateJobConditions(jobStatus,
-						kubeflowv1.JobSucceeded, commonutil.JobSucceededReason, msg)
+						kubeflowv1.JobSucceeded, commonutil.NewReason(kubeflowv1.PytorchJobKind, commonutil.JobSucceededReason), msg)
 					if err != nil {
 						commonutil.LoggerForJob(pytorchjob).Infof("Append pytorchjob condition error: %v", err)
 						return err
@@ -440,7 +441,7 @@ func (r *PyTorchJobReconciler) UpdateJobStatus(job interface{},
 					// Some workers are still running, leave a running condition.
 					msg := fmt.Sprintf("PyTorchJob %s/%s is running.",
 						pytorchjob.Namespace, pytorchjob.Name)
-					err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobRunning, commonutil.JobRunningReason, msg)
+					err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobRunning, commonutil.NewReason(kubeflowv1.PytorchJobKind, commonutil.JobRunningReason), msg)
 					if err != nil {
 						commonutil.LoggerForJob(pytorchjob).Infof("Append pytorchjob condition error: %v", err)
 						return err
@@ -452,8 +453,8 @@ func (r *PyTorchJobReconciler) UpdateJobStatus(job interface{},
 		if failed > 0 && (specReplicas > succeeded+running) {
 			if spec.RestartPolicy != kubeflowv1.RestartPolicyNever {
 				msg := fmt.Sprintf("PyTorchJob %s is restarting because %d %s replica(s) failed.", pytorchjob.Name, failed, rtype)
-				r.Recorder.Event(pytorchjob, corev1.EventTypeWarning, commonutil.JobRestartingReason, msg)
-				err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobRestarting, commonutil.JobRestartingReason, msg)
+				r.Recorder.Event(pytorchjob, corev1.EventTypeWarning, commonutil.NewReason(kubeflowv1.PytorchJobKind, commonutil.JobRestartingReason), msg)
+				err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobRestarting, commonutil.NewReason(kubeflowv1.PytorchJobKind, commonutil.JobRestartingReason), msg)
 				if err != nil {
 					commonutil.LoggerForJob(pytorchjob).Infof("Append job condition error: %v", err)
 					return err
@@ -461,12 +462,12 @@ func (r *PyTorchJobReconciler) UpdateJobStatus(job interface{},
 				trainingoperatorcommon.RestartedJobsCounterInc(pytorchjob.Namespace, r.GetFrameworkName())
 			} else {
 				msg := fmt.Sprintf("PyTorchJob %s is failed because %d %s replica(s) failed.", pytorchjob.Name, failed, rtype)
-				r.Recorder.Event(pytorchjob, corev1.EventTypeNormal, commonutil.JobFailedReason, msg)
+				r.Recorder.Event(pytorchjob, corev1.EventTypeNormal, commonutil.NewReason(kubeflowv1.PytorchJobKind, commonutil.JobFailedReason), msg)
 				if jobStatus.CompletionTime == nil {
 					now := metav1.Now()
 					jobStatus.CompletionTime = &now
 				}
-				err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobFailed, commonutil.JobFailedReason, msg)
+				err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobFailed, commonutil.NewReason(kubeflowv1.PytorchJobKind, commonutil.JobFailedReason), msg)
 				if err != nil {
 					commonutil.LoggerForJob(pytorchjob).Infof("Append job condition error: %v", err)
 					return err
@@ -552,7 +553,7 @@ func (r *PyTorchJobReconciler) onOwnerCreateFunc() func(event.CreateEvent) bool 
 		msg := fmt.Sprintf("PyTorchJob %s is created.", e.Object.GetName())
 		logrus.Info(msg)
 		trainingoperatorcommon.CreatedJobsCounterInc(pytorchjob.Namespace, r.GetFrameworkName())
-		if err := commonutil.UpdateJobConditions(&pytorchjob.Status, kubeflowv1.JobCreated, "PyTorchJobCreated", msg); err != nil {
+		if err := commonutil.UpdateJobConditions(&pytorchjob.Status, kubeflowv1.JobCreated, commonutil.NewReason(kubeflowv1.PytorchJobKind, commonutil.JobCreatedReason), msg); err != nil {
 			logrus.Error(err, "append job condition error")
 			return false
 		}

--- a/pkg/controller.v1/tensorflow/job_test.go
+++ b/pkg/controller.v1/tensorflow/job_test.go
@@ -244,7 +244,7 @@ var _ = Describe("TFJob controller", func() {
 				ctx := context.Background()
 				tc.tfJob.SetName(fmt.Sprintf(jobNameTemplate, idx))
 				tc.tfJob.SetUID(uuid.NewUUID())
-				Expect(commonutil.UpdateJobConditions(&tc.tfJob.Status, kubeflowv1.JobSucceeded, tfJobSucceededReason, "")).Should(Succeed())
+				Expect(commonutil.UpdateJobConditions(&tc.tfJob.Status, kubeflowv1.JobSucceeded, commonutil.NewReason(kubeflowv1.TFJobKind, commonutil.JobSucceededReason), "")).Should(Succeed())
 
 				refs := []metav1.OwnerReference{
 					*reconciler.GenOwnerReference(tc.tfJob),

--- a/pkg/controller.v1/tensorflow/tfjob_controller_test.go
+++ b/pkg/controller.v1/tensorflow/tfjob_controller_test.go
@@ -27,6 +27,7 @@ import (
 
 	kubeflowv1 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	tftestutil "github.com/kubeflow/training-operator/pkg/controller.v1/tensorflow/testutil"
+	commonutil "github.com/kubeflow/training-operator/pkg/util"
 )
 
 var _ = Describe("TFJob controller", func() {
@@ -119,7 +120,7 @@ var _ = Describe("TFJob controller", func() {
 					0, 0, 0,
 					4, 0, 0,
 					2, 0, 0,
-					&tfJobRunning, tfJobRunningReason,
+					&tfJobRunning, commonutil.NewReason(kubeflowv1.TFJobKind, commonutil.JobRunningReason),
 					true,
 				},
 				"Distributed TFJob (4 workers, 2 PS) is created, 2 workers, 1 PS are pending": {
@@ -141,7 +142,7 @@ var _ = Describe("TFJob controller", func() {
 					2, 0, 2,
 					1, 0, 0,
 					0, 0, 0,
-					&tfJobRunning, tfJobRunningReason,
+					&tfJobRunning, commonutil.NewReason(kubeflowv1.TFJobKind, commonutil.JobRunningReason),
 					false,
 				},
 				"Distributed TFJob (4 workers, 2 PS) is created, 2 workers, 1 PS are pending, 1 worker is succeeded": {
@@ -163,7 +164,7 @@ var _ = Describe("TFJob controller", func() {
 					0, 0, 0,
 					0, 4, 0,
 					0, 2, 0,
-					&tfJobSucceeded, tfJobSucceededReason,
+					&tfJobSucceeded, commonutil.NewReason(kubeflowv1.TFJobKind, commonutil.JobSucceededReason),
 					false,
 				},
 			}

--- a/pkg/controller.v1/xgboost/status.go
+++ b/pkg/controller.v1/xgboost/status.go
@@ -12,7 +12,7 @@ import (
 func setRunningCondition(logger *logrus.Entry, jobName string, jobStatus *kubeflowv1.JobStatus) error {
 	msg := fmt.Sprintf("XGBoostJob %s is running.", jobName)
 	if condition := findStatusCondition(jobStatus.Conditions, kubeflowv1.JobRunning); condition == nil {
-		err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobRunning, xgboostJobRunningReason, msg)
+		err := commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobRunning, commonutil.NewReason(kubeflowv1.XGBoostJobKind, commonutil.JobRunningReason), msg)
 		if err != nil {
 			logger.Infof("Append job condition error: %v", err)
 			return err

--- a/pkg/controller.v1/xgboost/status_test.go
+++ b/pkg/controller.v1/xgboost/status_test.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	kubeflowv1 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
+	commonutil "github.com/kubeflow/training-operator/pkg/util"
 )
 
 var ignoreJobConditionsTimeOpts = cmpopts.IgnoreFields(kubeflowv1.JobCondition{}, "LastUpdateTime", "LastTransitionTime")
@@ -24,7 +25,7 @@ func TestSetRunningCondition(t *testing.T) {
 			input: []kubeflowv1.JobCondition{
 				{
 					Type:    kubeflowv1.JobSucceeded,
-					Reason:  "XGBoostJobSucceeded",
+					Reason:  commonutil.NewReason(kubeflowv1.XGBoostJobKind, commonutil.JobSucceededReason),
 					Message: "XGBoostJob test-xbgoostjob is successfully completed.",
 					Status:  corev1.ConditionTrue,
 				},
@@ -32,13 +33,13 @@ func TestSetRunningCondition(t *testing.T) {
 			want: []kubeflowv1.JobCondition{
 				{
 					Type:    kubeflowv1.JobSucceeded,
-					Reason:  "XGBoostJobSucceeded",
+					Reason:  commonutil.NewReason(kubeflowv1.XGBoostJobKind, commonutil.JobSucceededReason),
 					Message: "XGBoostJob test-xbgoostjob is successfully completed.",
 					Status:  corev1.ConditionTrue,
 				},
 				{
 					Type:    kubeflowv1.JobRunning,
-					Reason:  "XGBoostJobRunning",
+					Reason:  commonutil.NewReason(kubeflowv1.XGBoostJobKind, commonutil.JobRunningReason),
 					Message: "XGBoostJob test-xbgoostjob is running.",
 					Status:  corev1.ConditionTrue,
 				},
@@ -48,13 +49,13 @@ func TestSetRunningCondition(t *testing.T) {
 			input: []kubeflowv1.JobCondition{
 				{
 					Type:    kubeflowv1.JobFailed,
-					Reason:  "XGBoostJobFailed",
+					Reason:  commonutil.NewReason(kubeflowv1.XGBoostJobKind, commonutil.JobFailedReason),
 					Message: "XGBoostJob test-sgboostjob is failed because 2 Worker replica(s) failed.",
 					Status:  corev1.ConditionTrue,
 				},
 				{
 					Type:    kubeflowv1.JobRunning,
-					Reason:  "XGBoostJobRunning",
+					Reason:  commonutil.NewReason(kubeflowv1.XGBoostJobKind, commonutil.JobRunningReason),
 					Message: "XGBoostJob test-xbgoostjob is running.",
 					Status:  corev1.ConditionTrue,
 				},
@@ -62,13 +63,13 @@ func TestSetRunningCondition(t *testing.T) {
 			want: []kubeflowv1.JobCondition{
 				{
 					Type:    kubeflowv1.JobFailed,
-					Reason:  "XGBoostJobFailed",
+					Reason:  commonutil.NewReason(kubeflowv1.XGBoostJobKind, commonutil.JobFailedReason),
 					Message: "XGBoostJob test-sgboostjob is failed because 2 Worker replica(s) failed.",
 					Status:  corev1.ConditionTrue,
 				},
 				{
 					Type:    kubeflowv1.JobRunning,
-					Reason:  "XGBoostJobRunning",
+					Reason:  commonutil.NewReason(kubeflowv1.XGBoostJobKind, commonutil.JobRunningReason),
 					Message: "XGBoostJob test-xbgoostjob is running.",
 					Status:  corev1.ConditionTrue,
 				},

--- a/pkg/util/status.go
+++ b/pkg/util/status.go
@@ -1,28 +1,32 @@
 package util
 
 import (
-	apiv1 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv1 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 )
 
 const (
 	// JobCreatedReason is added in a job when it is created.
-	JobCreatedReason = "JobCreated"
+	JobCreatedReason = "Created"
 	// JobSucceededReason is added in a job when it is succeeded.
-	JobSucceededReason = "JobSucceeded"
+	JobSucceededReason = "Succeeded"
 	// JobRunningReason is added in a job when it is running.
-	JobRunningReason = "JobRunning"
+	JobRunningReason = "Running"
 	// JobFailedReason is added in a job when it is failed.
-	JobFailedReason = "JobFailed"
+	JobFailedReason = "Failed"
 	// JobRestartingReason is added in a job when it is restarting.
-	JobRestartingReason = "JobRestarting"
+	JobRestartingReason = "Restarting"
 	// JobFailedValidationReason is added in a job when it failed validation
-	JobFailedValidationReason = "JobFailedValidation"
-
-	// labels for pods and servers.
-
+	JobFailedValidationReason = "FailedValidation"
 )
+
+func NewReason(kind, reason string) string {
+	return fmt.Sprintf("%s%s", kind, reason)
+}
 
 // IsSucceeded checks if the job is succeeded
 func IsSucceeded(status apiv1.JobStatus) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Currently, jobs use different reasons for Condition and Event even if the situation is the same. (`JobCreated` vs `TFJobCreated`)

For example, the JobController uses `JobXXX` (XXX is the reason such as Failed), and the pytorchjob-controller uses `PyTorchJobXXX` like this:

https://github.com/kubeflow/training-operator/blob/fcdf9a3897bf601455867f1a4b3c831f014fb77a/pkg/controller.v1/common/job.go#L227

https://github.com/kubeflow/training-operator/blob/fcdf9a3897bf601455867f1a4b3c831f014fb77a/pkg/controller.v1/pytorch/pytorchjob_controller.go#L555

So I modified the reasons for Condition and Event so that the Jobs use consistently the same reason format `${KIND}${REASON}` like `PyTorchJobCreated`  in the same situation.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
