### PR TITLE
fix nproc env in elastic mode for pytorchjob

### DIFF
--- a/pkg/controller.v1/pytorch/envvar.go
+++ b/pkg/controller.v1/pytorch/envvar.go
@@ -91,12 +91,15 @@ func setPodEnv(obj interface{}, podTemplateSpec *corev1.PodTemplateSpec, rtype, 
 				Value: strconv.Itoa(rank),
 			})
 			podTemplateSpec.Spec.Containers[i].Env = append(podTemplateSpec.Spec.Containers[i].Env, corev1.EnvVar{
-				Name:  EnvNprocPerNode,
-				Value: *pytorchjob.Spec.NprocPerNode,
-			})
-			podTemplateSpec.Spec.Containers[i].Env = append(podTemplateSpec.Spec.Containers[i].Env, corev1.EnvVar{
 				Name:  EnvNodeRank,
 				Value: strconv.Itoa(rank),
+			})
+		}
+
+		if pytorchjob.Spec.NprocPerNode != nil {
+			podTemplateSpec.Spec.Containers[i].Env = append(podTemplateSpec.Spec.Containers[i].Env, corev1.EnvVar{
+				Name:  EnvNprocPerNode,
+				Value: *pytorchjob.Spec.NprocPerNode,
 			})
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

In PyTorchJob elastic mode, nproc env may not be set.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes # https://github.com/kubeflow/training-operator/issues/1947

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
