### PR TITLE
Add @andreyvelich to Approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,5 @@
 approvers:
+  - andreyvelich
   - gaocegege
   - Jeffwan
   - johnugeorge


### PR DESCRIPTION
I added myself to Training Operator approvers to make it easier to approve PRs and merge them.

/assign @tenzen-y @johnugeorge 