### PR TITLE
Make Condition and ReplicaStatus optional

### DIFF
--- a/hack/python-sdk/swagger.json
+++ b/hack/python-sdk/swagger.json
@@ -105,10 +105,6 @@
     "kubeflow.org.v1.JobStatus": {
       "description": "JobStatus represents the current observed state of the training Job.",
       "type": "object",
-      "required": [
-        "conditions",
-        "replicaStatuses"
-      ],
       "properties": {
         "completionTime": {
           "description": "Represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",

--- a/manifests/base/crds/kubeflow.org_mpijobs.yaml
+++ b/manifests/base/crds/kubeflow.org_mpijobs.yaml
@@ -7845,9 +7845,6 @@ spec:
                   and is in UTC.
                 format: date-time
                 type: string
-            required:
-            - conditions
-            - replicaStatuses
             type: object
         type: object
     served: true

--- a/manifests/base/crds/kubeflow.org_mxjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_mxjobs.yaml
@@ -7840,9 +7840,6 @@ spec:
                   and is in UTC.
                 format: date-time
                 type: string
-            required:
-            - conditions
-            - replicaStatuses
             type: object
         type: object
     served: true

--- a/manifests/base/crds/kubeflow.org_paddlejobs.yaml
+++ b/manifests/base/crds/kubeflow.org_paddlejobs.yaml
@@ -8350,9 +8350,6 @@ spec:
                   and is in UTC.
                 format: date-time
                 type: string
-            required:
-            - conditions
-            - replicaStatuses
             type: object
         type: object
     served: true

--- a/manifests/base/crds/kubeflow.org_pytorchjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_pytorchjobs.yaml
@@ -8385,9 +8385,6 @@ spec:
                   and is in UTC.
                 format: date-time
                 type: string
-            required:
-            - conditions
-            - replicaStatuses
             type: object
         type: object
     served: true

--- a/manifests/base/crds/kubeflow.org_tfjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_tfjobs.yaml
@@ -7842,9 +7842,6 @@ spec:
                   and is in UTC.
                 format: date-time
                 type: string
-            required:
-            - conditions
-            - replicaStatuses
             type: object
         type: object
     served: true

--- a/manifests/base/crds/kubeflow.org_xgboostjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_xgboostjobs.yaml
@@ -7831,9 +7831,6 @@ spec:
                   and is in UTC.
                 format: date-time
                 type: string
-            required:
-            - conditions
-            - replicaStatuses
             type: object
         type: object
     served: true

--- a/pkg/apis/kubeflow.org/v1/common_types.go
+++ b/pkg/apis/kubeflow.org/v1/common_types.go
@@ -40,11 +40,11 @@ const (
 // JobStatus represents the current observed state of the training Job.
 type JobStatus struct {
 	// Conditions is an array of current observed job conditions.
-	Conditions []JobCondition `json:"conditions"`
+	Conditions []JobCondition `json:"conditions,omitempty"`
 
 	// ReplicaStatuses is map of ReplicaType and ReplicaStatus,
 	// specifies the status of each replica.
-	ReplicaStatuses map[ReplicaType]*ReplicaStatus `json:"replicaStatuses"`
+	ReplicaStatuses map[ReplicaType]*ReplicaStatus `json:"replicaStatuses,omitempty"`
 
 	// Represents time when the job was acknowledged by the job controller.
 	// It is not guaranteed to be set in happens-before order across separate operations.

--- a/pkg/apis/kubeflow.org/v1/openapi_generated.go
+++ b/pkg/apis/kubeflow.org/v1/openapi_generated.go
@@ -273,7 +273,6 @@ func schema_pkg_apis_kubefloworg_v1_JobStatus(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				Required: []string{"conditions", "replicaStatuses"},
 			},
 		},
 		Dependencies: []string{

--- a/sdk/python/docs/KubeflowOrgV1JobStatus.md
+++ b/sdk/python/docs/KubeflowOrgV1JobStatus.md
@@ -5,9 +5,9 @@ JobStatus represents the current observed state of the training Job.
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **completion_time** | [**datetime**](V1Time.md) |  | [optional] 
-**conditions** | [**list[KubeflowOrgV1JobCondition]**](KubeflowOrgV1JobCondition.md) | Conditions is an array of current observed job conditions. | 
+**conditions** | [**list[KubeflowOrgV1JobCondition]**](KubeflowOrgV1JobCondition.md) | Conditions is an array of current observed job conditions. | [optional] 
 **last_reconcile_time** | [**datetime**](V1Time.md) |  | [optional] 
-**replica_statuses** | [**dict(str, KubeflowOrgV1ReplicaStatus)**](KubeflowOrgV1ReplicaStatus.md) | ReplicaStatuses is map of ReplicaType and ReplicaStatus, specifies the status of each replica. | 
+**replica_statuses** | [**dict(str, KubeflowOrgV1ReplicaStatus)**](KubeflowOrgV1ReplicaStatus.md) | ReplicaStatuses is map of ReplicaType and ReplicaStatus, specifies the status of each replica. | [optional] 
 **start_time** | [**datetime**](V1Time.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/sdk/python/kubeflow/training/models/kubeflow_org_v1_job_status.py
+++ b/sdk/python/kubeflow/training/models/kubeflow_org_v1_job_status.py
@@ -63,10 +63,12 @@ class KubeflowOrgV1JobStatus(object):
 
         if completion_time is not None:
             self.completion_time = completion_time
-        self.conditions = conditions
+        if conditions is not None:
+            self.conditions = conditions
         if last_reconcile_time is not None:
             self.last_reconcile_time = last_reconcile_time
-        self.replica_statuses = replica_statuses
+        if replica_statuses is not None:
+            self.replica_statuses = replica_statuses
         if start_time is not None:
             self.start_time = start_time
 
@@ -111,8 +113,6 @@ class KubeflowOrgV1JobStatus(object):
         :param conditions: The conditions of this KubeflowOrgV1JobStatus.  # noqa: E501
         :type: list[KubeflowOrgV1JobCondition]
         """
-        if self.local_vars_configuration.client_side_validation and conditions is None:  # noqa: E501
-            raise ValueError("Invalid value for `conditions`, must not be `None`")  # noqa: E501
 
         self._conditions = conditions
 
@@ -157,8 +157,6 @@ class KubeflowOrgV1JobStatus(object):
         :param replica_statuses: The replica_statuses of this KubeflowOrgV1JobStatus.  # noqa: E501
         :type: dict(str, KubeflowOrgV1ReplicaStatus)
         """
-        if self.local_vars_configuration.client_side_validation and replica_statuses is None:  # noqa: E501
-            raise ValueError("Invalid value for `replica_statuses`, must not be `None`")  # noqa: E501
 
         self._replica_statuses = replica_statuses
 

--- a/sdk/python/test/test_kubeflow_org_v1_job_status.py
+++ b/sdk/python/test/test_kubeflow_org_v1_job_status.py
@@ -59,23 +59,6 @@ class TestKubeflowOrgV1JobStatus(unittest.TestCase):
             )
         else :
             return KubeflowOrgV1JobStatus(
-                conditions = [
-                    kubeflow_org_v1_job_condition.KubeflowOrgV1JobCondition(
-                        last_transition_time = None, 
-                        last_update_time = None, 
-                        message = '0', 
-                        reason = '0', 
-                        status = '0', 
-                        type = '0', )
-                    ],
-                replica_statuses = {
-                    'key' : kubeflow_org_v1_replica_status.KubeflowOrgV1ReplicaStatus(
-                        active = 56, 
-                        failed = 56, 
-                        label_selector = None, 
-                        selector = '0', 
-                        succeeded = 56, )
-                    },
         )
 
     def testKubeflowOrgV1JobStatus(self):


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I made `jobStatus.Condition` and `jobStatus.replicaStatus` optional. We shouldn't make those fields necessary since those fields can be null. 

/assign @johnugeorge 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
