### PR TITLE
utils changes needed to add train api

### DIFF
--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -191,7 +191,7 @@ class TrainingClient(object):
                 job = utils.get_pytorchjob_template(
                     name=name,
                     namespace=namespace,
-                    pod_template_spec=pod_template_spec,
+                    worker_pod_template_spec=pod_template_spec,
                     num_worker_replicas=num_worker_replicas,
                 )
             else:

--- a/sdk/python/kubeflow/training/constants/constants.py
+++ b/sdk/python/kubeflow/training/constants/constants.py
@@ -78,6 +78,7 @@ TFJOB_BASE_IMAGE_GPU = "docker.io/tensorflow/tensorflow:2.9.1-gpu"
 PYTORCHJOB_KIND = "PyTorchJob"
 PYTORCHJOB_PLURAL = "pytorchjobs"
 PYTORCHJOB_CONTAINER = "pytorch"
+PYTORCHJOB_STORAGE_CONTAINER = "pytorch-storage"
 PYTORCHJOB_REPLICA_TYPES = (REPLICA_TYPE_MASTER.lower(), REPLICA_TYPE_WORKER.lower())
 
 PYTORCHJOB_BASE_IMAGE = "docker.io/pytorch/pytorch:1.12.1-cuda11.3-cudnn8-runtime"
@@ -128,6 +129,7 @@ JOB_PARAMETERS = {
         "plural": PYTORCHJOB_PLURAL,
         "container": PYTORCHJOB_CONTAINER,
         "base_image": PYTORCHJOB_BASE_IMAGE,
+        "init_container": PYTORCHJOB_STORAGE_CONTAINER
     },
     MXJOB_KIND: {
         "model": models.KubeflowOrgV1MXJob,

--- a/sdk/python/kubeflow/training/constants/constants.py
+++ b/sdk/python/kubeflow/training/constants/constants.py
@@ -78,7 +78,6 @@ TFJOB_BASE_IMAGE_GPU = "docker.io/tensorflow/tensorflow:2.9.1-gpu"
 PYTORCHJOB_KIND = "PyTorchJob"
 PYTORCHJOB_PLURAL = "pytorchjobs"
 PYTORCHJOB_CONTAINER = "pytorch"
-PYTORCHJOB_STORAGE_CONTAINER = "pytorch-storage"
 PYTORCHJOB_REPLICA_TYPES = (REPLICA_TYPE_MASTER.lower(), REPLICA_TYPE_WORKER.lower())
 
 PYTORCHJOB_BASE_IMAGE = "docker.io/pytorch/pytorch:1.12.1-cuda11.3-cudnn8-runtime"
@@ -129,7 +128,6 @@ JOB_PARAMETERS = {
         "plural": PYTORCHJOB_PLURAL,
         "container": PYTORCHJOB_CONTAINER,
         "base_image": PYTORCHJOB_BASE_IMAGE,
-        "init_container": PYTORCHJOB_STORAGE_CONTAINER,
     },
     MXJOB_KIND: {
         "model": models.KubeflowOrgV1MXJob,

--- a/sdk/python/kubeflow/training/constants/constants.py
+++ b/sdk/python/kubeflow/training/constants/constants.py
@@ -129,7 +129,7 @@ JOB_PARAMETERS = {
         "plural": PYTORCHJOB_PLURAL,
         "container": PYTORCHJOB_CONTAINER,
         "base_image": PYTORCHJOB_BASE_IMAGE,
-        "init_container": PYTORCHJOB_STORAGE_CONTAINER
+        "init_container": PYTORCHJOB_STORAGE_CONTAINER,
     },
     MXJOB_KIND: {
         "model": models.KubeflowOrgV1MXJob,

--- a/sdk/python/kubeflow/training/utils/utils.py
+++ b/sdk/python/kubeflow/training/utils/utils.py
@@ -128,7 +128,10 @@ def get_container_spec(
     get container spec for given name and image.
     """
     if name is None or image is None:
-        container_spec = models.V1Container(name=name, image=image)
+        raise ValueError("container name or image cannot be none")
+
+    container_spec = models.V1Container(name=name, image=image)
+
     if args:
         container_spec.args = args
 
@@ -168,7 +171,7 @@ def get_pod_template_spec(
         ),
         spec=models.V1PodSpec(
             containers=[
-                models.V1Container(
+                get_container_spec(
                     name=constants.JOB_PARAMETERS[job_kind]["container"],
                     image=base_image,
                 )

--- a/sdk/python/kubeflow/training/utils/utils.py
+++ b/sdk/python/kubeflow/training/utils/utils.py
@@ -323,14 +323,7 @@ def get_pytorchjob_template(
     if elastic_policy:
         pytorchjob.spec.elastic_policy = elastic_policy
 
-    # for elastic policy currently mandating the presence of master replica, will be removed in future
-    if elastic_policy and master_pod_template_spec is None:
-        raise ValueError(
-            "master_pod_template_spec cannot be none when elastic policy is set."
-        )
-
-    # for elastic policy currently mandating the presence of master replica, will be removed in future
-    if elastic_policy or master_pod_template_spec:
+    if master_pod_template_spec:
         pytorchjob.spec.pytorch_replica_specs[
             constants.REPLICA_TYPE_MASTER
         ] = models.KubeflowOrgV1ReplicaSpec(

--- a/sdk/python/kubeflow/training/utils/utils.py
+++ b/sdk/python/kubeflow/training/utils/utils.py
@@ -308,7 +308,7 @@ def get_pytorchjob_template(
     if num_worker_replicas is None and num_chief_replicas == 0:
         raise ValueError("At least one replica for PyTorchJob must be set")
 
-    if num_chief_replicas >1:
+    if num_chief_replicas > 1:
         raise ValueError("master replica cannot be more than 1")
 
     # Create PyTorchJob template.
@@ -330,7 +330,7 @@ def get_pytorchjob_template(
         master_pod_template_spec = worker_pod_template_spec
 
     # for elastic policy currently mandating the presence of master replica, will be removed in future
-    if elastic_policy or num_chief_replicas==1:
+    if elastic_policy or num_chief_replicas == 1:
         pytorchjob.spec.pytorch_replica_specs[
             constants.REPLICA_TYPE_MASTER
         ] = models.KubeflowOrgV1ReplicaSpec(


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Changes needed for #1945 
**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #
1. The new Train api is dependent on 1 new function (utils.get_container_spec), and 2 existing functions with some changes (utils.get_pod_template_spec and utils.get_pytorchjob_template)

2. Train api sample is mentioned in the first comment.

3. Train api will be run in elastic mode, and for elastic mode currently it is assumed that there will be 1 master replica.

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
