### PR TITLE
[SDK] Fix Worker and Master templates for PyTorchJob

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -26,6 +26,6 @@ jobs:
         run: |
           pip install pytest python-dateutil urllib3 kubernetes
           pip install -U './sdk/python[huggingface]'
-          
+
       - name: Run unit test for training sdk
         run: pytest ./sdk/python/kubeflow/training/api/training_client_test.py

--- a/examples/sdk/create-pytorchjob-from-func.ipynb
+++ b/examples/sdk/create-pytorchjob-from-func.ipynb
@@ -364,7 +364,7 @@
     "training_client.create_job(\n",
     "    name=pytorchjob_name,\n",
     "    train_func=train_pytorch_model,\n",
-    "    num_worker_replicas=3, # How many PyTorch Workers will be created.\n",
+    "    num_workers=3, # How many PyTorch Workers will be created.\n",
     ")"
    ]
   },

--- a/sdk/python/kubeflow/training/api/training_client_test.py
+++ b/sdk/python/kubeflow/training/api/training_client_test.py
@@ -168,7 +168,7 @@ test_data = [
             "namespace": "test",
             "train_func": lambda: print("Test Training Function"),
             "base_image": "docker.io/test-training",
-            "num_worker_replicas": "3",
+            "num_workers": 3,
             "packages_to_install": ["boto3==1.34.14"],
             "pip_index_url": "https://pypi.custom.com/simple",
         },
@@ -203,5 +203,5 @@ def test_create_job(training_client, test_name, kwargs, expected_output):
         training_client.create_job(**kwargs)
         assert expected_output == "success"
     except Exception as e:
-        assert type(e) == expected_output
+        assert type(e) is expected_output
     print("test execution complete")

--- a/sdk/python/test/e2e/test_e2e_pytorchjob.py
+++ b/sdk/python/test/e2e/test_e2e_pytorchjob.py
@@ -181,13 +181,13 @@ def test_sdk_e2e_create_from_func(job_namespace):
             print(f"Start training for Epoch {i}")
             time.sleep(1)
 
-    num_workers = 1
+    num_workers = 3
 
     TRAINING_CLIENT.create_job(
         name=JOB_NAME,
         namespace=job_namespace,
         train_func=train_func,
-        num_worker_replicas=num_workers,
+        num_workers=num_workers,
     )
 
     logging.info(f"List of created {TRAINING_CLIENT.job_kind}s")


### PR DESCRIPTION
Currently, user has to set Master and Worker replica since we assign RANK and WORLD_SIZE only if Master is set: https://github.com/kubeflow/training-operator/blob/master/pkg/controller.v1/pytorch/envvar.go#L67.
Thus, I modified SDK to always set Master replicas.
Worker replicas is equal to `num_workers - 1` since we assign `RANK=0` to Master and it behaves like first Worker.

I added TODO in the SDK to track if we could create PyTorchJob without the Master, but it will require Controller changes.

Also, I renamed `num_worker_replicas` to `num_workers` to keep it consistent with `train` API.

 
/assign @tenzen-y @droctothorpe @johnugeorge @deepanker13 