### PR TITLE
Fix Distributed Data Samplers in PyTorch Examples

### DIFF
--- a/examples/pytorch/mnist/mnist.py
+++ b/examples/pytorch/mnist/mnist.py
@@ -10,8 +10,7 @@ import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
-
-WORLD_SIZE = int(os.environ.get('WORLD_SIZE', 1))
+from torch.utils.data import DistributedSampler
 
 
 class Net(nn.Module):
@@ -19,7 +18,7 @@ class Net(nn.Module):
         super(Net, self).__init__()
         self.conv1 = nn.Conv2d(1, 20, 5, 1)
         self.conv2 = nn.Conv2d(20, 50, 5, 1)
-        self.fc1 = nn.Linear(4*4*50, 500)
+        self.fc1 = nn.Linear(4 * 4 * 50, 500)
         self.fc2 = nn.Linear(500, 10)
 
     def forward(self, x):
@@ -27,83 +26,144 @@ class Net(nn.Module):
         x = F.max_pool2d(x, 2, 2)
         x = F.relu(self.conv2(x))
         x = F.max_pool2d(x, 2, 2)
-        x = x.view(-1, 4*4*50)
+        x = x.view(-1, 4 * 4 * 50)
         x = F.relu(self.fc1(x))
         x = self.fc2(x)
         return F.log_softmax(x, dim=1)
-    
-def train(args, model, device, train_loader, optimizer, epoch, writer):
+
+
+def train(args, model, device, train_loader, epoch, writer):
     model.train()
+    optimizer = optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum)
+
     for batch_idx, (data, target) in enumerate(train_loader):
+        # Attach tensors to the device.
         data, target = data.to(device), target.to(device)
+
         optimizer.zero_grad()
         output = model(data)
         loss = F.nll_loss(output, target)
         loss.backward()
         optimizer.step()
         if batch_idx % args.log_interval == 0:
-            print('Train Epoch: {} [{}/{} ({:.0f}%)]\tloss={:.4f}'.format(
-                epoch, batch_idx * len(data), len(train_loader.dataset),
-                100. * batch_idx / len(train_loader), loss.item()))
+            print(
+                "Train Epoch: {} [{}/{} ({:.0f}%)]\tloss={:.4f}".format(
+                    epoch,
+                    batch_idx * len(data),
+                    len(train_loader.dataset),
+                    100.0 * batch_idx / len(train_loader),
+                    loss.item(),
+                )
+            )
             niter = epoch * len(train_loader) + batch_idx
-            writer.add_scalar('loss', loss.item(), niter)
+            writer.add_scalar("loss", loss.item(), niter)
 
-def test(args, model, device, test_loader, writer, epoch):
+
+def test(model, device, test_loader, writer, epoch):
     model.eval()
-    test_loss = 0
+
     correct = 0
     with torch.no_grad():
         for data, target in test_loader:
+            # Attach tensors to the device.
             data, target = data.to(device), target.to(device)
+
             output = model(data)
-            test_loss += F.nll_loss(output, target, reduction='sum').item() # sum up batch loss
-            pred = output.max(1, keepdim=True)[1] # get the index of the max log-probability
+            # Get the index of the max log-probability.
+            pred = output.max(1, keepdim=True)[1]
             correct += pred.eq(target.view_as(pred)).sum().item()
 
-    test_loss /= len(test_loader.dataset)
-    print('\naccuracy={:.4f}\n'.format(float(correct) / len(test_loader.dataset)))
-    writer.add_scalar('accuracy', float(correct) / len(test_loader.dataset), epoch)
-
-
-def should_distribute():
-    return dist.is_available() and WORLD_SIZE > 1
-
-
-def is_distributed():
-    return dist.is_available() and dist.is_initialized()
+    print("\naccuracy={:.4f}\n".format(float(correct) / len(test_loader.dataset)))
+    writer.add_scalar("accuracy", float(correct) / len(test_loader.dataset), epoch)
 
 
 def main():
     # Training settings
-    parser = argparse.ArgumentParser(description='PyTorch MNIST Example')
-    parser.add_argument('--batch-size', type=int, default=64, metavar='N',
-                        help='input batch size for training (default: 64)')
-    parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
-                        help='input batch size for testing (default: 1000)')
-    parser.add_argument('--epochs', type=int, default=1, metavar='N',
-                        help='number of epochs to train (default: 10)')
-    parser.add_argument('--lr', type=float, default=0.01, metavar='LR',
-                        help='learning rate (default: 0.01)')
-    parser.add_argument('--momentum', type=float, default=0.5, metavar='M',
-                        help='SGD momentum (default: 0.5)')
-    parser.add_argument('--no-cuda', action='store_true', default=False,
-                        help='disables CUDA training')
-    parser.add_argument('--seed', type=int, default=1, metavar='S',
-                        help='random seed (default: 1)')
-    parser.add_argument('--log-interval', type=int, default=10, metavar='N',
-                        help='how many batches to wait before logging training status')
-    parser.add_argument('--save-model', action='store_true', default=False,
-                        help='For Saving the current Model')
-    parser.add_argument('--dir', default='logs', metavar='L',
-                        help='directory where summary logs are stored')
-    if dist.is_available():
-        parser.add_argument('--backend', type=str, help='Distributed backend',
-                            choices=[dist.Backend.GLOO, dist.Backend.NCCL, dist.Backend.MPI],
-                            default=dist.Backend.GLOO)
+    parser = argparse.ArgumentParser(description="PyTorch FashionMNIST Example")
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=64,
+        metavar="N",
+        help="input batch size for training (default: 64)",
+    )
+    parser.add_argument(
+        "--test-batch-size",
+        type=int,
+        default=1000,
+        metavar="N",
+        help="input batch size for testing (default: 1000)",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=1,
+        metavar="N",
+        help="number of epochs to train (default: 10)",
+    )
+    parser.add_argument(
+        "--lr",
+        type=float,
+        default=0.01,
+        metavar="LR",
+        help="learning rate (default: 0.01)",
+    )
+    parser.add_argument(
+        "--momentum",
+        type=float,
+        default=0.5,
+        metavar="M",
+        help="SGD momentum (default: 0.5)",
+    )
+    parser.add_argument(
+        "--no-cuda",
+        action="store_true",
+        default=False,
+        help="disables CUDA training",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=1,
+        metavar="S",
+        help="random seed (default: 1)",
+    )
+    parser.add_argument(
+        "--log-interval",
+        type=int,
+        default=10,
+        metavar="N",
+        help="how many batches to wait before logging training status",
+    )
+    parser.add_argument(
+        "--save-model",
+        action="store_true",
+        default=False,
+        help="For Saving the current Model",
+    )
+    parser.add_argument(
+        "--dir",
+        default="logs",
+        metavar="L",
+        help="directory where summary logs are stored",
+    )
+
+    parser.add_argument(
+        "--backend",
+        type=str,
+        help="Distributed backend",
+        choices=[dist.Backend.GLOO, dist.Backend.NCCL, dist.Backend.MPI],
+        default=dist.Backend.GLOO,
+    )
+
     args = parser.parse_args()
     use_cuda = not args.no_cuda and torch.cuda.is_available()
     if use_cuda:
-        print('Using CUDA')
+        print("Using CUDA")
+        if args.backend != dist.Backend.NCCL:
+            print(
+                "Warning. Please use `nccl` distributed backend for the best performance using GPUs"
+            )
 
     writer = SummaryWriter(args.dir)
 
@@ -111,40 +171,55 @@ def main():
 
     device = torch.device("cuda" if use_cuda else "cpu")
 
-    if should_distribute():
-        print('Using distributed PyTorch with {} backend'.format(args.backend))
-        dist.init_process_group(backend=args.backend)
-
-    kwargs = {'num_workers': 1, 'pin_memory': True} if use_cuda else {}
-    train_loader = torch.utils.data.DataLoader(
-        datasets.FashionMNIST('../data', train=True, download=True,
-                       transform=transforms.Compose([
-                           transforms.ToTensor(),
-                           transforms.Normalize((0.1307,), (0.3081,))
-                       ])),
-        batch_size=args.batch_size, shuffle=True, **kwargs)
-    test_loader = torch.utils.data.DataLoader(
-        datasets.FashionMNIST('../data', train=False, transform=transforms.Compose([
-                           transforms.ToTensor(),
-                           transforms.Normalize((0.1307,), (0.3081,))
-                       ])),
-        batch_size=args.test_batch_size, shuffle=False, **kwargs)
-
+    # Attach model to the device.
     model = Net().to(device)
 
-    if is_distributed():
-        Distributor = nn.parallel.DistributedDataParallel if use_cuda \
-            else nn.parallel.DistributedDataParallelCPU
-        model = Distributor(model)
+    print("Using distributed PyTorch with {} backend".format(args.backend))
+    # Set distributed training environment variables to run this training script locally.
+    if "WORLD_SIZE" not in os.environ:
+        os.environ["RANK"] = "0"
+        os.environ["WORLD_SIZE"] = "1"
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "1234"
 
-    optimizer = optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum)
+    print(f"World Size: {os.environ['WORLD_SIZE']}. Rank: {os.environ['RANK']}")
+
+    dist.init_process_group(backend=args.backend)
+    Distributor = nn.parallel.DistributedDataParallel
+    model = Distributor(model)
+
+    # Get FashionMNIST train and test dataset.
+    train_ds = datasets.FashionMNIST(
+        "../data",
+        train=True,
+        download=True,
+        transform=transforms.Compose([transforms.ToTensor()]),
+    )
+    test_ds = datasets.FashionMNIST(
+        "../data",
+        train=False,
+        download=True,
+        transform=transforms.Compose([transforms.ToTensor()]),
+    )
+    # Add train and test loaders.
+    train_loader = torch.utils.data.DataLoader(
+        train_ds,
+        batch_size=args.batch_size,
+        sampler=DistributedSampler(train_ds),
+    )
+    test_loader = torch.utils.data.DataLoader(
+        test_ds,
+        batch_size=args.test_batch_size,
+        sampler=DistributedSampler(test_ds),
+    )
 
     for epoch in range(1, args.epochs + 1):
-        train(args, model, device, train_loader, optimizer, epoch, writer)
-        test(args, model, device, test_loader, writer, epoch)
+        train(args, model, device, train_loader, epoch, writer)
+        test(model, device, test_loader, writer, epoch)
 
-    if (args.save_model):
-        torch.save(model.state_dict(),"mnist_cnn.pt")
-        
-if __name__ == '__main__':
+    if args.save_model:
+        torch.save(model.state_dict(), "mnist_cnn.pt")
+
+
+if __name__ == "__main__":
     main()

--- a/examples/sdk/create-pytorchjob-from-func.ipynb
+++ b/examples/sdk/create-pytorchjob-from-func.ipynb
@@ -52,26 +52,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "69f21f33-5c64-452c-90c4-977fc0dadb3b",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-05T21:44:44.851155Z",
+     "iopub.status.busy": "2024-03-05T21:44:44.850918Z",
+     "iopub.status.idle": "2024-03-05T21:44:44.862195Z",
+     "shell.execute_reply": "2024-03-05T21:44:44.860949Z",
+     "shell.execute_reply.started": "2024-03-05T21:44:44.851138Z"
+    },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "def train_pytorch_model():\n",
+    "def train_pytorch_model(parameters):\n",
     "    import logging\n",
     "    import os\n",
-    "    from torchvision import transforms, datasets\n",
+    "\n",
     "    import torch\n",
-    "    from torch import nn\n",
-    "    import torch.nn.functional as F\n",
     "    import torch.distributed as dist\n",
+    "    import torch.nn.functional as F\n",
+    "    from torch import nn\n",
+    "    from torch.utils.data import DistributedSampler\n",
+    "    from torchvision import datasets, transforms\n",
     "\n",
     "    logging.basicConfig(\n",
     "        format=\"%(asctime)s %(levelname)-8s %(message)s\",\n",
     "        datefmt=\"%Y-%m-%dT%H:%M:%SZ\",\n",
-    "        level=logging.DEBUG,\n",
+    "        level=logging.INFO,\n",
     "    )\n",
     "\n",
     "    # Create PyTorch CNN Model.\n",
@@ -97,34 +106,53 @@
     "    # Kubeflow Training Operator automatically set appropriate RANK and WORLD_SIZE based on the configuration.\n",
     "    RANK = int(os.environ[\"RANK\"])\n",
     "    WORLD_SIZE = int(os.environ[\"WORLD_SIZE\"])\n",
-    "    \n",
+    "\n",
+    "    # IF GPU is available, nccl dist backend is used. Otherwise, gloo dist backend is used.\n",
+    "    if torch.cuda.is_available():\n",
+    "        device = \"cuda\"\n",
+    "        backend = \"nccl\"\n",
+    "    else:\n",
+    "        device = \"cpu\"\n",
+    "        backend = \"gloo\"\n",
+    "\n",
+    "    logging.info(f\"Using Device: {device}, Backend: {backend}\")\n",
+    "\n",
     "    model = Net()\n",
+    "    # Attach model to the device.\n",
+    "    model = model.to(device)\n",
+    "\n",
     "    # Attach model to DistributedDataParallel strategy.\n",
     "    dist.init_process_group(backend=\"gloo\", rank=RANK, world_size=WORLD_SIZE)\n",
     "    Distributor = nn.parallel.DistributedDataParallel\n",
     "    model = Distributor(model)\n",
     "\n",
-    "    # Split batch size for each worker.\n",
-    "    batch_size = int(128 / WORLD_SIZE)\n",
+    "    # Get Fashion MNIST Dataset.\n",
+    "    dataset = datasets.FashionMNIST(\n",
+    "        \"./data\",\n",
+    "        train=True,\n",
+    "        download=True,\n",
+    "        transform=transforms.Compose([transforms.ToTensor()]),\n",
+    "    )\n",
     "\n",
-    "    # Get Fashion MNIST DataSet.\n",
+    "    # Every PyTorchJob worker gets distributed sampler of dataset.\n",
     "    train_loader = torch.utils.data.DataLoader(\n",
-    "        datasets.FashionMNIST(\n",
-    "            \"./data\",\n",
-    "            train=True,\n",
-    "            download=True,\n",
-    "            transform=transforms.Compose([transforms.ToTensor()]),\n",
-    "        ),\n",
-    "        batch_size=batch_size,\n",
+    "        dataset,\n",
+    "        batch_size=128,\n",
+    "        sampler=DistributedSampler(dataset),\n",
     "    )\n",
     "\n",
     "    # Start Training.\n",
     "    logging.info(f\"Start training for RANK: {RANK}. WORLD_SIZE: {WORLD_SIZE}\")\n",
-    "    for epoch in range(1):\n",
+    "\n",
+    "    for epoch in range(int(parameters[\"NUM_EPOCHS\"])):\n",
     "        model.train()\n",
     "        optimizer = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.5)\n",
     "\n",
     "        for batch_idx, (data, target) in enumerate(train_loader):\n",
+    "            # Attach tensors to the device.\n",
+    "            data = data.to(device)\n",
+    "            target = target.to(device)\n",
+    "\n",
     "            optimizer.zero_grad()\n",
     "            output = model(data)\n",
     "            loss = F.nll_loss(output, target)\n",
@@ -139,7 +167,9 @@
     "                        100.0 * batch_idx / len(train_loader),\n",
     "                        loss.item(),\n",
     "                    )\n",
-    "                )"
+    "                )\n",
+    "\n",
+    "    logging.info(\"Training is finished\")"
    ]
   },
   {
@@ -162,9 +192,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "9e2c6fd8-d0ba-4bc6-ac90-d4cf09751ace",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-05T21:44:47.071420Z",
+     "iopub.status.busy": "2024-03-05T21:44:47.071188Z",
+     "iopub.status.idle": "2024-03-05T21:46:56.033826Z",
+     "shell.execute_reply": "2024-03-05T21:46:56.032986Z",
+     "shell.execute_reply.started": "2024-03-05T21:44:47.071404Z"
+    },
     "tags": []
    },
    "outputs": [
@@ -172,10 +209,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/avelichk/miniconda3/envs/training-operator/lib/python3.9/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n",
-      "2023-09-08T22:00:27Z INFO     Added key: store_based_barrier_key:1 to store for rank: 0\n",
-      "2023-09-08T22:00:27Z INFO     Rank 0: Completed store-based barrier for key:store_based_barrier_key:1 with 1 nodes.\n"
+      "2024-03-05T21:44:47Z INFO     Using Device: cpu, Backend: gloo\n",
+      "2024-03-05T21:44:47Z INFO     Added key: store_based_barrier_key:1 to store for rank: 0\n",
+      "2024-03-05T21:44:47Z INFO     Rank 0: Completed store-based barrier for key:store_based_barrier_key:1 with 1 nodes.\n"
      ]
     },
     {
@@ -187,11 +223,18 @@
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 26421880/26421880 [00:01<00:00, 22627052.40it/s]\n"
-     ]
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f84c269459b842199b83caaee8bee276",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/26421880 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -204,11 +247,18 @@
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 29515/29515 [00:00<00:00, 1596941.21it/s]"
-     ]
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d30ad8fbf5764375b67d92ed2ad00a0f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/29515 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -221,12 +271,18 @@
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4422102/4422102 [00:00<00:00, 20494516.72it/s]\n"
-     ]
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7b55bfdfad3f4732b4465f126024ba15",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/4422102 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -239,11 +295,24 @@
      ]
     },
     {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "901afb3fdcae42fd909f835ed7502b8c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/5148 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5148/5148 [00:00<00:00, 8510948.76it/s]\n",
-      "2023-09-08T22:00:30Z INFO     Start training for RANK: 0. WORLD_SIZE: 1\n"
+      "2024-03-05T21:44:54Z INFO     Start training for RANK: 0. WORLD_SIZE: 1\n"
      ]
     },
     {
@@ -258,67 +327,69 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-09-08T22:00:30Z INFO     Train Epoch: 0 [0/60000 (0%)]\tloss=2.2989\n",
-      "2023-09-08T22:00:30Z INFO     Reducer buckets have been rebuilt in this iteration.\n",
-      "2023-09-08T22:00:30Z INFO     Train Epoch: 0 [1280/60000 (2%)]\tloss=2.2991\n",
-      "2023-09-08T22:00:30Z INFO     Train Epoch: 0 [2560/60000 (4%)]\tloss=2.2857\n",
-      "2023-09-08T22:00:31Z INFO     Train Epoch: 0 [3840/60000 (6%)]\tloss=2.2795\n",
-      "2023-09-08T22:00:31Z INFO     Train Epoch: 0 [5120/60000 (9%)]\tloss=2.2625\n",
-      "2023-09-08T22:00:31Z INFO     Train Epoch: 0 [6400/60000 (11%)]\tloss=2.2526\n",
-      "2023-09-08T22:00:32Z INFO     Train Epoch: 0 [7680/60000 (13%)]\tloss=2.2245\n",
-      "2023-09-08T22:00:32Z INFO     Train Epoch: 0 [8960/60000 (15%)]\tloss=2.1893\n",
-      "2023-09-08T22:00:32Z INFO     Train Epoch: 0 [10240/60000 (17%)]\tloss=2.1507\n",
-      "2023-09-08T22:00:33Z INFO     Train Epoch: 0 [11520/60000 (19%)]\tloss=2.0778\n",
-      "2023-09-08T22:00:33Z INFO     Train Epoch: 0 [12800/60000 (21%)]\tloss=1.9957\n",
-      "2023-09-08T22:00:34Z INFO     Train Epoch: 0 [14080/60000 (23%)]\tloss=1.9257\n",
-      "2023-09-08T22:00:34Z INFO     Train Epoch: 0 [15360/60000 (26%)]\tloss=1.7212\n",
-      "2023-09-08T22:00:34Z INFO     Train Epoch: 0 [16640/60000 (28%)]\tloss=1.5281\n",
-      "2023-09-08T22:00:35Z INFO     Train Epoch: 0 [17920/60000 (30%)]\tloss=1.3686\n",
-      "2023-09-08T22:00:35Z INFO     Train Epoch: 0 [19200/60000 (32%)]\tloss=1.2350\n",
-      "2023-09-08T22:00:35Z INFO     Train Epoch: 0 [20480/60000 (34%)]\tloss=1.1473\n",
-      "2023-09-08T22:00:36Z INFO     Train Epoch: 0 [21760/60000 (36%)]\tloss=1.1870\n",
-      "2023-09-08T22:00:36Z INFO     Train Epoch: 0 [23040/60000 (38%)]\tloss=1.0766\n",
-      "2023-09-08T22:00:36Z INFO     Train Epoch: 0 [24320/60000 (41%)]\tloss=1.0574\n",
-      "2023-09-08T22:00:37Z INFO     Train Epoch: 0 [25600/60000 (43%)]\tloss=0.9557\n",
-      "2023-09-08T22:00:37Z INFO     Train Epoch: 0 [26880/60000 (45%)]\tloss=0.9279\n",
-      "2023-09-08T22:00:37Z INFO     Train Epoch: 0 [28160/60000 (47%)]\tloss=0.9588\n",
-      "2023-09-08T22:00:38Z INFO     Train Epoch: 0 [29440/60000 (49%)]\tloss=1.0970\n",
-      "2023-09-08T22:00:38Z INFO     Train Epoch: 0 [30720/60000 (51%)]\tloss=0.9617\n",
-      "2023-09-08T22:00:38Z INFO     Train Epoch: 0 [32000/60000 (53%)]\tloss=0.9025\n",
-      "2023-09-08T22:00:39Z INFO     Train Epoch: 0 [33280/60000 (55%)]\tloss=0.8363\n",
-      "2023-09-08T22:00:39Z INFO     Train Epoch: 0 [34560/60000 (58%)]\tloss=0.9448\n",
-      "2023-09-08T22:00:39Z INFO     Train Epoch: 0 [35840/60000 (60%)]\tloss=0.7507\n",
-      "2023-09-08T22:00:40Z INFO     Train Epoch: 0 [37120/60000 (62%)]\tloss=0.7347\n",
-      "2023-09-08T22:00:40Z INFO     Train Epoch: 0 [38400/60000 (64%)]\tloss=0.6985\n",
-      "2023-09-08T22:00:40Z INFO     Train Epoch: 0 [39680/60000 (66%)]\tloss=0.8104\n",
-      "2023-09-08T22:00:41Z INFO     Train Epoch: 0 [40960/60000 (68%)]\tloss=0.8177\n",
-      "2023-09-08T22:00:41Z INFO     Train Epoch: 0 [42240/60000 (70%)]\tloss=0.8442\n",
-      "2023-09-08T22:00:41Z INFO     Train Epoch: 0 [43520/60000 (72%)]\tloss=0.7311\n",
-      "2023-09-08T22:00:42Z INFO     Train Epoch: 0 [44800/60000 (75%)]\tloss=0.7861\n",
-      "2023-09-08T22:00:42Z INFO     Train Epoch: 0 [46080/60000 (77%)]\tloss=0.7879\n",
-      "2023-09-08T22:00:42Z INFO     Train Epoch: 0 [47360/60000 (79%)]\tloss=0.7863\n",
-      "2023-09-08T22:00:43Z INFO     Train Epoch: 0 [48640/60000 (81%)]\tloss=0.8808\n",
-      "2023-09-08T22:00:43Z INFO     Train Epoch: 0 [49920/60000 (83%)]\tloss=0.7993\n",
-      "2023-09-08T22:00:43Z INFO     Train Epoch: 0 [51200/60000 (85%)]\tloss=0.7540\n",
-      "2023-09-08T22:00:44Z INFO     Train Epoch: 0 [52480/60000 (87%)]\tloss=0.8387\n",
-      "2023-09-08T22:00:44Z INFO     Train Epoch: 0 [53760/60000 (90%)]\tloss=0.7911\n",
-      "2023-09-08T22:00:44Z INFO     Train Epoch: 0 [55040/60000 (92%)]\tloss=0.6176\n",
-      "2023-09-08T22:00:45Z INFO     Train Epoch: 0 [56320/60000 (94%)]\tloss=0.6854\n",
-      "2023-09-08T22:00:45Z INFO     Train Epoch: 0 [57600/60000 (96%)]\tloss=0.7593\n",
-      "2023-09-08T22:00:45Z INFO     Train Epoch: 0 [58880/60000 (98%)]\tloss=0.7477\n"
+      "2024-03-05T21:44:54Z INFO     Train Epoch: 0 [0/60000 (0%)]\tloss=2.3120\n",
+      "2024-03-05T21:44:54Z INFO     Reducer buckets have been rebuilt in this iteration.\n",
+      "2024-03-05T21:44:57Z INFO     Train Epoch: 0 [1280/60000 (2%)]\tloss=2.3065\n",
+      "2024-03-05T21:44:59Z INFO     Train Epoch: 0 [2560/60000 (4%)]\tloss=2.2853\n",
+      "2024-03-05T21:45:02Z INFO     Train Epoch: 0 [3840/60000 (6%)]\tloss=2.2836\n",
+      "2024-03-05T21:45:05Z INFO     Train Epoch: 0 [5120/60000 (9%)]\tloss=2.2772\n",
+      "2024-03-05T21:45:07Z INFO     Train Epoch: 0 [6400/60000 (11%)]\tloss=2.2551\n",
+      "2024-03-05T21:45:10Z INFO     Train Epoch: 0 [7680/60000 (13%)]\tloss=2.2426\n",
+      "2024-03-05T21:45:13Z INFO     Train Epoch: 0 [8960/60000 (15%)]\tloss=2.2236\n",
+      "2024-03-05T21:45:16Z INFO     Train Epoch: 0 [10240/60000 (17%)]\tloss=2.1883\n",
+      "2024-03-05T21:45:18Z INFO     Train Epoch: 0 [11520/60000 (19%)]\tloss=2.1629\n",
+      "2024-03-05T21:45:21Z INFO     Train Epoch: 0 [12800/60000 (21%)]\tloss=2.0908\n",
+      "2024-03-05T21:45:23Z INFO     Train Epoch: 0 [14080/60000 (23%)]\tloss=2.0023\n",
+      "2024-03-05T21:45:25Z INFO     Train Epoch: 0 [15360/60000 (26%)]\tloss=1.8673\n",
+      "2024-03-05T21:45:28Z INFO     Train Epoch: 0 [16640/60000 (28%)]\tloss=1.7227\n",
+      "2024-03-05T21:45:30Z INFO     Train Epoch: 0 [17920/60000 (30%)]\tloss=1.5780\n",
+      "2024-03-05T21:45:33Z INFO     Train Epoch: 0 [19200/60000 (32%)]\tloss=1.3583\n",
+      "2024-03-05T21:45:36Z INFO     Train Epoch: 0 [20480/60000 (34%)]\tloss=1.2497\n",
+      "2024-03-05T21:45:38Z INFO     Train Epoch: 0 [21760/60000 (36%)]\tloss=1.0678\n",
+      "2024-03-05T21:45:41Z INFO     Train Epoch: 0 [23040/60000 (38%)]\tloss=1.0032\n",
+      "2024-03-05T21:45:43Z INFO     Train Epoch: 0 [24320/60000 (41%)]\tloss=1.0607\n",
+      "2024-03-05T21:45:46Z INFO     Train Epoch: 0 [25600/60000 (43%)]\tloss=1.1423\n",
+      "2024-03-05T21:45:48Z INFO     Train Epoch: 0 [26880/60000 (45%)]\tloss=0.9529\n",
+      "2024-03-05T21:45:51Z INFO     Train Epoch: 0 [28160/60000 (47%)]\tloss=1.0706\n",
+      "2024-03-05T21:45:53Z INFO     Train Epoch: 0 [29440/60000 (49%)]\tloss=1.0542\n",
+      "2024-03-05T21:45:56Z INFO     Train Epoch: 0 [30720/60000 (51%)]\tloss=0.8257\n",
+      "2024-03-05T21:45:59Z INFO     Train Epoch: 0 [32000/60000 (53%)]\tloss=1.0569\n",
+      "2024-03-05T21:46:01Z INFO     Train Epoch: 0 [33280/60000 (55%)]\tloss=0.8526\n",
+      "2024-03-05T21:46:04Z INFO     Train Epoch: 0 [34560/60000 (58%)]\tloss=0.8178\n",
+      "2024-03-05T21:46:06Z INFO     Train Epoch: 0 [35840/60000 (60%)]\tloss=0.9800\n",
+      "2024-03-05T21:46:09Z INFO     Train Epoch: 0 [37120/60000 (62%)]\tloss=0.9983\n",
+      "2024-03-05T21:46:11Z INFO     Train Epoch: 0 [38400/60000 (64%)]\tloss=1.0125\n",
+      "2024-03-05T21:46:14Z INFO     Train Epoch: 0 [39680/60000 (66%)]\tloss=0.8065\n",
+      "2024-03-05T21:46:17Z INFO     Train Epoch: 0 [40960/60000 (68%)]\tloss=1.0279\n",
+      "2024-03-05T21:46:19Z INFO     Train Epoch: 0 [42240/60000 (70%)]\tloss=0.6834\n",
+      "2024-03-05T21:46:22Z INFO     Train Epoch: 0 [43520/60000 (72%)]\tloss=0.9552\n",
+      "2024-03-05T21:46:25Z INFO     Train Epoch: 0 [44800/60000 (75%)]\tloss=0.9345\n",
+      "2024-03-05T21:46:27Z INFO     Train Epoch: 0 [46080/60000 (77%)]\tloss=0.7476\n",
+      "2024-03-05T21:46:30Z INFO     Train Epoch: 0 [47360/60000 (79%)]\tloss=0.9566\n",
+      "2024-03-05T21:46:32Z INFO     Train Epoch: 0 [48640/60000 (81%)]\tloss=0.9356\n",
+      "2024-03-05T21:46:35Z INFO     Train Epoch: 0 [49920/60000 (83%)]\tloss=0.6601\n",
+      "2024-03-05T21:46:38Z INFO     Train Epoch: 0 [51200/60000 (85%)]\tloss=0.8929\n",
+      "2024-03-05T21:46:40Z INFO     Train Epoch: 0 [52480/60000 (87%)]\tloss=0.7665\n",
+      "2024-03-05T21:46:43Z INFO     Train Epoch: 0 [53760/60000 (90%)]\tloss=0.7904\n",
+      "2024-03-05T21:46:45Z INFO     Train Epoch: 0 [55040/60000 (92%)]\tloss=0.8413\n",
+      "2024-03-05T21:46:48Z INFO     Train Epoch: 0 [56320/60000 (94%)]\tloss=0.7340\n",
+      "2024-03-05T21:46:51Z INFO     Train Epoch: 0 [57600/60000 (96%)]\tloss=0.7770\n",
+      "2024-03-05T21:46:53Z INFO     Train Epoch: 0 [58880/60000 (98%)]\tloss=0.6644\n",
+      "2024-03-05T21:46:56Z INFO     Training is finished\n"
      ]
     }
    ],
    "source": [
     "# Set dist env variables to run the above training locally on the Notebook.\n",
     "import os\n",
+    "\n",
     "os.environ[\"RANK\"] = \"0\"\n",
     "os.environ[\"WORLD_SIZE\"] = \"1\"\n",
     "os.environ[\"MASTER_ADDR\"] = \"localhost\"\n",
     "os.environ[\"MASTER_PORT\"] = \"1234\"\n",
     "\n",
     "# Train Model locally in the Notebook.\n",
-    "train_pytorch_model()"
+    "train_pytorch_model({\"NUM_EPOCHS\": \"1\"})"
    ]
   },
   {
@@ -332,7 +403,9 @@
     "\n",
     "Before creating PyTorchJob, you have to create `TrainingClient()`. It uses [Kubernetes Python client](https://github.com/kubernetes-client/python) to communicate with Kubernetes API server. You can set path and context for [the kubeconfig file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/). The default location for the kubeconfig is `~/.kube/config`.\n",
     "\n",
-    "Kubeflow Training Operator automatically set the appropriate env variables (`MASTER_PORT`, `MASTER_ADDR`, `WORLD_SIZE`, `RANK`) for each PyTorchJob container."
+    "Kubeflow Training Operator automatically set the appropriate env variables (`MASTER_PORT`, `MASTER_ADDR`, `WORLD_SIZE`, `RANK`) for each PyTorchJob container.\n",
+    "\n",
+    "PyTorchJob will train model on 3 epochs with 3 PyTorch workers."
    ]
   },
   {
@@ -340,20 +413,18 @@
    "execution_count": 4,
    "id": "eb1acd34-ebcf-409b-8bb3-0225cee37110",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-05T21:47:01.685451Z",
+     "iopub.status.busy": "2024-03-05T21:47:01.684682Z",
+     "iopub.status.idle": "2024-03-05T21:47:01.946879Z",
+     "shell.execute_reply": "2024-03-05T21:47:01.945531Z",
+     "shell.execute_reply.started": "2024-03-05T21:47:01.685429Z"
+    },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-09-08T22:01:42Z INFO     PyTorchJob default/train-pytorch has been created\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from kubeflow.training import TrainingClient\n",
-    "from kubeflow.training import constants\n",
+    "from kubeflow.training import TrainingClient, constants\n",
     "\n",
     "# Start PyTorchJob Training.\n",
     "pytorchjob_name = \"train-pytorch\"\n",
@@ -364,7 +435,8 @@
     "training_client.create_job(\n",
     "    name=pytorchjob_name,\n",
     "    train_func=train_pytorch_model,\n",
-    "    num_workers=3, # How many PyTorch Workers will be created.\n",
+    "    parameters={\"NUM_EPOCHS\": \"3\"}, # Input parameters for the train function.\n",
+    "    num_workers=3,  # How many PyTorch Workers will be created.\n",
     ")"
    ]
   },
@@ -373,9 +445,9 @@
    "id": "e44c3ad7-62c4-4b58-b52a-15fd8746b772",
    "metadata": {},
    "source": [
-    "### Check PyTorchJob Status\n",
+    "### Check the PyTorchJob Status\n",
     "\n",
-    "Use `KubeflowClient` APIs to get information about created PyTorchJob."
+    "Use `TrainingClient()` APIs to get information about created PyTorchJob."
    ]
   },
   {
@@ -383,6 +455,13 @@
    "execution_count": 5,
    "id": "4141f6c2-c38f-4972-b68a-35d150ef7485",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-05T21:47:05.021345Z",
+     "iopub.status.busy": "2024-03-05T21:47:05.020992Z",
+     "iopub.status.idle": "2024-03-05T21:47:05.046311Z",
+     "shell.execute_reply": "2024-03-05T21:47:05.044855Z",
+     "shell.execute_reply.started": "2024-03-05T21:47:05.021327Z"
+    },
     "tags": []
    },
    "outputs": [
@@ -403,22 +482,30 @@
    "id": "42e10587-7ac2-45bf-9c4f-d418e1585974",
    "metadata": {},
    "source": [
-    "### Get PyTorchJob Pod Names"
+    "### Get PyTorchJob Pod Names\n",
+    "\n",
+    "Since we used 3 workers, PyTorchJob will create 1 master pod and 2 worker pods to execute distributed training."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
    "id": "49b53308-a19b-45e8-942f-4333e727ee48",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-05T21:47:07.929048Z",
+     "iopub.status.busy": "2024-03-05T21:47:07.928812Z",
+     "iopub.status.idle": "2024-03-05T21:47:07.963438Z",
+     "shell.execute_reply": "2024-03-05T21:47:07.962346Z",
+     "shell.execute_reply.started": "2024-03-05T21:47:07.929033Z"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['train-pytorch-master-0',\n",
-       " 'train-pytorch-worker-0',\n",
-       " 'train-pytorch-worker-1',\n",
-       " 'train-pytorch-worker-2']"
+       "['train-pytorch-master-0', 'train-pytorch-worker-0', 'train-pytorch-worker-1']"
       ]
      },
      "execution_count": 6,
@@ -443,240 +530,111 @@
     "tags": []
    },
    "source": [
-    "### Get PyTorchJob Training Logs"
+    "### Get PyTorchJob Training Logs\n",
+    "\n",
+    "We can get the logs from the master pod.\n",
+    "\n",
+    "Every worker processes 20000 data samples on each epoch since we distribute 60000 samples across 3 workers."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "5232d542-d4bf-4c51-8b11-ad0534fb0b9d",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-05T21:50:34.618377Z",
+     "iopub.status.busy": "2024-03-05T21:50:34.618140Z",
+     "iopub.status.idle": "2024-03-05T21:50:34.666228Z",
+     "shell.execute_reply": "2024-03-05T21:50:34.664982Z",
+     "shell.execute_reply.started": "2024-03-05T21:50:34.618362Z"
+    },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2023-09-08T22:10:08Z INFO     The logs of pod train-pytorch-master-0:\n",
-      " 2023-09-08T21:01:59Z INFO     Added key: store_based_barrier_key:1 to store for rank: 0\n",
-      "2023-09-08T21:01:59Z INFO     Rank 0: Completed store-based barrier for key:store_based_barrier_key:1 with 4 nodes.\n",
+      "2024-03-05T21:47:03Z INFO     Using Device: cpu, Backend: gloo\n",
       "Downloading http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-images-idx3-ubyte.gz\n",
       "Downloading http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-images-idx3-ubyte.gz to ./data/FashionMNIST/raw/train-images-idx3-ubyte.gz\n",
-      "100%|██████████| 26421880/26421880 [00:02<00:00, 12793779.84it/s]\n",
+      "100%|██████████| 26421880/26421880 [00:02<00:00, 12643822.46it/s]\n",
       "Extracting ./data/FashionMNIST/raw/train-images-idx3-ubyte.gz to ./data/FashionMNIST/raw\n",
       "\n",
       "Downloading http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-labels-idx1-ubyte.gz\n",
       "Downloading http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-labels-idx1-ubyte.gz to ./data/FashionMNIST/raw/train-labels-idx1-ubyte.gz\n",
-      "100%|██████████| 29515/29515 [00:00<00:00, 209261.44it/s]\n",
       "Extracting ./data/FashionMNIST/raw/train-labels-idx1-ubyte.gz to ./data/FashionMNIST/raw\n",
+      "100%|██████████| 29515/29515 [00:00<00:00, 209382.13it/s]\n",
       "\n",
       "Downloading http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-images-idx3-ubyte.gz\n",
       "Downloading http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-images-idx3-ubyte.gz to ./data/FashionMNIST/raw/t10k-images-idx3-ubyte.gz\n",
-      "100%|██████████| 4422102/4422102 [00:01<00:00, 3953124.28it/s]\n",
+      "100%|██████████| 4422102/4422102 [00:00<00:00, 5191230.97it/s]\n",
       "Extracting ./data/FashionMNIST/raw/t10k-images-idx3-ubyte.gz to ./data/FashionMNIST/raw\n",
       "\n",
       "Downloading http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-labels-idx1-ubyte.gz\n",
       "Downloading http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-labels-idx1-ubyte.gz to ./data/FashionMNIST/raw/t10k-labels-idx1-ubyte.gz\n",
-      "100%|██████████| 5148/5148 [00:00<00:00, 53182948.26it/s]\n",
+      "100%|██████████| 5148/5148 [00:00<00:00, 57733360.94it/s]\n",
       "Extracting ./data/FashionMNIST/raw/t10k-labels-idx1-ubyte.gz to ./data/FashionMNIST/raw\n",
       "\n",
-      "2023-09-08T21:02:05Z INFO     Start training for RANK: 0. WORLD_SIZE: 4\n",
-      "2023-09-08T21:02:05Z INFO     Train Epoch: 0 [0/60000 (0%)]\tloss=2.3026\n",
-      "2023-09-08T21:02:05Z INFO     Reducer buckets have been rebuilt in this iteration.\n",
-      "2023-09-08T21:02:07Z INFO     Train Epoch: 0 [320/60000 (1%)]\tloss=2.2942\n",
-      "2023-09-08T21:02:10Z INFO     Train Epoch: 0 [640/60000 (1%)]\tloss=2.2931\n",
-      "2023-09-08T21:02:12Z INFO     Train Epoch: 0 [960/60000 (2%)]\tloss=2.2750\n",
-      "2023-09-08T21:02:14Z INFO     Train Epoch: 0 [1280/60000 (2%)]\tloss=2.2734\n",
-      "2023-09-08T21:02:17Z INFO     Train Epoch: 0 [1600/60000 (3%)]\tloss=2.2644\n",
-      "2023-09-08T21:02:19Z INFO     Train Epoch: 0 [1920/60000 (3%)]\tloss=2.2451\n",
-      "2023-09-08T21:02:21Z INFO     Train Epoch: 0 [2240/60000 (4%)]\tloss=2.1874\n",
-      "2023-09-08T21:02:23Z INFO     Train Epoch: 0 [2560/60000 (4%)]\tloss=2.2048\n",
-      "2023-09-08T21:02:25Z INFO     Train Epoch: 0 [2880/60000 (5%)]\tloss=2.1906\n",
-      "2023-09-08T21:02:26Z INFO     Train Epoch: 0 [3200/60000 (5%)]\tloss=2.1379\n",
-      "2023-09-08T21:02:29Z INFO     Train Epoch: 0 [3520/60000 (6%)]\tloss=2.0556\n",
-      "2023-09-08T21:02:31Z INFO     Train Epoch: 0 [3840/60000 (6%)]\tloss=1.8509\n",
-      "2023-09-08T21:02:32Z INFO     Train Epoch: 0 [4160/60000 (7%)]\tloss=1.6425\n",
-      "2023-09-08T21:02:34Z INFO     Train Epoch: 0 [4480/60000 (7%)]\tloss=1.6744\n",
-      "2023-09-08T21:02:36Z INFO     Train Epoch: 0 [4800/60000 (8%)]\tloss=1.3866\n",
-      "2023-09-08T21:02:38Z INFO     Train Epoch: 0 [5120/60000 (9%)]\tloss=1.2680\n",
-      "2023-09-08T21:02:41Z INFO     Train Epoch: 0 [5440/60000 (9%)]\tloss=1.2594\n",
-      "2023-09-08T21:02:43Z INFO     Train Epoch: 0 [5760/60000 (10%)]\tloss=1.3052\n",
-      "2023-09-08T21:02:45Z INFO     Train Epoch: 0 [6080/60000 (10%)]\tloss=1.1057\n",
-      "2023-09-08T21:02:47Z INFO     Train Epoch: 0 [6400/60000 (11%)]\tloss=1.0416\n",
-      "2023-09-08T21:02:49Z INFO     Train Epoch: 0 [6720/60000 (11%)]\tloss=1.2431\n",
-      "2023-09-08T21:02:50Z INFO     Train Epoch: 0 [7040/60000 (12%)]\tloss=0.9392\n",
-      "2023-09-08T21:02:53Z INFO     Train Epoch: 0 [7360/60000 (12%)]\tloss=0.9794\n",
-      "2023-09-08T21:02:55Z INFO     Train Epoch: 0 [7680/60000 (13%)]\tloss=0.9787\n",
-      "2023-09-08T21:02:57Z INFO     Train Epoch: 0 [8000/60000 (13%)]\tloss=1.2992\n",
-      "2023-09-08T21:02:59Z INFO     Train Epoch: 0 [8320/60000 (14%)]\tloss=1.0311\n",
-      "2023-09-08T21:03:01Z INFO     Train Epoch: 0 [8640/60000 (14%)]\tloss=1.0544\n",
-      "2023-09-08T21:03:02Z INFO     Train Epoch: 0 [8960/60000 (15%)]\tloss=1.1326\n",
-      "2023-09-08T21:03:04Z INFO     Train Epoch: 0 [9280/60000 (15%)]\tloss=0.6292\n",
-      "2023-09-08T21:03:06Z INFO     Train Epoch: 0 [9600/60000 (16%)]\tloss=1.2502\n",
-      "2023-09-08T21:03:08Z INFO     Train Epoch: 0 [9920/60000 (17%)]\tloss=0.8754\n",
-      "2023-09-08T21:03:10Z INFO     Train Epoch: 0 [10240/60000 (17%)]\tloss=1.0590\n",
-      "2023-09-08T21:03:13Z INFO     Train Epoch: 0 [10560/60000 (18%)]\tloss=1.0957\n",
-      "2023-09-08T21:03:15Z INFO     Train Epoch: 0 [10880/60000 (18%)]\tloss=0.9105\n",
-      "2023-09-08T21:03:17Z INFO     Train Epoch: 0 [11200/60000 (19%)]\tloss=0.6360\n",
-      "2023-09-08T21:03:19Z INFO     Train Epoch: 0 [11520/60000 (19%)]\tloss=0.9720\n",
-      "2023-09-08T21:03:21Z INFO     Train Epoch: 0 [11840/60000 (20%)]\tloss=1.1181\n",
-      "2023-09-08T21:03:23Z INFO     Train Epoch: 0 [12160/60000 (20%)]\tloss=0.9001\n",
-      "2023-09-08T21:03:25Z INFO     Train Epoch: 0 [12480/60000 (21%)]\tloss=0.6984\n",
-      "2023-09-08T21:03:27Z INFO     Train Epoch: 0 [12800/60000 (21%)]\tloss=0.7768\n",
-      "2023-09-08T21:03:30Z INFO     Train Epoch: 0 [13120/60000 (22%)]\tloss=1.1038\n",
-      "2023-09-08T21:03:32Z INFO     Train Epoch: 0 [13440/60000 (22%)]\tloss=0.8548\n",
-      "2023-09-08T21:03:34Z INFO     Train Epoch: 0 [13760/60000 (23%)]\tloss=0.8793\n",
-      "2023-09-08T21:03:37Z INFO     Train Epoch: 0 [14080/60000 (23%)]\tloss=0.8937\n",
-      "2023-09-08T21:03:39Z INFO     Train Epoch: 0 [14400/60000 (24%)]\tloss=0.8367\n",
-      "2023-09-08T21:03:42Z INFO     Train Epoch: 0 [14720/60000 (25%)]\tloss=0.6917\n",
-      "2023-09-08T21:03:45Z INFO     Train Epoch: 0 [15040/60000 (25%)]\tloss=0.8002\n",
-      "2023-09-08T21:03:47Z INFO     Train Epoch: 0 [15360/60000 (26%)]\tloss=0.9557\n",
-      "2023-09-08T21:03:48Z INFO     Train Epoch: 0 [15680/60000 (26%)]\tloss=0.7246\n",
-      "2023-09-08T21:03:50Z INFO     Train Epoch: 0 [16000/60000 (27%)]\tloss=1.0920\n",
-      "2023-09-08T21:03:52Z INFO     Train Epoch: 0 [16320/60000 (27%)]\tloss=0.4943\n",
-      "2023-09-08T21:03:54Z INFO     Train Epoch: 0 [16640/60000 (28%)]\tloss=0.9251\n",
-      "2023-09-08T21:03:55Z INFO     Train Epoch: 0 [16960/60000 (28%)]\tloss=0.6982\n",
-      "2023-09-08T21:03:58Z INFO     Train Epoch: 0 [17280/60000 (29%)]\tloss=0.7784\n",
-      "2023-09-08T21:04:00Z INFO     Train Epoch: 0 [17600/60000 (29%)]\tloss=0.6317\n",
-      "2023-09-08T21:04:02Z INFO     Train Epoch: 0 [17920/60000 (30%)]\tloss=0.6022\n",
-      "2023-09-08T21:04:04Z INFO     Train Epoch: 0 [18240/60000 (30%)]\tloss=1.1098\n",
-      "2023-09-08T21:04:06Z INFO     Train Epoch: 0 [18560/60000 (31%)]\tloss=1.1230\n",
-      "2023-09-08T21:04:08Z INFO     Train Epoch: 0 [18880/60000 (31%)]\tloss=0.7113\n",
-      "2023-09-08T21:04:10Z INFO     Train Epoch: 0 [19200/60000 (32%)]\tloss=0.5611\n",
-      "2023-09-08T21:04:12Z INFO     Train Epoch: 0 [19520/60000 (33%)]\tloss=0.8134\n",
-      "2023-09-08T21:04:14Z INFO     Train Epoch: 0 [19840/60000 (33%)]\tloss=0.8513\n",
-      "2023-09-08T21:04:16Z INFO     Train Epoch: 0 [20160/60000 (34%)]\tloss=1.1050\n",
-      "2023-09-08T21:04:18Z INFO     Train Epoch: 0 [20480/60000 (34%)]\tloss=0.5541\n",
-      "2023-09-08T21:04:20Z INFO     Train Epoch: 0 [20800/60000 (35%)]\tloss=0.9637\n",
-      "2023-09-08T21:04:22Z INFO     Train Epoch: 0 [21120/60000 (35%)]\tloss=0.4796\n",
-      "2023-09-08T21:04:24Z INFO     Train Epoch: 0 [21440/60000 (36%)]\tloss=0.9878\n",
-      "2023-09-08T21:04:26Z INFO     Train Epoch: 0 [21760/60000 (36%)]\tloss=0.6691\n",
-      "2023-09-08T21:04:28Z INFO     Train Epoch: 0 [22080/60000 (37%)]\tloss=0.7739\n",
-      "2023-09-08T21:04:31Z INFO     Train Epoch: 0 [22400/60000 (37%)]\tloss=0.5405\n",
-      "2023-09-08T21:04:32Z INFO     Train Epoch: 0 [22720/60000 (38%)]\tloss=0.6155\n",
-      "2023-09-08T21:04:35Z INFO     Train Epoch: 0 [23040/60000 (38%)]\tloss=1.0303\n",
-      "2023-09-08T21:04:37Z INFO     Train Epoch: 0 [23360/60000 (39%)]\tloss=0.5421\n",
-      "2023-09-08T21:04:39Z INFO     Train Epoch: 0 [23680/60000 (39%)]\tloss=0.7717\n",
-      "2023-09-08T21:04:41Z INFO     Train Epoch: 0 [24000/60000 (40%)]\tloss=0.8697\n",
-      "2023-09-08T21:04:43Z INFO     Train Epoch: 0 [24320/60000 (41%)]\tloss=0.7996\n",
-      "2023-09-08T21:04:44Z INFO     Train Epoch: 0 [24640/60000 (41%)]\tloss=0.6494\n",
-      "2023-09-08T21:04:46Z INFO     Train Epoch: 0 [24960/60000 (42%)]\tloss=0.7669\n",
-      "2023-09-08T21:04:48Z INFO     Train Epoch: 0 [25280/60000 (42%)]\tloss=0.4775\n",
-      "2023-09-08T21:04:50Z INFO     Train Epoch: 0 [25600/60000 (43%)]\tloss=0.7363\n",
-      "2023-09-08T21:04:51Z INFO     Train Epoch: 0 [25920/60000 (43%)]\tloss=0.5954\n",
-      "2023-09-08T21:04:53Z INFO     Train Epoch: 0 [26240/60000 (44%)]\tloss=0.9329\n",
-      "2023-09-08T21:04:55Z INFO     Train Epoch: 0 [26560/60000 (44%)]\tloss=0.7000\n",
-      "2023-09-08T21:04:57Z INFO     Train Epoch: 0 [26880/60000 (45%)]\tloss=0.5993\n",
-      "2023-09-08T21:04:59Z INFO     Train Epoch: 0 [27200/60000 (45%)]\tloss=0.9582\n",
-      "2023-09-08T21:05:01Z INFO     Train Epoch: 0 [27520/60000 (46%)]\tloss=0.4871\n",
-      "2023-09-08T21:05:03Z INFO     Train Epoch: 0 [27840/60000 (46%)]\tloss=0.6944\n",
-      "2023-09-08T21:05:06Z INFO     Train Epoch: 0 [28160/60000 (47%)]\tloss=0.7795\n",
-      "2023-09-08T21:05:08Z INFO     Train Epoch: 0 [28480/60000 (47%)]\tloss=0.7967\n",
-      "2023-09-08T21:05:10Z INFO     Train Epoch: 0 [28800/60000 (48%)]\tloss=0.9489\n",
-      "2023-09-08T21:05:12Z INFO     Train Epoch: 0 [29120/60000 (49%)]\tloss=0.6331\n",
-      "2023-09-08T21:05:14Z INFO     Train Epoch: 0 [29440/60000 (49%)]\tloss=0.9203\n",
-      "2023-09-08T21:05:16Z INFO     Train Epoch: 0 [29760/60000 (50%)]\tloss=0.7250\n",
-      "2023-09-08T21:05:18Z INFO     Train Epoch: 0 [30080/60000 (50%)]\tloss=1.0080\n",
-      "2023-09-08T21:05:20Z INFO     Train Epoch: 0 [30400/60000 (51%)]\tloss=0.6063\n",
-      "2023-09-08T21:05:23Z INFO     Train Epoch: 0 [30720/60000 (51%)]\tloss=0.6403\n",
-      "2023-09-08T21:05:24Z INFO     Train Epoch: 0 [31040/60000 (52%)]\tloss=0.4953\n",
-      "2023-09-08T21:05:26Z INFO     Train Epoch: 0 [31360/60000 (52%)]\tloss=0.4997\n",
-      "2023-09-08T21:05:28Z INFO     Train Epoch: 0 [31680/60000 (53%)]\tloss=0.7053\n",
-      "2023-09-08T21:05:30Z INFO     Train Epoch: 0 [32000/60000 (53%)]\tloss=0.7847\n",
-      "2023-09-08T21:05:32Z INFO     Train Epoch: 0 [32320/60000 (54%)]\tloss=0.5874\n",
-      "2023-09-08T21:05:34Z INFO     Train Epoch: 0 [32640/60000 (54%)]\tloss=0.6826\n",
-      "2023-09-08T21:05:36Z INFO     Train Epoch: 0 [32960/60000 (55%)]\tloss=0.5787\n",
-      "2023-09-08T21:05:39Z INFO     Train Epoch: 0 [33280/60000 (55%)]\tloss=0.5482\n",
-      "2023-09-08T21:05:41Z INFO     Train Epoch: 0 [33600/60000 (56%)]\tloss=0.5237\n",
-      "2023-09-08T21:05:42Z INFO     Train Epoch: 0 [33920/60000 (57%)]\tloss=0.4103\n",
-      "2023-09-08T21:05:44Z INFO     Train Epoch: 0 [34240/60000 (57%)]\tloss=0.4330\n",
-      "2023-09-08T21:05:46Z INFO     Train Epoch: 0 [34560/60000 (58%)]\tloss=0.3828\n",
-      "2023-09-08T21:05:48Z INFO     Train Epoch: 0 [34880/60000 (58%)]\tloss=0.6742\n",
-      "2023-09-08T21:05:49Z INFO     Train Epoch: 0 [35200/60000 (59%)]\tloss=0.5098\n",
-      "2023-09-08T21:05:51Z INFO     Train Epoch: 0 [35520/60000 (59%)]\tloss=0.5187\n",
-      "2023-09-08T21:05:53Z INFO     Train Epoch: 0 [35840/60000 (60%)]\tloss=0.5226\n",
-      "2023-09-08T21:05:54Z INFO     Train Epoch: 0 [36160/60000 (60%)]\tloss=0.7099\n",
-      "2023-09-08T21:05:56Z INFO     Train Epoch: 0 [36480/60000 (61%)]\tloss=0.6922\n",
-      "2023-09-08T21:05:59Z INFO     Train Epoch: 0 [36800/60000 (61%)]\tloss=0.6208\n",
-      "2023-09-08T21:06:01Z INFO     Train Epoch: 0 [37120/60000 (62%)]\tloss=0.7056\n",
-      "2023-09-08T21:06:03Z INFO     Train Epoch: 0 [37440/60000 (62%)]\tloss=0.5346\n",
-      "2023-09-08T21:06:05Z INFO     Train Epoch: 0 [37760/60000 (63%)]\tloss=0.4693\n",
-      "2023-09-08T21:06:07Z INFO     Train Epoch: 0 [38080/60000 (63%)]\tloss=0.8529\n",
-      "2023-09-08T21:06:10Z INFO     Train Epoch: 0 [38400/60000 (64%)]\tloss=0.6755\n",
-      "2023-09-08T21:06:11Z INFO     Train Epoch: 0 [38720/60000 (65%)]\tloss=0.5663\n",
-      "2023-09-08T21:06:13Z INFO     Train Epoch: 0 [39040/60000 (65%)]\tloss=0.5107\n",
-      "2023-09-08T21:06:15Z INFO     Train Epoch: 0 [39360/60000 (66%)]\tloss=0.4245\n",
-      "2023-09-08T21:06:17Z INFO     Train Epoch: 0 [39680/60000 (66%)]\tloss=0.5797\n",
-      "2023-09-08T21:06:19Z INFO     Train Epoch: 0 [40000/60000 (67%)]\tloss=0.5011\n",
-      "2023-09-08T21:06:20Z INFO     Train Epoch: 0 [40320/60000 (67%)]\tloss=0.4641\n",
-      "2023-09-08T21:06:22Z INFO     Train Epoch: 0 [40640/60000 (68%)]\tloss=0.2431\n",
-      "2023-09-08T21:06:24Z INFO     Train Epoch: 0 [40960/60000 (68%)]\tloss=0.5040\n",
-      "2023-09-08T21:06:26Z INFO     Train Epoch: 0 [41280/60000 (69%)]\tloss=0.6674\n",
-      "2023-09-08T21:06:29Z INFO     Train Epoch: 0 [41600/60000 (69%)]\tloss=0.8426\n",
-      "2023-09-08T21:06:31Z INFO     Train Epoch: 0 [41920/60000 (70%)]\tloss=0.5418\n",
-      "2023-09-08T21:06:33Z INFO     Train Epoch: 0 [42240/60000 (70%)]\tloss=0.6396\n",
-      "2023-09-08T21:06:35Z INFO     Train Epoch: 0 [42560/60000 (71%)]\tloss=0.4182\n",
-      "2023-09-08T21:06:38Z INFO     Train Epoch: 0 [42880/60000 (71%)]\tloss=0.7471\n",
-      "2023-09-08T21:06:40Z INFO     Train Epoch: 0 [43200/60000 (72%)]\tloss=0.6492\n",
-      "2023-09-08T21:06:42Z INFO     Train Epoch: 0 [43520/60000 (73%)]\tloss=0.3955\n",
-      "2023-09-08T21:06:44Z INFO     Train Epoch: 0 [43840/60000 (73%)]\tloss=0.5986\n",
-      "2023-09-08T21:06:46Z INFO     Train Epoch: 0 [44160/60000 (74%)]\tloss=0.5604\n",
-      "2023-09-08T21:06:48Z INFO     Train Epoch: 0 [44480/60000 (74%)]\tloss=0.4396\n",
-      "2023-09-08T21:06:50Z INFO     Train Epoch: 0 [44800/60000 (75%)]\tloss=0.5718\n",
-      "2023-09-08T21:06:52Z INFO     Train Epoch: 0 [45120/60000 (75%)]\tloss=0.5190\n",
-      "2023-09-08T21:06:54Z INFO     Train Epoch: 0 [45440/60000 (76%)]\tloss=0.7500\n",
-      "2023-09-08T21:06:56Z INFO     Train Epoch: 0 [45760/60000 (76%)]\tloss=0.4298\n",
-      "2023-09-08T21:06:58Z INFO     Train Epoch: 0 [46080/60000 (77%)]\tloss=0.5909\n",
-      "2023-09-08T21:07:00Z INFO     Train Epoch: 0 [46400/60000 (77%)]\tloss=0.4499\n",
-      "2023-09-08T21:07:02Z INFO     Train Epoch: 0 [46720/60000 (78%)]\tloss=0.6639\n",
-      "2023-09-08T21:07:05Z INFO     Train Epoch: 0 [47040/60000 (78%)]\tloss=0.3891\n",
-      "2023-09-08T21:07:08Z INFO     Train Epoch: 0 [47360/60000 (79%)]\tloss=0.5912\n",
-      "2023-09-08T21:07:10Z INFO     Train Epoch: 0 [47680/60000 (79%)]\tloss=0.4047\n",
-      "2023-09-08T21:07:12Z INFO     Train Epoch: 0 [48000/60000 (80%)]\tloss=0.5517\n",
-      "2023-09-08T21:07:14Z INFO     Train Epoch: 0 [48320/60000 (81%)]\tloss=0.5204\n",
-      "2023-09-08T21:07:17Z INFO     Train Epoch: 0 [48640/60000 (81%)]\tloss=0.7532\n",
-      "2023-09-08T21:07:19Z INFO     Train Epoch: 0 [48960/60000 (82%)]\tloss=0.6107\n",
-      "2023-09-08T21:07:20Z INFO     Train Epoch: 0 [49280/60000 (82%)]\tloss=0.6882\n",
-      "2023-09-08T21:07:22Z INFO     Train Epoch: 0 [49600/60000 (83%)]\tloss=0.3215\n",
-      "2023-09-08T21:07:24Z INFO     Train Epoch: 0 [49920/60000 (83%)]\tloss=0.3356\n",
-      "2023-09-08T21:07:26Z INFO     Train Epoch: 0 [50240/60000 (84%)]\tloss=0.4973\n",
-      "2023-09-08T21:07:28Z INFO     Train Epoch: 0 [50560/60000 (84%)]\tloss=0.8383\n",
-      "2023-09-08T21:07:31Z INFO     Train Epoch: 0 [50880/60000 (85%)]\tloss=0.4020\n",
-      "2023-09-08T21:07:32Z INFO     Train Epoch: 0 [51200/60000 (85%)]\tloss=0.4866\n",
-      "2023-09-08T21:07:34Z INFO     Train Epoch: 0 [51520/60000 (86%)]\tloss=0.4938\n",
-      "2023-09-08T21:07:36Z INFO     Train Epoch: 0 [51840/60000 (86%)]\tloss=0.7432\n",
-      "2023-09-08T21:07:38Z INFO     Train Epoch: 0 [52160/60000 (87%)]\tloss=0.4650\n",
-      "2023-09-08T21:07:40Z INFO     Train Epoch: 0 [52480/60000 (87%)]\tloss=0.8149\n",
-      "2023-09-08T21:07:41Z INFO     Train Epoch: 0 [52800/60000 (88%)]\tloss=0.5370\n",
-      "2023-09-08T21:07:43Z INFO     Train Epoch: 0 [53120/60000 (89%)]\tloss=0.7261\n",
-      "2023-09-08T21:07:46Z INFO     Train Epoch: 0 [53440/60000 (89%)]\tloss=0.6188\n",
-      "2023-09-08T21:07:48Z INFO     Train Epoch: 0 [53760/60000 (90%)]\tloss=0.5179\n",
-      "2023-09-08T21:07:51Z INFO     Train Epoch: 0 [54080/60000 (90%)]\tloss=0.7616\n",
-      "2023-09-08T21:07:53Z INFO     Train Epoch: 0 [54400/60000 (91%)]\tloss=0.7180\n",
-      "2023-09-08T21:07:55Z INFO     Train Epoch: 0 [54720/60000 (91%)]\tloss=0.4831\n",
-      "2023-09-08T21:07:56Z INFO     Train Epoch: 0 [55040/60000 (92%)]\tloss=0.3719\n",
-      "2023-09-08T21:07:59Z INFO     Train Epoch: 0 [55360/60000 (92%)]\tloss=0.4730\n",
-      "2023-09-08T21:08:01Z INFO     Train Epoch: 0 [55680/60000 (93%)]\tloss=0.5402\n",
-      "2023-09-08T21:08:02Z INFO     Train Epoch: 0 [56000/60000 (93%)]\tloss=0.7432\n",
-      "2023-09-08T21:08:04Z INFO     Train Epoch: 0 [56320/60000 (94%)]\tloss=0.6275\n",
-      "2023-09-08T21:08:06Z INFO     Train Epoch: 0 [56640/60000 (94%)]\tloss=0.3235\n",
-      "2023-09-08T21:08:07Z INFO     Train Epoch: 0 [56960/60000 (95%)]\tloss=0.7855\n",
-      "2023-09-08T21:08:09Z INFO     Train Epoch: 0 [57280/60000 (95%)]\tloss=0.5046\n",
-      "2023-09-08T21:08:11Z INFO     Train Epoch: 0 [57600/60000 (96%)]\tloss=0.5732\n",
-      "2023-09-08T21:08:13Z INFO     Train Epoch: 0 [57920/60000 (97%)]\tloss=0.2879\n",
-      "2023-09-08T21:08:15Z INFO     Train Epoch: 0 [58240/60000 (97%)]\tloss=0.4233\n",
-      "2023-09-08T21:08:18Z INFO     Train Epoch: 0 [58560/60000 (98%)]\tloss=0.5561\n",
-      "2023-09-08T21:08:20Z INFO     Train Epoch: 0 [58880/60000 (98%)]\tloss=0.6785\n",
-      "2023-09-08T21:08:21Z INFO     Train Epoch: 0 [59200/60000 (99%)]\tloss=0.3826\n",
-      "2023-09-08T21:08:23Z INFO     Train Epoch: 0 [59520/60000 (99%)]\tloss=0.5397\n",
-      "2023-09-08T21:08:26Z INFO     Train Epoch: 0 [59840/60000 (100%)]\tloss=0.5987\n",
+      "2024-03-05T21:47:16Z INFO     Start training for RANK: 0. WORLD_SIZE: 3\n",
+      "2024-03-05T21:47:17Z INFO     Train Epoch: 0 [0/60000 (0%)]\tloss=2.2958\n",
+      "2024-03-05T21:47:21Z INFO     Train Epoch: 0 [1280/60000 (6%)]\tloss=2.2902\n",
+      "2024-03-05T21:47:26Z INFO     Train Epoch: 0 [2560/60000 (13%)]\tloss=2.2863\n",
+      "2024-03-05T21:47:29Z INFO     Train Epoch: 0 [3840/60000 (19%)]\tloss=2.2719\n",
+      "2024-03-05T21:47:33Z INFO     Train Epoch: 0 [5120/60000 (25%)]\tloss=2.2630\n",
+      "2024-03-05T21:47:38Z INFO     Train Epoch: 0 [6400/60000 (32%)]\tloss=2.2362\n",
+      "2024-03-05T21:47:42Z INFO     Train Epoch: 0 [7680/60000 (38%)]\tloss=2.2007\n",
+      "2024-03-05T21:47:45Z INFO     Train Epoch: 0 [8960/60000 (45%)]\tloss=2.1735\n",
+      "2024-03-05T21:47:49Z INFO     Train Epoch: 0 [10240/60000 (51%)]\tloss=2.1185\n",
+      "2024-03-05T21:47:53Z INFO     Train Epoch: 0 [11520/60000 (57%)]\tloss=2.0732\n",
+      "2024-03-05T21:47:58Z INFO     Train Epoch: 0 [12800/60000 (64%)]\tloss=1.9446\n",
+      "2024-03-05T21:48:02Z INFO     Train Epoch: 0 [14080/60000 (70%)]\tloss=1.7036\n",
+      "2024-03-05T21:48:06Z INFO     Train Epoch: 0 [15360/60000 (76%)]\tloss=1.6633\n",
+      "2024-03-05T21:48:10Z INFO     Train Epoch: 0 [16640/60000 (83%)]\tloss=1.3292\n",
+      "2024-03-05T21:48:14Z INFO     Train Epoch: 0 [17920/60000 (89%)]\tloss=1.3720\n",
+      "2024-03-05T21:48:18Z INFO     Train Epoch: 0 [19200/60000 (96%)]\tloss=1.1136\n",
+      "2024-03-05T21:48:21Z INFO     Train Epoch: 1 [0/60000 (0%)]\tloss=0.9830\n",
+      "2024-03-05T21:48:25Z INFO     Train Epoch: 1 [1280/60000 (6%)]\tloss=1.1548\n",
+      "2024-03-05T21:48:29Z INFO     Train Epoch: 1 [2560/60000 (13%)]\tloss=0.9911\n",
+      "2024-03-05T21:48:33Z INFO     Train Epoch: 1 [3840/60000 (19%)]\tloss=0.8874\n",
+      "2024-03-05T21:48:36Z INFO     Train Epoch: 1 [5120/60000 (25%)]\tloss=1.0731\n",
+      "2024-03-05T21:48:39Z INFO     Train Epoch: 1 [6400/60000 (32%)]\tloss=0.7734\n",
+      "2024-03-05T21:48:44Z INFO     Train Epoch: 1 [7680/60000 (38%)]\tloss=0.7550\n",
+      "2024-03-05T21:48:47Z INFO     Train Epoch: 1 [8960/60000 (45%)]\tloss=0.9045\n",
+      "2024-03-05T21:48:51Z INFO     Train Epoch: 1 [10240/60000 (51%)]\tloss=0.8567\n",
+      "2024-03-05T21:48:55Z INFO     Train Epoch: 1 [11520/60000 (57%)]\tloss=0.9150\n",
+      "2024-03-05T21:48:59Z INFO     Train Epoch: 1 [12800/60000 (64%)]\tloss=0.8769\n",
+      "2024-03-05T21:49:02Z INFO     Train Epoch: 1 [14080/60000 (70%)]\tloss=0.8903\n",
+      "2024-03-05T21:49:07Z INFO     Train Epoch: 1 [15360/60000 (76%)]\tloss=0.9694\n",
+      "2024-03-05T21:49:11Z INFO     Train Epoch: 1 [16640/60000 (83%)]\tloss=0.7397\n",
+      "2024-03-05T21:49:14Z INFO     Train Epoch: 1 [17920/60000 (89%)]\tloss=0.9153\n",
+      "2024-03-05T21:49:18Z INFO     Train Epoch: 1 [19200/60000 (96%)]\tloss=0.7878\n",
+      "2024-03-05T21:49:20Z INFO     Train Epoch: 2 [0/60000 (0%)]\tloss=0.6716\n",
+      "2024-03-05T21:49:25Z INFO     Train Epoch: 2 [1280/60000 (6%)]\tloss=0.9508\n",
+      "2024-03-05T21:49:29Z INFO     Train Epoch: 2 [2560/60000 (13%)]\tloss=0.7306\n",
+      "2024-03-05T21:49:34Z INFO     Train Epoch: 2 [3840/60000 (19%)]\tloss=0.7212\n",
+      "2024-03-05T21:49:38Z INFO     Train Epoch: 2 [5120/60000 (25%)]\tloss=0.9555\n",
+      "2024-03-05T21:49:42Z INFO     Train Epoch: 2 [6400/60000 (32%)]\tloss=0.6037\n",
+      "2024-03-05T21:49:45Z INFO     Train Epoch: 2 [7680/60000 (38%)]\tloss=0.6307\n",
+      "2024-03-05T21:49:49Z INFO     Train Epoch: 2 [8960/60000 (45%)]\tloss=0.7282\n",
+      "2024-03-05T21:49:54Z INFO     Train Epoch: 2 [10240/60000 (51%)]\tloss=0.7196\n",
+      "2024-03-05T21:49:57Z INFO     Train Epoch: 2 [11520/60000 (57%)]\tloss=0.7827\n",
+      "2024-03-05T21:50:01Z INFO     Train Epoch: 2 [12800/60000 (64%)]\tloss=0.7565\n",
+      "2024-03-05T21:50:05Z INFO     Train Epoch: 2 [14080/60000 (70%)]\tloss=0.7726\n",
+      "2024-03-05T21:50:08Z INFO     Train Epoch: 2 [15360/60000 (76%)]\tloss=0.8723\n",
+      "2024-03-05T21:50:12Z INFO     Train Epoch: 2 [16640/60000 (83%)]\tloss=0.6533\n",
+      "2024-03-05T21:50:15Z INFO     Train Epoch: 2 [17920/60000 (89%)]\tloss=0.8277\n",
+      "2024-03-05T21:50:19Z INFO     Train Epoch: 2 [19200/60000 (96%)]\tloss=0.6978\n",
+      "2024-03-05T21:50:21Z INFO     Training is finished\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "training_client.get_job_logs(pytorchjob_name)"
+    "logs, _ = training_client.get_job_logs(pytorchjob_name)\n",
+    "\n",
+    "print(logs[\"train-pytorch-master-0\"])"
    ]
   },
   {
@@ -691,20 +649,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "32ae88fd-5b5d-4ba1-a560-9a35c5ac17de",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-03-05T21:50:49.741925Z",
+     "iopub.status.busy": "2024-03-05T21:50:49.741582Z",
+     "iopub.status.idle": "2024-03-05T21:50:49.772285Z",
+     "shell.execute_reply": "2024-03-05T21:50:49.771323Z",
+     "shell.execute_reply.started": "2024-03-05T21:50:49.741904Z"
+    },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-09-08T22:10:29Z INFO     PyTorchJob default/train-pytorch has been deleted\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "training_client.delete_job(pytorchjob_name)"
    ]


### PR DESCRIPTION
I fixed PyTorch training examples where we forgot to distribute data across PyTorch workers using `DistributedSampler(dataset)`. After that change each PyTorch worker will correctly process chunk of training data.

Also, for FashionMNIST example I removed check if this script is running in distributed mode since for PyTorch we can just set arbitrary values for env variables and run this script in 1 Worker.

/assign @johnugeorge @tenzen-y @kuizhiqing 