### PR TITLE
[SDK] Add resources per worker for Create Job API

### DIFF
--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -139,6 +139,8 @@ class TrainingClient(object):
 
         namespace = namespace or self.namespace
 
+        # TODO (andreyvelich): PVC Creation should be part of Training Operator Controller.
+        # Ref issue: https://github.com/kubeflow/training-operator/issues/1971
         try:
             self.core_api.create_namespaced_persistent_volume_claim(
                 namespace=namespace,

--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -222,14 +222,14 @@ class TrainingClient(object):
         worker_pod_template_spec = utils.get_pod_template_spec(
             containers=[container_spec],
             init_containers=[init_container_spec],
-            volumes_spec=[constants.STORAGE_INITIALIZER_VOLUME],
+            volumes=[constants.STORAGE_INITIALIZER_VOLUME],
         )
 
         # create master pod spec
         master_pod_template_spec = utils.get_pod_template_spec(
             containers=[container_spec],
             init_containers=[init_container_spec],
-            volumes_spec=[constants.STORAGE_INITIALIZER_VOLUME],
+            volumes=[constants.STORAGE_INITIALIZER_VOLUME],
         )
 
         job = utils.get_pytorchjob_template(
@@ -364,7 +364,8 @@ class TrainingClient(object):
                 pip_index_url=pip_index_url,
                 resources=resources_per_worker,
             )
-            # Get Pod template spec from function or image.
+
+            # Get Pod template spec using the above container.
             pod_template_spec = utils.get_pod_template_spec(
                 containers=[container_spec],
             )

--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -163,11 +163,19 @@ class TrainingClient(object):
 
         if isinstance(model_provider_parameters, HuggingFaceModelParams):
             mp = "hf"
+        else:
+            raise ValueError(
+                f"Invalid model provider parameters {model_provider_parameters}"
+            )
 
         if isinstance(dataset_provider_parameters, S3DatasetParams):
             dp = "s3"
         elif isinstance(dataset_provider_parameters, HfDatasetParams):
             dp = "hf"
+        else:
+            raise ValueError(
+                f"Invalid dataset provider parameters {dataset_provider_parameters}"
+            )
 
         # create init container spec
         init_container_spec = utils.get_container_spec(

--- a/sdk/python/kubeflow/training/api/training_client_test.py
+++ b/sdk/python/kubeflow/training/api/training_client_test.py
@@ -124,15 +124,6 @@ test_data = [
         ValueError,
     ),
     (
-        "invalid pod template spec parameters",
-        {
-            "name": "test job",
-            "train_func": lambda: "test train function",
-            "job_kind": constants.MXJOB_KIND,
-        },
-        KeyError,
-    ),
-    (
         "paddle job can't be created using function",
         {
             "name": "test job",
@@ -171,6 +162,16 @@ test_data = [
             "num_workers": 3,
             "packages_to_install": ["boto3==1.34.14"],
             "pip_index_url": "https://pypi.custom.com/simple",
+        },
+        "success",
+    ),
+    (
+        "valid flow to create job using image",
+        {
+            "name": "test-job",
+            "namespace": "test",
+            "base_image": "docker.io/test-training",
+            "num_workers": 2,
         },
         "success",
     ),

--- a/sdk/python/kubeflow/training/constants/constants.py
+++ b/sdk/python/kubeflow/training/constants/constants.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 from kubeflow.training import models
-from typing import Union
+from typing import Union, Dict
+from kubeflow.storage_initializer.constants import INIT_CONTAINER_MOUNT_PATH
 
 # How long to wait in seconds for requests to the Kubernetes API Server.
 DEFAULT_TIMEOUT = 120
@@ -68,8 +69,25 @@ REPLICA_TYPE_SCHEDULER = "Scheduler"
 REPLICA_TYPE_SERVER = "Server"
 REPLICA_TYPE_LAUNCHER = "Launcher"
 
+# Constants for Train API.
+STORAGE_INITIALIZER = "storage-initializer"
+STORAGE_INITIALIZER_IMAGE = "docker.io/kubeflow/storage-initializer"
+
+STORAGE_INITIALIZER_VOLUME_MOUNT = models.V1VolumeMount(
+    name=STORAGE_INITIALIZER,
+    mount_path=INIT_CONTAINER_MOUNT_PATH,
+)
+STORAGE_INITIALIZER_VOLUME = models.V1Volume(
+    name=STORAGE_INITIALIZER,
+    persistent_volume_claim=models.V1PersistentVolumeClaimVolumeSource(
+        claim_name=STORAGE_INITIALIZER
+    ),
+)
+TRAINER_TRANSFORMER_IMAGE = "docker.io/kubeflow/trainer-huggingface"
+
 # TFJob constants.
 TFJOB_KIND = "TFJob"
+TFJOB_MODEL = "KubeflowOrgV1TFJob"
 TFJOB_PLURAL = "tfjobs"
 TFJOB_CONTAINER = "tensorflow"
 TFJOB_REPLICA_TYPES = (
@@ -83,18 +101,15 @@ TFJOB_BASE_IMAGE_GPU = "docker.io/tensorflow/tensorflow:2.9.1-gpu"
 
 # PyTorchJob constants
 PYTORCHJOB_KIND = "PyTorchJob"
+PYTORCHJOB_MODEL = "KubeflowOrgV1PyTorchJob"
 PYTORCHJOB_PLURAL = "pytorchjobs"
 PYTORCHJOB_CONTAINER = "pytorch"
 PYTORCHJOB_REPLICA_TYPES = (REPLICA_TYPE_MASTER.lower(), REPLICA_TYPE_WORKER.lower())
-PYTORCHJOB_BASE_IMAGE = "docker.io/pytorch/pytorch:1.12.1-cuda11.3-cudnn8-runtime"
-STORAGE_CONTAINER = "storage-initializer"
-STORAGE_CONTAINER_IMAGE = "docker.io/kubeflow/storage-initializer"
-TRAINER_TRANSFORMER_IMAGE = "docker.io/kubeflow/trainer-huggingface"
-TRAINER_PVC_NAME = "storage-initializer"
-TRAINER_PV = "storage-pv"
+PYTORCHJOB_BASE_IMAGE = "docker.io/pytorch/pytorch:2.1.2-cuda11.8-cudnn8-runtime"
 
 # MXJob constants
 MXJOB_KIND = "MXJob"
+MXJOB_MODEL = "KubeflowOrgV1MXJob"
 MXJOB_PLURAL = "mxjobs"
 MXJOB_CONTAINER = "mxnet"
 MXJOB_REPLICA_TYPES = (
@@ -105,18 +120,21 @@ MXJOB_REPLICA_TYPES = (
 
 # XGBoostJob constants
 XGBOOSTJOB_KIND = "XGBoostJob"
+XGBOOSTJOB_MODEL = "KubeflowOrgV1XGBoostJob"
 XGBOOSTJOB_PLURAL = "xgboostjobs"
 XGBOOSTJOB_CONTAINER = "xgboost"
 XGBOOSTJOB_REPLICA_TYPES = (REPLICA_TYPE_MASTER.lower(), REPLICA_TYPE_WORKER.lower())
 
 # MPIJob constants
 MPIJOB_KIND = "MPIJob"
+MPIJOB_MODEL = "KubeflowOrgV1MPIJob"
 MPIJOB_PLURAL = "mpijobs"
 MPIJOB_CONTAINER = "mpi"
 MPIJOB_REPLICA_TYPES = (REPLICA_TYPE_LAUNCHER.lower(), REPLICA_TYPE_WORKER.lower())
 
 # PaddleJob constants
 PADDLEJOB_KIND = "PaddleJob"
+PADDLEJOB_MODEL = "KubeflowOrgV1PaddleJob"
 PADDLEJOB_PLURAL = "paddlejobs"
 PADDLEJOB_CONTAINER = "paddle"
 PADDLEJOB_REPLICA_TYPES = (REPLICA_TYPE_MASTER.lower(), REPLICA_TYPE_WORKER.lower())
@@ -129,34 +147,37 @@ PADDLEJOB_BASE_IMAGE = (
 # Dictionary to get plural, model, and container for each Job kind.
 JOB_PARAMETERS = {
     TFJOB_KIND: {
-        "model": models.KubeflowOrgV1TFJob,
+        "model": TFJOB_MODEL,
         "plural": TFJOB_PLURAL,
         "container": TFJOB_CONTAINER,
         "base_image": TFJOB_BASE_IMAGE,
     },
     PYTORCHJOB_KIND: {
-        "model": models.KubeflowOrgV1PyTorchJob,
+        "model": PYTORCHJOB_MODEL,
         "plural": PYTORCHJOB_PLURAL,
         "container": PYTORCHJOB_CONTAINER,
         "base_image": PYTORCHJOB_BASE_IMAGE,
     },
     MXJOB_KIND: {
-        "model": models.KubeflowOrgV1MXJob,
+        "model": MXJOB_MODEL,
         "plural": MXJOB_PLURAL,
         "container": MXJOB_CONTAINER,
+        "base_image": "TODO",
     },
     XGBOOSTJOB_KIND: {
-        "model": models.KubeflowOrgV1XGBoostJob,
+        "model": XGBOOSTJOB_MODEL,
         "plural": XGBOOSTJOB_PLURAL,
         "container": XGBOOSTJOB_CONTAINER,
+        "base_image": "TODO",
     },
     MPIJOB_KIND: {
-        "model": models.KubeflowOrgV1MPIJob,
+        "model": MPIJOB_MODEL,
         "plural": MPIJOB_PLURAL,
         "container": MPIJOB_CONTAINER,
+        "base_image": "TODO",
     },
     PADDLEJOB_KIND: {
-        "model": models.KubeflowOrgV1PaddleJob,
+        "model": PADDLEJOB_MODEL,
         "plural": PADDLEJOB_PLURAL,
         "container": PADDLEJOB_CONTAINER,
         "base_image": PADDLEJOB_BASE_IMAGE,

--- a/sdk/python/kubeflow/training/utils/utils.py
+++ b/sdk/python/kubeflow/training/utils/utils.py
@@ -379,7 +379,7 @@ def get_pvc_spec(
     namespace: str,
     storage_config: Dict[str, Optional[str]],
 ):
-    if pvc_name is None or namespace is None or "size" not in storage_config is None:
+    if pvc_name is None or namespace is None or "size" not in storage_config:
         raise ValueError("One of the arguments is None")
 
     pvc_spec = models.V1PersistentVolumeClaim(

--- a/sdk/python/test/e2e/test_e2e_pytorchjob.py
+++ b/sdk/python/test/e2e/test_e2e_pytorchjob.py
@@ -212,6 +212,34 @@ def test_sdk_e2e_create_from_func(job_namespace):
     TRAINING_CLIENT.delete_job(JOB_NAME, job_namespace)
 
 
+@pytest.mark.skipif(
+    GANG_SCHEDULER_NAME in GANG_SCHEDULERS,
+    reason="For plain scheduling",
+)
+def test_sdk_e2e_create_from_image(job_namespace):
+    JOB_NAME = "pytorchjob-from-image"
+
+    TRAINING_CLIENT.create_job(
+        name=JOB_NAME,
+        namespace=job_namespace,
+        base_image="docker.io/hello-world",
+        num_workers=1,
+    )
+
+    logging.info(f"List of created {TRAINING_CLIENT.job_kind}s")
+    logging.info(TRAINING_CLIENT.list_jobs(job_namespace))
+
+    try:
+        utils.verify_job_e2e(TRAINING_CLIENT, JOB_NAME, job_namespace, wait_timeout=900)
+    except Exception as e:
+        utils.print_job_results(TRAINING_CLIENT, JOB_NAME, job_namespace)
+        TRAINING_CLIENT.delete_job(JOB_NAME, job_namespace)
+        raise Exception(f"PyTorchJob create from function E2E fails. Exception: {e}")
+
+    utils.print_job_results(TRAINING_CLIENT, JOB_NAME, job_namespace)
+    TRAINING_CLIENT.delete_job(JOB_NAME, job_namespace)
+
+
 def generate_pytorchjob(
     job_namespace: str,
     job_name: str,

--- a/sdk/python/test/e2e/utils.py
+++ b/sdk/python/test/e2e/utils.py
@@ -47,7 +47,8 @@ def verify_job_e2e(
 
     # Job should have Created, Running, and Succeeded conditions.
     conditions = client.get_job_conditions(job=job)
-    if len(conditions) != 3:
+    # If Job is complete fast, it has 2 conditions: Created and Succeeded.
+    if len(conditions) != 3 and len(conditions) != 2:
         raise Exception(f"{client.job_kind} conditions are invalid: {conditions}")
 
     # Job should have correct conditions.

--- a/sdk/python/test/e2e/utils.py
+++ b/sdk/python/test/e2e/utils.py
@@ -48,7 +48,7 @@ def verify_job_e2e(
     # Job should have Created, Running, and Succeeded conditions.
     conditions = client.get_job_conditions(job=job)
     # If Job is complete fast, it has 2 conditions: Created and Succeeded.
-    if len(conditions) != 3 and len(conditions) != 2:
+    if len(conditions) < 2:
         raise Exception(f"{client.job_kind} conditions are invalid: {conditions}")
 
     # Job should have correct conditions.


### PR DESCRIPTION
Blocked by: https://github.com/kubeflow/training-operator/pull/1988.
/hold

I added `resources_per_worker` parameter to `create_job` API.
Also, this has some refactoring for our SDK utils functions:
- I removed validation from `train` API for resource per worker. Let's add the validation in the future if that is required. We might have users who want to do fine-tuning with `train` API on CPUs.
- We have 3 new functions in utils. `get_pod_template_spec` to return Pod template spec, `get_container_spec` to return Container Spec,  `get_command_using_train_func` to return args and command for train function.
- I made a few changes to reduce number of typing errors in Pylance.

Please take a look.
/assign @deepanker13 @johnugeorge @tenzen-y @droctothorpe @kuizhiqing 