### PR TITLE
Implement integration test for MPIJob v1 related to suspend semantics

### DIFF
--- a/pkg/controller.v1/mpi/mpijob_controller.go
+++ b/pkg/controller.v1/mpi/mpijob_controller.go
@@ -317,7 +317,7 @@ func (jc *MPIJobReconciler) onOwnerCreateFunc() func(event.CreateEvent) bool {
 		}
 
 		jc.Scheme.Default(mpiJob)
-		msg := fmt.Sprintf("MPIJob %s/%s is created.", mpiJob.Namespace, e.Object.GetName())
+		msg := fmt.Sprintf("MPIJob %s is created.", e.Object.GetName())
 		logrus.Info(msg)
 		trainingoperatorcommon.CreatedJobsCounterInc(mpiJob.Namespace, jc.GetFrameworkName())
 		commonutil.UpdateJobConditions(&mpiJob.Status, kubeflowv1.JobCreated, corev1.ConditionTrue, commonutil.NewReason(kubeflowv1.MPIJobKind, commonutil.JobCreatedReason), msg)

--- a/pkg/controller.v1/xgboost/xgboostjob_controller_test.go
+++ b/pkg/controller.v1/xgboost/xgboostjob_controller_test.go
@@ -37,7 +37,7 @@ var _ = Describe("XGBoost controller", func() {
 	const (
 		expectedPort = int32(9999)
 	)
-	Context("", func() {
+	Context("When creating the XGBoostJob", func() {
 		const name = "test-job"
 		var (
 			ns         *corev1.Namespace


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I implemented integration test for MPIJob v1 related to suspend semantics.

follow-up: https://github.com/kubeflow/training-operator/pull/1859

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
