### PR TITLE
Use a community hosted image in MXJob E2E

### DIFF
--- a/examples/mxnet/mxjob_dist_v1.yaml
+++ b/examples/mxnet/mxjob_dist_v1.yaml
@@ -35,8 +35,8 @@ spec:
           containers:
             - name: mxnet
               image: kubeflow/mxnet-gpu:latest
-              command: ["python"]
-              args: ["/incubator-mxnet/example/image-classification/train_mnist.py","--num-epochs","10","--num-layers","2","--kv-store","dist_device_sync","--gpus","0"]
+              command: ["python3"]
+              args: ["/mxnet/mxnet/example/image-classification/train_mnist.py","--num-epochs","10","--num-layers","2","--kv-store","dist_device_sync","--gpus","0"]
               resources:
                 limits:
                   nvidia.com/gpu: 1

--- a/sdk/python/test/e2e/test_e2e_mxjob.py
+++ b/sdk/python/test/e2e/test_e2e_mxjob.py
@@ -221,11 +221,10 @@ def generate_mxjob(
 def generate_containers() -> Tuple[V1Container, V1Container, V1Container]:
     worker_container = V1Container(
         name=CONTAINER_NAME,
-        # TODO (tenzen-y): Replace the below image with the kubeflow hosted image
-        image="docker.io/johnugeorge/mxnet:1.9.1_cpu_py3",
+        image="docker.io/kubeflow/mxnet-gpu:latest",
         command=["/usr/local/bin/python3"],
         args=[
-            "incubator-mxnet/example/image-classification/train_mnist.py",
+            "/mxnet/mxnet/example/image-classification/train_mnist.py",
             "--num-epochs",
             "1",
             "--num-examples",
@@ -239,16 +238,14 @@ def generate_containers() -> Tuple[V1Container, V1Container, V1Container]:
 
     server_container = V1Container(
         name=CONTAINER_NAME,
-        # TODO (tenzen-y): Replace the below image with the kubeflow hosted image
-        image="docker.io/johnugeorge/mxnet:1.9.1_cpu_py3",
+        image="docker.io/kubeflow/mxnet-gpu:latest",
         ports=[V1ContainerPort(container_port=9991, name="mxjob-port")],
         resources=V1ResourceRequirements(limits={"memory": "1Gi", "cpu": "0.25"}),
     )
 
     scheduler_container = V1Container(
         name=CONTAINER_NAME,
-        # TODO (tenzen-y): Replace the below image with the kubeflow hosted image
-        image="docker.io/johnugeorge/mxnet:1.9.1_cpu_py3",
+        image="docker.io/kubeflow/mxnet-gpu:latest",
         ports=[V1ContainerPort(container_port=9991, name="mxjob-port")],
         resources=V1ResourceRequirements(limits={"memory": "1Gi", "cpu": "0.25"}),
     )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I replaced the MXJob E2E image with a community-hosted image. Also, I fixed the bug in a MXJob example.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
