### PR TITLE
fix: volcano podgroup should has a non-empty queue name

### DIFF
--- a/pkg/controller.v1/common/job.go
+++ b/pkg/controller.v1/common/job.go
@@ -249,7 +249,7 @@ func (jc *JobController) ReconcileJobs(
 		// General cases which need to reconcile
 		if jc.Config.EnableGangScheduling() {
 			minMember := totalReplicas
-			queue := ""
+			queue := "default"
 			priorityClass := ""
 			var schedulerTimeout *int32
 			var minResources *corev1.ResourceList


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #1967

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
