### PR TITLE
Add flake8 linter for Python files in CI/CD

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -24,8 +24,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pytest python-dateutil urllib3 kubernetes
+          pip install flake8 pytest python-dateutil urllib3 kubernetes
           pip install -U './sdk/python[huggingface]'
 
       - name: Run unit test for training sdk
         run: pytest ./sdk/python/kubeflow/training/api/training_client_test.py
+
+      - name: Lint with flake8
+        run: |
+          flake8 sdk/ --count --select=E9,F63,F7,F82 --extend-ignore=W503 --exclude=/*kubeflow_org_v1*,__init__.py,api_client.py,configuration.py,exceptions.py,rest.py --show-source --statistics
+          flake8 sdk/ --count --extend-ignore=W503 --exclude=/*kubeflow_org_v1*,__init__.py,api_client.py,configuration.py,exceptions.py,rest.py --max-complexity=10 --max-line-length=100 --statistics


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Check the style and quality of python code using flake8 in CI/CD

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes # #1910
