### PR TITLE
Fix Master Label for PyTorchJob

### DIFF
--- a/pkg/controller.v1/pytorch/pytorchjob_controller.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller.go
@@ -507,10 +507,10 @@ func (r *PyTorchJobReconciler) SetClusterSpec(job interface{}, podTemplate *core
 func (r *PyTorchJobReconciler) IsMasterRole(replicas map[kubeflowv1.ReplicaType]*kubeflowv1.ReplicaSpec,
 	rtype kubeflowv1.ReplicaType, index int) bool {
 	if _, ok := replicas[kubeflowv1.PyTorchJobReplicaTypeMaster]; ok {
-		return string(rtype) == strings.ToLower(string(kubeflowv1.PyTorchJobReplicaTypeMaster))
+		return rtype == kubeflowv1.PyTorchJobReplicaTypeMaster
 	}
 	// else check if it is worker with index 0
-	return string(rtype) == strings.ToLower(string(kubeflowv1.PyTorchJobReplicaTypeWorker)) && index == 0
+	return rtype == kubeflowv1.PyTorchJobReplicaTypeWorker && index == 0
 }
 
 func (r *PyTorchJobReconciler) GetDefaultContainerName() string {


### PR DESCRIPTION
We shouldn't convert replica type to lower in `IsMasterRole` function for PyTorchJob since the replica type that we send is equal to `Worker` or `Master` as `rtype`: https://github.com/kubeflow/training-operator/blob/master/pkg/controller.v1/common/pod.go#L319

We are doing the same for TFJob: https://github.com/kubeflow/training-operator/blob/master/pkg/controller.v1/tensorflow/tfjob_controller.go#L609.


/assign @johnugeorge @deepanker13 @tenzen-y 