### PR TITLE
fix: fix build mnist image err due to python in base pytorch image too old

### DIFF
--- a/examples/pytorch/mnist/Dockerfile
+++ b/examples/pytorch/mnist/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.0-cuda10.0-cudnn7-runtime
+FROM pytorch/pytorch:1.2-cuda10.0-cudnn7-runtime
 
 RUN pip install tensorboardX==1.6.0
 RUN mkdir -p /opt/mnist


### PR DESCRIPTION
fix: fix build mnist image err due to python in base image too old
```
Step 1/7 : FROM pytorch/pytorch:1.0-cuda10.0-cudnn7-runtime
1.0-cuda10.0-cudnn7-runtime: Pulling from pytorch/pytorch
7b8b6451c85f: Pull complete 
ab4d1096d9ba: Pull complete 
e6797d1788ac: Pull complete 
033f35f6796e: Pull complete 
ecb8d4c892d7: Pull complete 
0aafcc0949f7: Pull complete 
5a393bfad573: Pull complete 
5d844e57dce8: Pull complete 
Digest: sha256:38624589af23ed9032a08450a3ccf2d756a587740e68ff6d765791d5723d27c5
Status: Downloaded newer image for pytorch/pytorch:1.0-cuda10.0-cudnn7-runtime
 ---> 83d5fed9611f
Step 2/7 : RUN pip install tensorboardX==1.6.0
 ---> Running in 49047b96b670
Collecting tensorboardX==1.6.0
  Downloading https://files.pythonhosted.org/packages/5c/76/89dd44458eb976347e5a6e75eb79fecf8facd46c1ce259bad54e0044ea35/tensorboardX-1.6-py2.py3-none-any.whl (129kB)
Requirement already satisfied: six in /opt/conda/lib/python3.6/site-packages (from tensorboardX==1.6.0) (1.11.0)
Collecting protobuf>=3.2.0 (from tensorboardX==1.6.0)
  Downloading https://files.pythonhosted.org/packages/6c/be/4e32d02bf08b8f76bf6e59f2a531690c1e4264530404501f3489ca975d9a/protobuf-4.21.0-py2.py3-none-any.whl (164kB)
protobuf requires Python '>=3.7' but the running Python is 3.6.7
The command '/bin/sh -c pip install tensorboardX==1.6.0' returned a non-zero code: 1

```


```
Sending build context to Docker daemon  23.04kB
Step 1/7 : FROM pytorch/pytorch:1.2-cuda10.0-cudnn7-runtime
1.2-cuda10.0-cudnn7-runtime: Pulling from pytorch/pytorch
f7277927d38a: Pull complete 
8d3eac894db4: Pull complete 
edf72af6d627: Pull complete 
3e4f86211d23: Pull complete 
4af0f459ec15: Pull complete 
fba59189913c: Pull complete 
a3baf4ea0534: Pull complete 
2a82ee97d3d6: Pull complete 
ae0fb1eb0719: Pull complete 
Digest: sha256:c8d372e59b86104cf1ffa859b58fada30248a9689cd6e446d06134c9bad52e77
Status: Downloaded newer image for pytorch/pytorch:1.2-cuda10.0-cudnn7-runtime
 ---> 255eed982b39
Step 2/7 : RUN pip install tensorboardX==1.6.0
 ---> Running in 595e44007071
Collecting tensorboardX==1.6.0
  Downloading https://files.pythonhosted.org/packages/5c/76/89dd44458eb976347e5a6e75eb79fecf8facd46c1ce259bad54e0044ea35/tensorboardX-1.6-py2.py3-none-any.whl (129kB)
Requirement already satisfied: six in /opt/conda/lib/python3.6/site-packages (from tensorboardX==1.6.0) (1.12.0)
Collecting protobuf>=3.2.0 (from tensorboardX==1.6.0)
  Downloading https://files.pythonhosted.org/packages/32/27/1141a8232723dcb10a595cc0ce4321dcbbd5215300bf4acfc142343205bf/protobuf-3.19.6-py2.py3-none-any.whl (162kB)
Requirement already satisfied: numpy in /opt/conda/lib/python3.6/site-packages (from tensorboardX==1.6.0) (1.16.5)
Installing collected packages: protobuf, tensorboardX
Successfully installed protobuf-3.19.6 tensorboardX-1.6
Removing intermediate container 595e44007071
 ---> 2d6e2f0bf0df
Step 3/7 : RUN mkdir -p /opt/mnist
 ---> Running in 331bc2a0b159
Removing intermediate container 331bc2a0b159
 ---> 75823d183082
Step 4/7 : WORKDIR /opt/mnist/src
 ---> Running in 3a421eb6a023
Removing intermediate container 3a421eb6a023
 ---> 8a2db5f47cb5
Step 5/7 : ADD mnist.py /opt/mnist/src/mnist.py
 ---> 8f9c5f299c78
Step 6/7 : RUN  chgrp -R 0 /opt/mnist   && chmod -R g+rwX /opt/mnist
 ---> Running in 9d1f6696fe1e
Removing intermediate container 9d1f6696fe1e
 ---> 057c069e4e26
Step 7/7 : ENTRYPOINT ["python", "/opt/mnist/src/mnist.py"]
 ---> Running in 45a48a570e5d
Removing intermediate container 45a48a570e5d
 ---> d8a782eda94e
Successfully built d8a782eda94e
Successfully tagged kubeflow/pytorch-dist-mnist-test:1.0

```