### PR TITLE
[SDK] Add information about TrainingClient logging

### DIFF
--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -772,9 +772,12 @@ class TrainingClient(object):
         replica_index: Optional[int] = None,
         follow: bool = False,
         timeout: int = constants.DEFAULT_TIMEOUT,
-    ) -> Dict[str, str]:
-        """Print the training logs for the Job. By default it returns logs from
-        the `master` pod.
+    ) -> Optional[Dict[str, str]]:
+        """Get the logs for every Training Job pod. By default it returns logs from
+        the `master` pod. Logs are returned in this format: { "pod-name": "Log data" }.
+
+        If follow = True, this function prints logs to StdOut and returns None.
+
 
         Args:
             name: Name for the Job.
@@ -845,7 +848,7 @@ class TrainingClient(object):
             while True:
                 for index, log_queue in enumerate(log_queue_pool):
                     if all(finished):
-                        return {}
+                        return
                     if finished[index]:
                         continue
                     # grouping the every 50 log lines of the same pod

--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -782,7 +782,6 @@ class TrainingClient(object):
 
         If follow = True, this function prints logs to StdOut and returns None.
 
-
         Args:
             name: Name for the Job.
             namespace: Namespace for the Job. By default namespace is taken from

--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -24,7 +24,9 @@ from kubeflow.training.api_client import ApiClient
 from kubeflow.training.constants import constants
 from kubeflow.training.utils import utils
 
+logging.basicConfig()
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 status_logger = utils.StatusLogger(
     header="{:<30.30} {:<20.20} {}".format("NAME", "STATE", "TIME"),
@@ -843,7 +845,7 @@ class TrainingClient(object):
             while True:
                 for index, log_queue in enumerate(log_queue_pool):
                     if all(finished):
-                        return
+                        return {}
                     if finished[index]:
                         continue
                     # grouping the every 50 log lines of the same pod
@@ -853,7 +855,7 @@ class TrainingClient(object):
                             if logline is None:
                                 finished[index] = True
                                 break
-                            print(f"[Pod {pods[index]}]: {logline}")
+                            logger.info(f"[Pod {pods[index]}]: {logline}")
                         except queue.Empty:
                             break
         elif pods:

--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -24,9 +24,7 @@ from kubeflow.training.api_client import ApiClient
 from kubeflow.training.constants import constants
 from kubeflow.training.utils import utils
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 status_logger = utils.StatusLogger(
     header="{:<30.30} {:<20.20} {}".format("NAME", "STATE", "TIME"),
@@ -43,7 +41,13 @@ class TrainingClient(object):
         namespace: str = utils.get_default_target_namespace(),
         job_kind: str = constants.PYTORCHJOB_KIND,
     ):
-        """TrainingClient constructor.
+        """TrainingClient constructor. Configure logging in your application
+            as follows to see detailed information from the TrainingClient APIs:
+            .. code-block:: python
+                import logging
+                logging.basicConfig()
+                log = logging.getLogger("kubeflow.training.api.training_client")
+                log.setLevel(logging.DEBUG)
 
         Args:
             config_file: Path to the kube-config file. Defaults to ~/.kube/config.
@@ -858,7 +862,7 @@ class TrainingClient(object):
                             if logline is None:
                                 finished[index] = True
                                 break
-                            logger.info(f"[Pod {pods[index]}]: {logline}")
+                            print(f"[Pod {pods[index]}]: {logline}")
                         except queue.Empty:
                             break
         elif pods:

--- a/sdk/python/kubeflow/training/utils/utils.py
+++ b/sdk/python/kubeflow/training/utils/utils.py
@@ -321,7 +321,7 @@ def get_pytorchjob_template(
         ),
     )
 
-    if num_procs_per_worker > 0:
+    if num_procs_per_worker:
         pytorchjob.spec.nproc_per_node = num_procs_per_worker
     if elastic_policy:
         pytorchjob.spec.elastic_policy = elastic_policy
@@ -334,7 +334,7 @@ def get_pytorchjob_template(
             template=master_pod_template_spec,
         )
 
-    if num_worker_replicas >= 1:
+    if num_worker_replicas:
         pytorchjob.spec.pytorch_replica_specs[
             constants.REPLICA_TYPE_WORKER
         ] = models.KubeflowOrgV1ReplicaSpec(


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/training-operator/issues/1946.

~~As we discussed, in the issue for `get_job_logs` API, user will see pod logs only if `follow=True` and we use `logger.info()` to print it.~~
If users want to see all messages from TrainingClient APIs, they can override the default logger config in their program:

```
log = logging.getLogger("kubeflow.training.api.training_client")
log.setLevel(logging.DEBUG)
```

Also, I fixed `get_pytorchjob_template` func, since we just need to check if `num_procs_per_worker` and `num_worker_replicas` is set before using it.


**UPDATE:** After discussion on this PR, we decided to use `print()` for the messages that users are required to see while using SDK.

/assign @droctothorpe @johnugeorge @tenzen-y @deepanker13

/hold for the review