### PR TITLE
Avoid modifying log level globally

### DIFF
--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -770,7 +770,7 @@ class TrainingClient(object):
         replica_index: Optional[int] = None,
         follow: bool = False,
         timeout: int = constants.DEFAULT_TIMEOUT,
-    ) -> dict[str, str]:
+    ) -> Dict[str, str]:
         """Print the training logs for the Job. By default it returns logs from
         the `master` pod.
 
@@ -801,7 +801,7 @@ class TrainingClient(object):
                 to execute the request.
 
         Returns:
-            dict[str, str]: A dictionary in which the keys are pod names and the
+            Dict[str, str]: A dictionary in which the keys are pod names and the
             values are the corresponding logs.
 
         Raises:
@@ -822,6 +822,7 @@ class TrainingClient(object):
             timeout=timeout,
         )
 
+        logs_dict = {}
         if pods and follow:
             log_streams = []
             for pod in pods:
@@ -856,7 +857,6 @@ class TrainingClient(object):
                         except queue.Empty:
                             break
         elif pods:
-            logs_dict = {}
             for pod in pods:
                 try:
                     pod_logs = self.core_api.read_namespaced_pod_log(

--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -24,8 +24,7 @@ from kubeflow.training.api_client import ApiClient
 from kubeflow.training.constants import constants
 from kubeflow.training.utils import utils
 
-logging.basicConfig(format="%(message)s")
-logging.getLogger().setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
 
 status_logger = utils.StatusLogger(
     header="{:<30.30} {:<20.20} {}".format("NAME", "STATE", "TIME"),
@@ -222,7 +221,7 @@ class TrainingClient(object):
                 f"Failed to create {job_kind}: {namespace}/{job.metadata.name}"
             )
 
-        logging.info(f"{job_kind} {namespace}/{job.metadata.name} has been created")
+        logger.debug(f"{job_kind} {namespace}/{job.metadata.name} has been created")
 
     def get_job(
         self,
@@ -849,7 +848,7 @@ class TrainingClient(object):
                             if logline is None:
                                 finished[index] = True
                                 break
-                            logging.info("[Pod %s]: %s", pods[index], logline)
+                            logger.debug("[Pod %s]: %s", pods[index], logline)
                         except queue.Empty:
                             break
         elif pods:
@@ -860,7 +859,7 @@ class TrainingClient(object):
                         namespace,
                         container=constants.JOB_PARAMETERS[job_kind]["container"],
                     )
-                    logging.info("The logs of pod %s:\n %s", pod, pod_logs)
+                    logger.debug("The logs of pod %s:\n %s", pod, pod_logs)
                 except Exception:
                     raise RuntimeError(f"Failed to read logs for pod {namespace}/{pod}")
 
@@ -908,7 +907,7 @@ class TrainingClient(object):
         except Exception:
             raise RuntimeError(f"Failed to update {job_kind}: {namespace}/{name}")
 
-        logging.info(f"{job_kind} {namespace}/{name} has been updated")
+        logger.debug(f"{job_kind} {namespace}/{name} has been updated")
 
     def delete_job(
         self,
@@ -950,4 +949,4 @@ class TrainingClient(object):
         except Exception:
             raise RuntimeError(f"Failed to delete {job_kind}: {namespace}/{name}")
 
-        logging.info(f"{job_kind} {namespace}/{name} has been deleted")
+        logger.debug(f"{job_kind} {namespace}/{name} has been deleted")

--- a/sdk/python/kubeflow/training/utils/utils.py
+++ b/sdk/python/kubeflow/training/utils/utils.py
@@ -25,8 +25,7 @@ from kubeflow.training.constants import constants
 from kubeflow.training import models
 
 
-logging.basicConfig(format="%(message)s")
-logging.getLogger().setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class StatusLogger:
@@ -39,9 +38,9 @@ class StatusLogger:
 
     def __call__(self, *values):
         if self.first_call:
-            logging.info(self.header)
+            logger.debug(self.header)
             self.first_call = False
-        logging.info(self.column_format.format(*values))
+        logger.debug(self.column_format.format(*values))
 
 
 class FakeResponse:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR eliminates the code that was setting the log level to `INFO` globally, as documented in [this](https://github.com/kubeflow/training-operator/issues/1942) issue.

The `get_job_logs` implementation needs to be addressed before merging, but I figured it would be easier to talk about with a proper PR @johnugeorge.

Do you want it to not print to stdout by default and just return a data structure that looks like this?

```python
{
    pod1: logs,
    pod2: logs,
    pod3: logs
}
```

**Which issue(s) this PR fixes**
Fixes # https://github.com/kubeflow/training-operator/issues/1942
