### PR TITLE
set PYTHONUNBUFFERED to 1

### DIFF
--- a/pkg/controller.v1/paddlepaddle/envvar.go
+++ b/pkg/controller.v1/paddlepaddle/envvar.go
@@ -59,7 +59,7 @@ func setPodEnv(obj interface{}, podTemplateSpec *corev1.PodTemplateSpec, rtype, 
 		// Ref https://stackoverflow.com/questions/59812009/what-is-the-use-of-pythonunbuffered-in-docker-file.
 		podTemplateSpec.Spec.Containers[i].Env = append(podTemplateSpec.Spec.Containers[i].Env, corev1.EnvVar{
 			Name:  "PYTHONUNBUFFERED",
-			Value: "0",
+			Value: "1",
 		})
 
 		podTemplateSpec.Spec.Containers[i].Env = append(podTemplateSpec.Spec.Containers[i].Env, corev1.EnvVar{

--- a/pkg/controller.v1/pytorch/envvar.go
+++ b/pkg/controller.v1/pytorch/envvar.go
@@ -45,7 +45,7 @@ func setPodEnv(obj interface{}, podTemplateSpec *corev1.PodTemplateSpec, rtype, 
 		podTemplateSpec.Spec.Containers[i].Env = append(
 			podTemplateSpec.Spec.Containers[i].Env, corev1.EnvVar{
 				Name:  "PYTHONUNBUFFERED",
-				Value: "0",
+				Value: "1",
 			})
 
 		// If the master is not null, then we need to set the MASTER_ADDR and RANK.

--- a/pkg/controller.v1/xgboost/xgboost.go
+++ b/pkg/controller.v1/xgboost/xgboost.go
@@ -92,7 +92,7 @@ func SetPodEnv(job interface{}, podTemplate *corev1.PodTemplateSpec, rtype, inde
 		})
 		podTemplate.Spec.Containers[i].Env = append(podTemplate.Spec.Containers[i].Env, corev1.EnvVar{
 			Name:  "PYTHONUNBUFFERED",
-			Value: "0",
+			Value: "1",
 		})
 		// This variables are used if it is a LightGBM job
 		if totalReplicas > 1 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

As mentioned in the comment, set PYTHONUNBUFFERED to non zero value means to set python unbuffered, which is the desired state.

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
