### PR TITLE
Train api init container creation

### DIFF
--- a/sdk/python/kubeflow/storage_init_container/Dockerfile
+++ b/sdk/python/kubeflow/storage_init_container/Dockerfile
@@ -1,0 +1,17 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the Python package and its source code into the container
+COPY . /app/storage
+
+# Copy the requirements.txt file into the container
+COPY requirements.txt /app/requirements.txt
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Run storage.py when the container launches
+ENTRYPOINT ["python", "storage/storage.py"]

--- a/sdk/python/kubeflow/storage_init_container/Dockerfile
+++ b/sdk/python/kubeflow/storage_init_container/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.9
+FROM python:3.11
 
 # Set the working directory in the container
 WORKDIR /app

--- a/sdk/python/kubeflow/storage_init_container/abstract_model_provider.py
+++ b/sdk/python/kubeflow/storage_init_container/abstract_model_provider.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+
+
+class modelProvider(ABC):
+    @abstractmethod
+    def load_config(self):
+        pass
+
+    @abstractmethod
+    def download_model(self):
+        pass

--- a/sdk/python/kubeflow/storage_init_container/hugging_face.py
+++ b/sdk/python/kubeflow/storage_init_container/hugging_face.py
@@ -1,0 +1,56 @@
+from abstract_model_provider import modelProvider
+from dataclasses import dataclass, field
+from typing import Literal
+import transformers
+from urllib.parse import urlparse
+import json
+from typing import Dict, Any
+
+TRANSFORMER_TYPES = [
+    "AutoModelForSequenceClassification",
+    "AutoModelForTokenClassification",
+    "AutoModelForQuestionAnswering",
+    "AutoModelForCausalLM",
+    "AutoModelForMaskedLM",
+    "AutoModelForImageClassification",
+]
+
+
+@dataclass
+class HuggingFaceModelParams:
+    access_token: str
+    model_uri: str
+    transformer_type: Literal[*TRANSFORMER_TYPES]
+    mount_path: str = field(default="/workspace/models")
+
+    def __post_init__(self):
+        # Custom checks or validations can be added here
+        if self.transformer_type not in TRANSFORMER_TYPES:
+            raise ValueError("transformer_type must be one of %s", TRANSFORMER_TYPES)
+
+
+@dataclass
+class HuggingFaceTrainParams:
+    additional_data: Dict[str, Any] = field(default_factory=dict)
+
+
+class HuggingFace(modelProvider):
+    def load_config(self, serialised_args):
+        # implementation for loading the config
+        self.config = HuggingFaceModelParams(**json.loads(serialised_args))
+
+    def download_model_and_tokenizer(self):
+        # implementation for downloading the model
+        print("downloading model")
+        transformer_type_class = getattr(transformers, self.config.transformer_type)
+        parsed_uri = urlparse(self.config.model_uri)
+        self.model = parsed_uri.netloc + parsed_uri.path
+        transformer_type_class.from_pretrained(
+            self.model,
+            token=self.config.access_token,
+            cache_dir=self.config.mount_path,
+            trust_remote_code=True,
+        )
+        transformers.AutoTokenizer.from_pretrained(
+            self.model, cache_dir=self.config.mount_path
+        )

--- a/sdk/python/kubeflow/storage_init_container/hugging_face.py
+++ b/sdk/python/kubeflow/storage_init_container/hugging_face.py
@@ -34,6 +34,7 @@ class HuggingFaceModelParams:
 @dataclass
 class HuggingFaceTrainParams:
     additional_data: Dict[str, Any] = field(default_factory=dict)
+    peft_config: Dict[str, Any] = field(default_factory=dict)
 
 
 class HuggingFace(modelProvider):

--- a/sdk/python/kubeflow/storage_init_container/hugging_face.py
+++ b/sdk/python/kubeflow/storage_init_container/hugging_face.py
@@ -27,6 +27,8 @@ class HuggingFaceModelParams:
         # Custom checks or validations can be added here
         if self.transformer_type not in TRANSFORMER_TYPES:
             raise ValueError("transformer_type must be one of %s", TRANSFORMER_TYPES)
+        if self.model_uri is None:
+            raise ValueError("model_uri cannot be none.")
 
 
 @dataclass

--- a/sdk/python/kubeflow/storage_init_container/hugging_face.py
+++ b/sdk/python/kubeflow/storage_init_container/hugging_face.py
@@ -21,7 +21,7 @@ class HuggingFaceModelParams:
     access_token: str
     model_uri: str
     transformer_type: Literal[*TRANSFORMER_TYPES]
-    mount_path: str = field(default="/workspace/models")
+    download_dir: str = field(default="/workspace/models")
 
     def __post_init__(self):
         # Custom checks or validations can be added here
@@ -48,9 +48,9 @@ class HuggingFace(modelProvider):
         transformer_type_class.from_pretrained(
             self.model,
             token=self.config.access_token,
-            cache_dir=self.config.mount_path,
+            cache_dir=self.config.download_dir,
             trust_remote_code=True,
         )
         transformers.AutoTokenizer.from_pretrained(
-            self.model, cache_dir=self.config.mount_path
+            self.model, cache_dir=self.config.download_dir
         )

--- a/sdk/python/kubeflow/storage_init_container/requirements.txt
+++ b/sdk/python/kubeflow/storage_init_container/requirements.txt
@@ -1,0 +1,5 @@
+torch==2.1.1
+torchvision==0.16.1
+torchaudio==2.1.1
+einops==0.7.0
+transformers_stream_generator==0.0.4

--- a/sdk/python/kubeflow/storage_init_container/storage.py
+++ b/sdk/python/kubeflow/storage_init_container/storage.py
@@ -1,0 +1,30 @@
+import argparse
+from hugging_face import HuggingFace
+
+
+def model_factory(model_provider, model_provider_args):
+    match model_provider:
+        case "hf":
+            hf = HuggingFace()
+            hf.load_config(model_provider_args)
+            hf.download_model_and_tokenizer()
+        case _:
+            return "This is the default case"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="script for downloading model and datasets to PVC."
+    )
+    parser.add_argument("model_provider", type=str, help="name of model provider")
+    parser.add_argument(
+        "model_provider_args", type=str, help="model provider serialised arguments"
+    )
+
+    parser.add_argument("dataset_provider", type=str, help="name of dataset provider")
+    parser.add_argument(
+        "dataset_provider_args", type=str, help="dataset provider serialised arguments"
+    )
+    args = parser.parse_args()
+
+    model_factory(args.model_provider, args.model_provider_args)

--- a/sdk/python/kubeflow/training/constants/constants.py
+++ b/sdk/python/kubeflow/training/constants/constants.py
@@ -78,6 +78,7 @@ TFJOB_BASE_IMAGE_GPU = "docker.io/tensorflow/tensorflow:2.9.1-gpu"
 PYTORCHJOB_KIND = "PyTorchJob"
 PYTORCHJOB_PLURAL = "pytorchjobs"
 PYTORCHJOB_CONTAINER = "pytorch"
+PYTORCHJOB_STORAGE_CONTAINER = "pytorch-storage"
 PYTORCHJOB_REPLICA_TYPES = (REPLICA_TYPE_MASTER.lower(), REPLICA_TYPE_WORKER.lower())
 
 PYTORCHJOB_BASE_IMAGE = "docker.io/pytorch/pytorch:1.12.1-cuda11.3-cudnn8-runtime"
@@ -128,6 +129,7 @@ JOB_PARAMETERS = {
         "plural": PYTORCHJOB_PLURAL,
         "container": PYTORCHJOB_CONTAINER,
         "base_image": PYTORCHJOB_BASE_IMAGE,
+        "init_container": PYTORCHJOB_STORAGE_CONTAINER
     },
     MXJOB_KIND: {
         "model": models.KubeflowOrgV1MXJob,

--- a/sdk/python/kubeflow/training/constants/constants.py
+++ b/sdk/python/kubeflow/training/constants/constants.py
@@ -78,7 +78,6 @@ TFJOB_BASE_IMAGE_GPU = "docker.io/tensorflow/tensorflow:2.9.1-gpu"
 PYTORCHJOB_KIND = "PyTorchJob"
 PYTORCHJOB_PLURAL = "pytorchjobs"
 PYTORCHJOB_CONTAINER = "pytorch"
-PYTORCHJOB_STORAGE_CONTAINER = "pytorch-storage"
 PYTORCHJOB_REPLICA_TYPES = (REPLICA_TYPE_MASTER.lower(), REPLICA_TYPE_WORKER.lower())
 
 PYTORCHJOB_BASE_IMAGE = "docker.io/pytorch/pytorch:1.12.1-cuda11.3-cudnn8-runtime"
@@ -129,7 +128,6 @@ JOB_PARAMETERS = {
         "plural": PYTORCHJOB_PLURAL,
         "container": PYTORCHJOB_CONTAINER,
         "base_image": PYTORCHJOB_BASE_IMAGE,
-        "init_container": PYTORCHJOB_STORAGE_CONTAINER,
     },
     MXJOB_KIND: {
         "model": models.KubeflowOrgV1MXJob,

--- a/sdk/python/kubeflow/training/constants/constants.py
+++ b/sdk/python/kubeflow/training/constants/constants.py
@@ -129,7 +129,7 @@ JOB_PARAMETERS = {
         "plural": PYTORCHJOB_PLURAL,
         "container": PYTORCHJOB_CONTAINER,
         "base_image": PYTORCHJOB_BASE_IMAGE,
-        "init_container": PYTORCHJOB_STORAGE_CONTAINER
+        "init_container": PYTORCHJOB_STORAGE_CONTAINER,
     },
     MXJOB_KIND: {
         "model": models.KubeflowOrgV1MXJob,

--- a/sdk/python/kubeflow/training/utils/utils.py
+++ b/sdk/python/kubeflow/training/utils/utils.py
@@ -310,6 +310,9 @@ def get_pytorchjob_template(
     if num_worker_replicas is None and master_pod_template_spec is None:
         raise ValueError("At least one replica for PyTorchJob must be set")
 
+    if num_chief_replicas > 1:
+        raise ValueError("master replica cannot be more than 1")
+
     # Create PyTorchJob template.
     pytorchjob = models.KubeflowOrgV1PyTorchJob(
         api_version=constants.API_VERSION,
@@ -326,7 +329,7 @@ def get_pytorchjob_template(
     if elastic_policy:
         pytorchjob.spec.elastic_policy = elastic_policy
     if not master_pod_template_spec:
-        master_pod_template_spec = pod_template_spec
+        master_pod_template_spec = worker_pod_template_spec
 
     if master_pod_template_spec:
         pytorchjob.spec.pytorch_replica_specs[

--- a/sdk/python/kubeflow/training/utils/utils.py
+++ b/sdk/python/kubeflow/training/utils/utils.py
@@ -325,6 +325,8 @@ def get_pytorchjob_template(
         pytorchjob.spec.nproc_per_node = num_procs_per_worker
     if elastic_policy:
         pytorchjob.spec.elastic_policy = elastic_policy
+    if not master_pod_template_spec:
+        master_pod_template_spec = pod_template_spec
 
     if master_pod_template_spec:
         pytorchjob.spec.pytorch_replica_specs[

--- a/sdk/python/kubeflow/training/utils/utils.py
+++ b/sdk/python/kubeflow/training/utils/utils.py
@@ -310,9 +310,6 @@ def get_pytorchjob_template(
     if num_worker_replicas is None and master_pod_template_spec is None:
         raise ValueError("At least one replica for PyTorchJob must be set")
 
-    if num_chief_replicas > 1:
-        raise ValueError("master replica cannot be more than 1")
-
     # Create PyTorchJob template.
     pytorchjob = models.KubeflowOrgV1PyTorchJob(
         api_version=constants.API_VERSION,
@@ -328,8 +325,6 @@ def get_pytorchjob_template(
         pytorchjob.spec.nproc_per_node = num_procs_per_worker
     if elastic_policy:
         pytorchjob.spec.elastic_policy = elastic_policy
-    if not master_pod_template_spec:
-        master_pod_template_spec = worker_pod_template_spec
 
     if master_pod_template_spec:
         pytorchjob.spec.pytorch_replica_specs[


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1.  If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
1. Adding a new folder for creating init container images with a docker file in it.
2. Adding hugging face as the model provider.
3. storage.py will start the download of models to the mount path.
4. changes require python 3.11
**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Partially Fixes #1945 
**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
