### PR TITLE
Replace XGBoost image for E2E with community hosted

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -55,6 +55,22 @@ jobs:
             python-version: "3.10"
 
     steps:
+      # This step is a Workaround to avoid the "No space left on device" error.
+      # ref: https://github.com/actions/runner-images/issues/2840
+      - name: Remove unnecessary files
+        shell: bash
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/share/swift
+          
+          echo "Disk usage after cleanup:"
+          df -h
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/sdk/python/test/e2e/test_e2e_xgboostjob.py
+++ b/sdk/python/test/e2e/test_e2e_xgboostjob.py
@@ -181,7 +181,7 @@ def generate_xgboostjob(
 def generate_container() -> V1Container:
     return V1Container(
         name=CONTAINER_NAME,
-        image="docker.io/merlintang/xgboost-dist-iris:1.1",
+        image="docker.io/kubeflow/xgboost-dist-iris:latest",
         args=[
             "--job_type=Train",
             "--xgboost_parameter=objective:multi:softprob,num_class:3",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I replaced the image with community hosted one.
follow up: https://github.com/kubeflow/training-operator/pull/1913

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
