### PR TITLE
Provide an updated kubectl delivery with the latest kubectl CLI

### DIFF
--- a/.github/workflows/publish-core-images.yaml
+++ b/.github/workflows/publish-core-images.yaml
@@ -22,3 +22,5 @@ jobs:
         include:
           - component-name: training-operator
             dockerfile: build/images/training-operator/Dockerfile
+          - component-name: kubectl-delivery
+            dockerfile: build/images/kubectl-delivery/Dockerfile

--- a/build/images/kubectl-delivery/Dockerfile
+++ b/build/images/kubectl-delivery/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.17 AS build
+
+# Install kubectl.
+ENV K8S_VERSION v1.27.0
+RUN apk add --no-cache wget
+RUN wget -q https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
+RUN chmod +x ./kubectl
+RUN mv ./kubectl /bin/kubectl
+
+FROM alpine:3.17
+COPY --from=build /bin/kubectl /bin/kubectl
+RUN apk add --no-cache bash
+COPY scripts/kubectl-delivery/deliver-kubectl.sh .
+ENTRYPOINT ["./deliver_kubectl.sh"]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,5 +32,5 @@ const (
 	// PyTorchInitContainerMaxTriesDefault is the default number of tries for the pytorch init container.
 	PyTorchInitContainerMaxTriesDefault = 100
 	// MPIKubectlDeliveryImageDefault is the default image for launcher pod in MPIJob init container.
-	MPIKubectlDeliveryImageDefault = "mpioperator/kubectl-delivery:latest"
+	MPIKubectlDeliveryImageDefault = "kubeflow/kubectl-delivery:latest"
 )

--- a/scripts/kubectl-delivery/deliver-kubectl.sh
+++ b/scripts/kubectl-delivery/deliver-kubectl.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This shell script is used to build an image from our argo workflow
+
+if ! which kubectl > /dev/null; then
+  echo "kubectl needs to be installed"
+  exit 1
+fi
+
+: ${TARGET_DIR:?"Need to set TARGET_DIR, e.g. /opt/kube"}
+
+cp $(which kubectl) ${TARGET_DIR}
+
+file="/etc/mpi/hostfile"
+workers=()
+i=0
+IFS=$'\n'       # make newlines the only separator
+set -f          # disable globbing
+for line in $(cat < "$file"); do
+      echo "$line"
+      workers[i]=$line # Put it into the array
+      i=$(($i + 1))
+      echo $i
+done
+
+hello="hello"
+
+for(( i=0;i<${#workers[@]};i++)) do
+   worker=$(echo ${workers[i]} | awk '{print $1}')
+   echo "worker name is ${worker}"
+   while true
+     do
+        status=$(/opt/kube/kubectl exec -it ${worker} echo "hello")
+        status="${status%%[[:cntrl:]]}"
+        echo "hello is ${hello}"
+        if [[ "a${status}" == "a${hello}" ]] ;then
+            echo "${worker} is running.."
+            break
+        fi
+        sleep 1
+     done
+done;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

When running an MPI Job kubectl is required to start the mpi binary on the workers. The launcher connects to the workers using kubectl. This kubectl is provided by an init container. That init container provides a very old version of kubectl. Also the image for the init container is not controlled inside the training operator repository. So with the pull request the image is managed within the repository. 

Also it uses a 1.27 version of the kubectl that provides the latest features and fixes. 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #1899

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
