### PR TITLE
fix: Upgrade controller-gen to v0.14.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	GOBIN=$(PROJECT_DIR)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.13.0
+	GOBIN=$(PROJECT_DIR)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.

--- a/manifests/base/crds/kubeflow.org_mpijobs.yaml
+++ b/manifests/base/crds/kubeflow.org_mpijobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: mpijobs.kubeflow.org
 spec:
   group: kubeflow.org
@@ -26,25 +26,32 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
             properties:
               cleanPodPolicy:
-                description: CleanPodPolicy defines the policy that whether to kill
-                  pods after the job completes. Defaults to None.
+                description: |-
+                  CleanPodPolicy defines the policy that whether to kill pods after the job completes.
+                  Defaults to None.
                 type: string
               mainContainer:
-                description: MainContainer specifies name of the main container which
+                description: |-
+                  MainContainer specifies name of the main container which
                   executes the MPI code.
                 type: string
               mpiReplicaSpecs:
@@ -52,21 +59,27 @@ spec:
                   description: ReplicaSpec is a description of the replica
                   properties:
                     replicas:
-                      description: Replicas is the desired number of replicas of the
-                        given template. If unspecified, defaults to 1.
+                      description: |-
+                        Replicas is the desired number of replicas of the given template.
+                        If unspecified, defaults to 1.
                       format: int32
                       type: integer
                     restartPolicy:
-                      description: Restart policy for all replicas within the job.
-                        One of Always, OnFailure, Never and ExitCode. Default to Never.
+                      description: |-
+                        Restart policy for all replicas within the job.
+                        One of Always, OnFailure, Never and ExitCode.
+                        Default to Never.
                       type: string
                     template:
-                      description: Template is the object that describes the pod that
+                      description: |-
+                        Template is the object that describes the pod that
                         will be created for this replica. RestartPolicy in PodTemplateSpec
                         will be overide by RestartPolicy in ReplicaSpec
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          description: |-
+                            Standard object's metadata.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                           properties:
                             annotations:
                               additionalProperties:
@@ -86,15 +99,15 @@ spec:
                               type: string
                           type: object
                         spec:
-                          description: 'Specification of the desired behavior of the
-                            pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                          description: |-
+                            Specification of the desired behavior of the pod.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                           properties:
                             activeDeadlineSeconds:
-                              description: Optional duration in seconds the pod may
-                                be active on the node relative to StartTime before
-                                the system will actively try to mark it failed and
-                                kill associated containers. Value must be a positive
-                                integer.
+                              description: |-
+                                Optional duration in seconds the pod may be active on the node relative to
+                                StartTime before the system will actively try to mark it failed and kill associated containers.
+                                Value must be a positive integer.
                               format: int64
                               type: integer
                             affinity:
@@ -105,21 +118,17 @@ spec:
                                     rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.
                                       items:
-                                        description: An empty preferred scheduling
-                                          term matches all objects with implicit weight
-                                          0 (i.e. it's a no-op). A null preferred
-                                          scheduling term matches no objects (i.e.
-                                          is also a no-op).
+                                        description: |-
+                                          An empty preferred scheduling term matches all objects with implicit weight 0
+                                          (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                         properties:
                                           preference:
                                             description: A node selector term, associated
@@ -129,35 +138,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -170,35 +170,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -221,57 +212,46 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified
-                                        by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to an update), the
-                                        system may or may not try to eventually evict
-                                        the pod from its node.
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to an update), the system
+                                        may or may not try to eventually evict the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
                                             terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector
-                                              term matches no objects. The requirements
-                                              of them are ANDed. The TopologySelectorTerm
-                                              type implements a subset of the NodeSelectorTerm.
+                                            description: |-
+                                              A null or empty node selector term matches no objects. The requirements of
+                                              them are ANDed.
+                                              The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
                                                 description: A list of node selector
                                                   requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -284,35 +264,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -335,15 +306,13 @@ spec:
                                     etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -364,11 +333,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -376,23 +343,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -404,29 +364,20 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaceSelector:
-                                                description: A label query over the
-                                                  set of namespaces that the term
-                                                  applies to. The term is applied
-                                                  to the union of the namespaces selected
-                                                  by this field and the ones listed
-                                                  in the namespaces field. null selector
-                                                  and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -434,11 +385,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -446,23 +395,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -474,50 +416,37 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaces:
-                                                description: namespaces specifies
-                                                  a static list of namespace names
-                                                  that the term applies to. The term
-                                                  is applied to the union of the namespaces
-                                                  listed in this field and the ones
-                                                  selected by namespaceSelector. null
-                                                  or empty namespaces list and null
-                                                  namespaceSelector means "this pod's
-                                                  namespace".
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching
-                                              the corresponding podAffinityTerm, in
-                                              the range 1-100.
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -526,24 +455,20 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified
-                                        by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to a pod label update),
-                                        the system may or may not try to eventually
-                                        evict the pod from its node.
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
                                       items:
-                                        description: Defines a set of pods (namely
-                                          those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -554,10 +479,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -565,21 +489,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -592,25 +510,19 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
@@ -618,10 +530,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -629,21 +540,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -656,39 +561,29 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace".
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -701,13 +596,11 @@ spec:
                                     node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the anti-affinity
-                                        expressions specified by this field, but it
-                                        may choose a node that violates one or more
-                                        of the expressions. The node that is most
-                                        preferred is the one with the greatest sum
-                                        of weights, i.e.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the anti-affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -728,11 +621,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -740,23 +631,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -768,29 +652,20 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaceSelector:
-                                                description: A label query over the
-                                                  set of namespaces that the term
-                                                  applies to. The term is applied
-                                                  to the union of the namespaces selected
-                                                  by this field and the ones listed
-                                                  in the namespaces field. null selector
-                                                  and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -798,11 +673,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -810,23 +683,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -838,50 +704,37 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaces:
-                                                description: namespaces specifies
-                                                  a static list of namespace names
-                                                  that the term applies to. The term
-                                                  is applied to the union of the namespaces
-                                                  listed in this field and the ones
-                                                  selected by namespaceSelector. null
-                                                  or empty namespaces list and null
-                                                  namespaceSelector means "this pod's
-                                                  namespace".
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching
-                                              the corresponding podAffinityTerm, in
-                                              the range 1-100.
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -890,24 +743,20 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements
-                                        specified by this field are not met at scheduling
-                                        time, the pod will not be scheduled onto the
-                                        node. If the anti-affinity requirements specified
-                                        by this field cease to be met at some point
-                                        during pod execution (e.g. due to a pod label
-                                        update), the system may or may not try to
-                                        eventually evict the pod from its node.
+                                      description: |-
+                                        If the anti-affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the anti-affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
                                       items:
-                                        description: Defines a set of pods (namely
-                                          those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -918,10 +767,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -929,21 +777,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -956,25 +798,19 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
@@ -982,10 +818,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -993,21 +828,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -1020,39 +849,29 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace".
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1066,41 +885,39 @@ spec:
                                 mounted.
                               type: boolean
                             containers:
-                              description: List of containers belonging to the pod.
-                                Containers cannot currently be added or removed. There
-                                must be at least one container in a Pod. Cannot be
-                                updated.
+                              description: |-
+                                List of containers belonging to the pod.
+                                Containers cannot currently be added or removed.
+                                There must be at least one container in a Pod.
+                                Cannot be updated.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
-                                      provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The container image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
-                                      used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The container image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -1110,16 +927,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1133,10 +947,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1147,11 +961,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -1167,12 +979,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -1206,10 +1015,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1225,15 +1034,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1242,10 +1049,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -1262,10 +1069,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -1276,48 +1083,43 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images
-                                      This field is optional to allow higher level
-                                      config management to default or override container
-                                      images in workload controllers like Deployments
-                                      and StatefulSets.'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system
-                                      should take in response to container lifecycle
-                                      events. Cannot be updated.
+                                    description: |-
+                                      Actions that the management system should take in response to container lifecycle events.
+                                      Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1327,10 +1129,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -1342,11 +1143,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -1365,25 +1164,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1394,41 +1192,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1438,10 +1229,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -1453,11 +1243,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -1476,25 +1264,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1505,10 +1292,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -1516,35 +1303,31 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness.
+                                    description: |-
+                                      Periodic probe of container liveness.
                                       Container will be restarted if the probe fails.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -1557,11 +1340,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -1571,9 +1355,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -1583,11 +1367,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -1605,36 +1387,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -1649,55 +1430,52 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as
-                                      a DNS_LABEL. Each container in a pod must have
-                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    description: |-
+                                      Name of the container specified as a DNS_LABEL.
+                                      Each container in a pod must have a unique name (DNS_LABEL).
+                                      Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the
-                                      container. Not specifying a port here DOES NOT
-                                      prevent that port from being exposed. Any port
-                                      which is listening on the default "0.0.0.0"
-                                      address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
+                                    description: |-
+                                      List of ports to expose from the container. Not specifying a port here
+                                      DOES NOT prevent that port from being exposed. Any port which is
+                                      listening on the default "0.0.0.0" address inside a container will be
+                                      accessible from the network.
+                                      Modifying this array with strategic merge patch may corrupt the data.
                                       For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -1705,24 +1483,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -1733,36 +1511,31 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service
-                                      readiness. Container will be removed from service
-                                      endpoints if the probe fails. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Periodic probe of container service readiness.
+                                      Container will be removed from service endpoints if the probe fails.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -1775,11 +1548,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -1789,9 +1563,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -1801,11 +1575,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -1823,36 +1595,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -1867,30 +1638,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -1901,14 +1669,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -1917,26 +1685,31 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Compute Resources required by this container.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -1952,9 +1725,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1963,48 +1736,41 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: RestartPolicy defines the restart
-                                      behavior of individual containers in a pod.
-                                      This field may only be set for init containers,
-                                      and the only allowed value is "Always". For
-                                      non-init containers or when this field is not
-                                      specified, the restart behavior is defined by
-                                      the Pod's restart policy and the container type.
+                                    description: |-
+                                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                                      This field may only be set for init containers, and the only allowed value is "Always".
+                                      For non-init containers or when this field is not specified,
+                                      the restart behavior is defined by the Pod's restart policy and the container type.
                                     type: string
                                   securityContext:
-                                    description: 'SecurityContext defines the security
-                                      options the container should be run with. If
-                                      set, the fields of SecurityContext override
-                                      the equivalent fields of PodSecurityContext.
-                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    description: |-
+                                      SecurityContext defines the security options the container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -2022,68 +1788,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2103,52 +1860,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -2156,60 +1905,46 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: StartupProbe indicates that the Pod
-                                      has successfully initialized. If specified,
-                                      no other probes are executed until this completes
-                                      successfully. If this probe fails, the Pod will
-                                      be restarted, just as if the livenessProbe failed.
+                                    description: |-
+                                      StartupProbe indicates that the Pod has successfully initialized.
+                                      If specified, no other probes are executed until this completes successfully.
+                                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -2222,11 +1957,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -2236,9 +1972,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -2248,11 +1984,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -2270,36 +2004,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -2314,72 +2047,62 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -2403,46 +2126,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -2450,34 +2172,36 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             dnsConfig:
-                              description: Specifies the DNS parameters of a pod.
-                                Parameters specified here will be merged to the generated
-                                DNS configuration based on DNSPolicy.
+                              description: |-
+                                Specifies the DNS parameters of a pod.
+                                Parameters specified here will be merged to the generated DNS
+                                configuration based on DNSPolicy.
                               properties:
                                 nameservers:
-                                  description: A list of DNS name server IP addresses.
-                                    This will be appended to the base nameservers
-                                    generated from DNSPolicy. Duplicated nameservers
-                                    will be removed.
+                                  description: |-
+                                    A list of DNS name server IP addresses.
+                                    This will be appended to the base nameservers generated from DNSPolicy.
+                                    Duplicated nameservers will be removed.
                                   items:
                                     type: string
                                   type: array
                                 options:
-                                  description: A list of DNS resolver options. This
-                                    will be merged with the base options generated
-                                    from DNSPolicy. Duplicated entries will be removed.
-                                    Resolution options given in Options will override
-                                    those that appear in the base DNSPolicy.
+                                  description: |-
+                                    A list of DNS resolver options.
+                                    This will be merged with the base options generated from DNSPolicy.
+                                    Duplicated entries will be removed. Resolution options given in Options
+                                    will override those that appear in the base DNSPolicy.
                                   items:
                                     description: PodDNSConfigOption defines DNS resolver
                                       options of a pod.
@@ -2490,75 +2214,68 @@ spec:
                                     type: object
                                   type: array
                                 searches:
-                                  description: A list of DNS search domains for host-name
-                                    lookup. This will be appended to the base search
-                                    paths generated from DNSPolicy. Duplicated search
-                                    paths will be removed.
+                                  description: |-
+                                    A list of DNS search domains for host-name lookup.
+                                    This will be appended to the base search paths generated from DNSPolicy.
+                                    Duplicated search paths will be removed.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
-                              description: Set DNS policy for the pod. Defaults to
-                                "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
-                                'ClusterFirst', 'Default' or 'None'. DNS parameters
-                                given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy. To have DNS options set along
-                                with hostNetwork, you have to specify DNS policy explicitly
-                                to 'ClusterFirstWithHostNet'.
+                              description: |-
+                                Set DNS policy for the pod.
+                                Defaults to "ClusterFirst".
+                                Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                                DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                                To have DNS options set along with hostNetwork, you have to specify DNS policy
+                                explicitly to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
-                              description: 'EnableServiceLinks indicates whether information
-                                about services should be injected into pod''s environment
-                                variables, matching the syntax of Docker links. Optional:
-                                Defaults to true.'
+                              description: |-
+                                EnableServiceLinks indicates whether information about services should be injected into pod's
+                                environment variables, matching the syntax of Docker links.
+                                Optional: Defaults to true.
                               type: boolean
                             ephemeralContainers:
-                              description: List of ephemeral containers run in this
-                                pod. Ephemeral containers may be run in an existing
-                                pod to perform user-initiated actions such as debugging.
-                                This list cannot be specified when creating a pod,
-                                and it cannot be modified by updating the pod spec.
-                                In order to add an ephemeral container to an existing
-                                pod, use the pod's ephemeralcontainers subresource.
+                              description: |-
+                                List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                                pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                                creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                                ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
                               items:
-                                description: An EphemeralContainer is a temporary
-                                  container that you may add to an existing Pod for
-                                  user-initiated activities such as debugging. Ephemeral
-                                  containers have no resource or scheduling guarantees,
-                                  and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted. The kubelet
-                                  may evict a Pod if an ephemeral container causes
-                                  the Pod to exceed its resource allocation.
+                                description: |-
+                                  An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                                  user-initiated activities such as debugging. Ephemeral containers have no resource or
+                                  scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                                  removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                                  Pod to exceed its resource allocation.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the
-                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                      produce the string literal "$(VAR_NAME)".'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)".
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The image''s ENTRYPOINT is used if
-                                      this is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -2568,16 +2285,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -2591,10 +2305,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -2605,11 +2319,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -2625,12 +2337,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -2664,10 +2373,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -2683,15 +2392,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -2700,10 +2407,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -2720,10 +2427,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -2734,43 +2441,40 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
                                     description: Lifecycle is not allowed for ephemeral
                                       containers.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2780,10 +2484,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -2795,11 +2498,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -2818,25 +2519,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2847,41 +2547,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2891,10 +2584,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -2906,11 +2598,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -2929,25 +2619,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2958,10 +2647,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -2977,26 +2666,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -3009,11 +2692,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -3023,9 +2707,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -3035,11 +2719,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3057,36 +2739,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -3101,38 +2782,34 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the ephemeral container specified
-                                      as a DNS_LABEL. This name must be unique among
-                                      all containers, init containers and ephemeral
-                                      containers.
+                                    description: |-
+                                      Name of the ephemeral container specified as a DNS_LABEL.
+                                      This name must be unique among all containers, init containers and ephemeral containers.
                                     type: string
                                   ports:
                                     description: Ports are not allowed for ephemeral
@@ -3142,9 +2819,9 @@ spec:
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -3152,24 +2829,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -3188,26 +2865,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -3220,11 +2891,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -3234,9 +2906,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -3246,11 +2918,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3268,36 +2938,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -3312,30 +2981,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -3346,14 +3012,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -3362,27 +3028,30 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: Resources are not allowed for ephemeral
-                                      containers. Ephemeral containers use spare resources
+                                    description: |-
+                                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
                                       already allocated to the pod.
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -3398,9 +3067,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -3409,45 +3078,40 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: Restart policy for the container
-                                      to manage the restart behavior of each container
-                                      within a pod. This may only be set for init
-                                      containers. You cannot set this field on ephemeral
-                                      containers.
+                                    description: |-
+                                      Restart policy for the container to manage the restart behavior of each
+                                      container within a pod.
+                                      This may only be set for init containers. You cannot set this field on
+                                      ephemeral containers.
                                     type: string
                                   securityContext:
-                                    description: 'Optional: SecurityContext defines
-                                      the security options the ephemeral container
-                                      should be run with. If set, the fields of SecurityContext
-                                      override the equivalent fields of PodSecurityContext.'
+                                    description: |-
+                                      Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -3465,68 +3129,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3546,52 +3201,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -3599,25 +3246,18 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
@@ -3630,26 +3270,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -3662,11 +3296,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -3676,9 +3311,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -3688,11 +3323,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3710,36 +3343,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -3754,81 +3386,71 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: "If set, the name of the container
-                                      from PodSpec that this ephemeral container targets.
-                                      The ephemeral container will be run in the namespaces
-                                      (IPC, PID, etc) of this container. If not set
-                                      then the ephemeral container uses the namespaces
-                                      configured in the Pod spec. \n The container
-                                      runtime must implement support for this feature."
+                                    description: |-
+                                      If set, the name of the container from PodSpec that this ephemeral container targets.
+                                      The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                      If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+
+                                      The container runtime must implement support for this feature.
                                     type: string
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -3852,47 +3474,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Subpath mounts are not allowed for
-                                      ephemeral containers. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -3900,24 +3520,24 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             hostAliases:
-                              description: HostAliases is an optional list of hosts
-                                and IPs that will be injected into the pod's hosts
-                                file if specified. This is only valid for non-hostNetwork
-                                pods.
+                              description: |-
+                                HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                file if specified. This is only valid for non-hostNetwork pods.
                               items:
-                                description: HostAlias holds the mapping between IP
-                                  and hostnames that will be injected as an entry
-                                  in the pod's hosts file.
+                                description: |-
+                                  HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                  pod's hosts file.
                                 properties:
                                   hostnames:
                                     description: Hostnames for the above IP address.
@@ -3930,93 +3550,89 @@ spec:
                                 type: object
                               type: array
                             hostIPC:
-                              description: 'Use the host''s ipc namespace. Optional:
-                                Default to false.'
+                              description: |-
+                                Use the host's ipc namespace.
+                                Optional: Default to false.
                               type: boolean
                             hostNetwork:
-                              description: Host networking requested for this pod.
-                                Use the host's network namespace. If this option is
-                                set, the ports that will be used must be specified.
+                              description: |-
+                                Host networking requested for this pod. Use the host's network namespace.
+                                If this option is set, the ports that will be used must be specified.
                                 Default to false.
                               type: boolean
                             hostPID:
-                              description: 'Use the host''s pid namespace. Optional:
-                                Default to false.'
+                              description: |-
+                                Use the host's pid namespace.
+                                Optional: Default to false.
                               type: boolean
                             hostUsers:
-                              description: 'Use the host''s user namespace. Optional:
-                                Default to true. If set to true or not present, the
-                                pod will be run in the host user namespace, useful
-                                for when the pod needs a feature only available to
-                                the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE. When set to false, a new
-                                userns is created for the pod.'
+                              description: |-
+                                Use the host's user namespace.
+                                Optional: Default to true.
+                                If set to true or not present, the pod will be run in the host user namespace, useful
+                                for when the pod needs a feature only available to the host user namespace, such as
+                                loading a kernel module with CAP_SYS_MODULE.
+                                When set to false, a new userns is created for the pod.
                               type: boolean
                             hostname:
-                              description: Specifies the hostname of the Pod If not
-                                specified, the pod's hostname will be set to a system-defined
-                                value.
+                              description: |-
+                                Specifies the hostname of the Pod
+                                If not specified, the pod's hostname will be set to a system-defined value.
                               type: string
                             imagePullSecrets:
-                              description: 'ImagePullSecrets is an optional list of
-                                references to secrets in the same namespace to use
-                                for pulling any of the images used by this PodSpec.
-                                If specified, these secrets will be passed to individual
-                                puller implementations for them to use. More info:
-                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                              description: |-
+                                ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                If specified, these secrets will be passed to individual puller implementations for them to use.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                               items:
-                                description: LocalObjectReference contains enough
-                                  information to let you locate the referenced object
-                                  inside the same namespace.
+                                description: |-
+                                  LocalObjectReference contains enough information to let you locate the
+                                  referenced object inside the same namespace.
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               type: array
                             initContainers:
-                              description: List of initialization containers belonging
-                                to the pod. Init containers are executed in order
-                                prior to containers being started. If any init container
-                                fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy. The name for
-                                an init container or normal container must be unique
-                                among all containers.
+                              description: |-
+                                List of initialization containers belonging to the pod.
+                                Init containers are executed in order prior to containers being started. If any
+                                init container fails, the pod is considered to have failed and is handled according
+                                to its restartPolicy. The name for an init container or normal container must be
+                                unique among all containers.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
-                                      provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The container image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
-                                      used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The container image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -4026,16 +3642,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -4049,10 +3662,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -4063,11 +3676,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -4083,12 +3694,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -4122,10 +3730,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -4141,15 +3749,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -4158,10 +3764,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -4178,10 +3784,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -4192,48 +3798,43 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images
-                                      This field is optional to allow higher level
-                                      config management to default or override container
-                                      images in workload controllers like Deployments
-                                      and StatefulSets.'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system
-                                      should take in response to container lifecycle
-                                      events. Cannot be updated.
+                                    description: |-
+                                      Actions that the management system should take in response to container lifecycle events.
+                                      Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4243,10 +3844,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -4258,11 +3858,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -4281,25 +3879,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -4310,41 +3907,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4354,10 +3944,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -4369,11 +3958,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -4392,25 +3979,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -4421,10 +4007,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -4432,35 +4018,31 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness.
+                                    description: |-
+                                      Periodic probe of container liveness.
                                       Container will be restarted if the probe fails.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -4473,11 +4055,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -4487,9 +4070,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -4499,11 +4082,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -4521,36 +4102,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -4565,55 +4145,52 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as
-                                      a DNS_LABEL. Each container in a pod must have
-                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    description: |-
+                                      Name of the container specified as a DNS_LABEL.
+                                      Each container in a pod must have a unique name (DNS_LABEL).
+                                      Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the
-                                      container. Not specifying a port here DOES NOT
-                                      prevent that port from being exposed. Any port
-                                      which is listening on the default "0.0.0.0"
-                                      address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
+                                    description: |-
+                                      List of ports to expose from the container. Not specifying a port here
+                                      DOES NOT prevent that port from being exposed. Any port which is
+                                      listening on the default "0.0.0.0" address inside a container will be
+                                      accessible from the network.
+                                      Modifying this array with strategic merge patch may corrupt the data.
                                       For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -4621,24 +4198,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -4649,36 +4226,31 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service
-                                      readiness. Container will be removed from service
-                                      endpoints if the probe fails. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Periodic probe of container service readiness.
+                                      Container will be removed from service endpoints if the probe fails.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -4691,11 +4263,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -4705,9 +4278,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -4717,11 +4290,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -4739,36 +4310,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -4783,30 +4353,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -4817,14 +4384,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -4833,26 +4400,31 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Compute Resources required by this container.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -4868,9 +4440,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -4879,48 +4451,41 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: RestartPolicy defines the restart
-                                      behavior of individual containers in a pod.
-                                      This field may only be set for init containers,
-                                      and the only allowed value is "Always". For
-                                      non-init containers or when this field is not
-                                      specified, the restart behavior is defined by
-                                      the Pod's restart policy and the container type.
+                                    description: |-
+                                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                                      This field may only be set for init containers, and the only allowed value is "Always".
+                                      For non-init containers or when this field is not specified,
+                                      the restart behavior is defined by the Pod's restart policy and the container type.
                                     type: string
                                   securityContext:
-                                    description: 'SecurityContext defines the security
-                                      options the container should be run with. If
-                                      set, the fields of SecurityContext override
-                                      the equivalent fields of PodSecurityContext.
-                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    description: |-
+                                      SecurityContext defines the security options the container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -4938,68 +4503,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -5019,52 +4575,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -5072,60 +4620,46 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: StartupProbe indicates that the Pod
-                                      has successfully initialized. If specified,
-                                      no other probes are executed until this completes
-                                      successfully. If this probe fails, the Pod will
-                                      be restarted, just as if the livenessProbe failed.
+                                    description: |-
+                                      StartupProbe indicates that the Pod has successfully initialized.
+                                      If specified, no other probes are executed until this completes successfully.
+                                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -5138,11 +4672,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -5152,9 +4687,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -5164,11 +4699,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -5186,36 +4719,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -5230,72 +4762,62 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -5319,46 +4841,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -5366,47 +4887,54 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             nodeName:
-                              description: NodeName is a request to schedule this
-                                pod onto a specific node. If it is non-empty, the
-                                scheduler simply schedules this pod onto that node,
-                                assuming that it fits resource requirements.
+                              description: |-
+                                NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
+                                the scheduler simply schedules this pod onto that node, assuming that it fits resource
+                                requirements.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: 'NodeSelector is a selector which must
-                                be true for the pod to fit on a node. Selector which
-                                must match a node''s labels for the pod to be scheduled
-                                on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                              description: |-
+                                NodeSelector is a selector which must be true for the pod to fit on a node.
+                                Selector which must match a node's labels for the pod to be scheduled on that node.
+                                More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                               type: object
                               x-kubernetes-map-type: atomic
                             os:
-                              description: "Specifies the OS of the containers in
-                                the pod. Some pod and container fields are restricted
-                                if this is set. \n If the OS field is set to linux,
-                                the following fields must be unset: -securityContext.windowsOptions
-                                \n If the OS field is set to windows, following fields
-                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
-                                - spec.securityContext.seLinuxOptions - spec.securityContext."
+                              description: |-
+                                Specifies the OS of the containers in the pod.
+                                Some pod and container fields are restricted if this is set.
+
+
+                                If the OS field is set to linux, the following fields must be unset:
+                                -securityContext.windowsOptions
+
+
+                                If the OS field is set to windows, following fields must be unset:
+                                - spec.hostPID
+                                - spec.hostIPC
+                                - spec.hostUsers
+                                - spec.securityContext.seLinuxOptions
+                                - spec.securityContext.
                               properties:
                                 name:
-                                  description: 'Name is the name of the operating
-                                    system. The currently supported values are linux
-                                    and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                    Clients should expect to handle additional values
-                                    and treat unrecognized values in this field as
-                                    os: null'
+                                  description: |-
+                                    Name is the name of the operating system. The currently supported values are linux and windows.
+                                    Additional value may be defined in future and can be one of:
+                                    https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values and treat unrecognized values in this field as os: null
                                   type: string
                               required:
                               - name
@@ -5418,44 +4946,43 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: Overhead represents the resource overhead
-                                associated with running a pod for a given RuntimeClass.
-                                This field will be autopopulated at admission time
-                                by the RuntimeClass admission controller. If the RuntimeClass
-                                admission controller is enabled, overhead must not
-                                be set in Pod create requests. The RuntimeClass admission
-                                controller will reject Pod create requests which have
-                                the overhead already set.
+                              description: |-
+                                Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                                This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                                the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                                The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                                set.
                               type: object
                             preemptionPolicy:
-                              description: PreemptionPolicy is the Policy for preempting
-                                pods with lower priority. One of Never, PreemptLowerPriority.
+                              description: |-
+                                PreemptionPolicy is the Policy for preempting pods with lower priority.
+                                One of Never, PreemptLowerPriority.
                                 Defaults to PreemptLowerPriority if unset.
                               type: string
                             priority:
-                              description: The priority value. Various system components
-                                use this field to find the priority of the pod. When
-                                Priority Admission Controller is enabled, it prevents
-                                users from setting this field. The admission controller
-                                populates this field from PriorityClassName. The higher
-                                the value, the higher the priority.
+                              description: |-
+                                The priority value. Various system components use this field to find the
+                                priority of the pod. When Priority Admission Controller is enabled, it
+                                prevents users from setting this field. The admission controller populates
+                                this field from PriorityClassName.
+                                The higher the value, the higher the priority.
                               format: int32
                               type: integer
                             priorityClassName:
-                              description: If specified, indicates the pod's priority.
-                                "system-node-critical" and "system-cluster-critical"
-                                are two special keywords which indicate the highest
-                                priorities with the former being the highest priority.
-                                Any other name must be defined by creating a PriorityClass
-                                object with that name. If not specified, the pod priority
-                                will be default or zero if there is no default.
+                              description: |-
+                                If specified, indicates the pod's priority. "system-node-critical" and
+                                "system-cluster-critical" are two special keywords which indicate the
+                                highest priorities with the former being the highest priority. Any other
+                                name must be defined by creating a PriorityClass object with that name.
+                                If not specified, the pod priority will be default or zero if there is no
+                                default.
                               type: string
                             readinessGates:
-                              description: 'If specified, all readiness gates will
-                                be evaluated for pod readiness. A pod is ready when
-                                all its containers are ready AND all conditions specified
-                                in the readiness gates have status equal to "True"
-                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                              description: |-
+                                If specified, all readiness gates will be evaluated for pod readiness.
+                                A pod is ready when all its containers are ready AND
+                                all conditions specified in the readiness gates have status equal to "True"
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
                               items:
                                 description: PodReadinessGate contains the reference
                                   to a pod condition
@@ -5469,40 +4996,47 @@ spec:
                                 type: object
                               type: array
                             resourceClaims:
-                              description: "ResourceClaims defines which ResourceClaims
-                                must be allocated and reserved before the Pod is allowed
-                                to start. The resources will be made available to
-                                those containers which consume them by name. \n This
-                                is an alpha field and requires enabling the DynamicResourceAllocation
-                                feature gate. \n This field is immutable."
+                              description: |-
+                                ResourceClaims defines which ResourceClaims must be allocated
+                                and reserved before the Pod is allowed to start. The resources
+                                will be made available to those containers which consume them
+                                by name.
+
+
+                                This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate.
+
+
+                                This field is immutable.
                               items:
-                                description: PodResourceClaim references exactly one
-                                  ResourceClaim through a ClaimSource. It adds a name
-                                  to it that uniquely identifies the ResourceClaim
-                                  inside the Pod. Containers that need access to the
-                                  ResourceClaim reference it with this name.
+                                description: |-
+                                  PodResourceClaim references exactly one ResourceClaim through a ClaimSource.
+                                  It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                                  Containers that need access to the ResourceClaim reference it with this name.
                                 properties:
                                   name:
-                                    description: Name uniquely identifies this resource
-                                      claim inside the pod. This must be a DNS_LABEL.
+                                    description: |-
+                                      Name uniquely identifies this resource claim inside the pod.
+                                      This must be a DNS_LABEL.
                                     type: string
                                   source:
                                     description: Source describes where to find the
                                       ResourceClaim.
                                     properties:
                                       resourceClaimName:
-                                        description: ResourceClaimName is the name
-                                          of a ResourceClaim object in the same namespace
-                                          as this pod.
+                                        description: |-
+                                          ResourceClaimName is the name of a ResourceClaim object in the same
+                                          namespace as this pod.
                                         type: string
                                       resourceClaimTemplateName:
-                                        description: "ResourceClaimTemplateName is
-                                          the name of a ResourceClaimTemplate object
-                                          in the same namespace as this pod. \n The
-                                          template will be used to create a new ResourceClaim,
-                                          which will be bound to this pod. When this
-                                          pod is deleted, the ResourceClaim will also
-                                          be deleted."
+                                        description: |-
+                                          ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                          object in the same namespace as this pod.
+
+
+                                          The template will be used to create a new ResourceClaim, which will
+                                          be bound to this pod. When this pod is deleted, the ResourceClaim
+                                          will also be deleted.
                                         type: string
                                     type: object
                                 required:
@@ -5513,42 +5047,44 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             restartPolicy:
-                              description: 'Restart policy for all containers within
-                                the pod. One of Always, OnFailure, Never. In some
-                                contexts, only a subset of those values may be permitted.
-                                Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                              description: |-
+                                Restart policy for all containers within the pod.
+                                One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                                Default to Always.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass
-                                object in the node.k8s.io group, which should be used
-                                to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run. If unset
-                                or empty, the "legacy" RuntimeClass will be used,
-                                which is an implicit class with an empty definition
-                                that uses the default runtime handler. More info:
-                                https://git.k8s.'
+                              description: |-
+                                RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                                to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                                If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                                empty definition that uses the default runtime handler.
+                                More info: https://git.k8s.
                               type: string
                             schedulerName:
-                              description: If specified, the pod will be dispatched
-                                by specified scheduler. If not specified, the pod
-                                will be dispatched by default scheduler.
+                              description: |-
+                                If specified, the pod will be dispatched by specified scheduler.
+                                If not specified, the pod will be dispatched by default scheduler.
                               type: string
                             schedulingGates:
-                              description: "SchedulingGates is an opaque list of values
-                                that if specified will block scheduling the pod. If
-                                schedulingGates is not empty, the pod will stay in
-                                the SchedulingGated state and the scheduler will not
-                                attempt to schedule the pod. \n SchedulingGates can
-                                only be set at pod creation time, and be removed only
-                                afterwards. \n This is a beta feature enabled by the
-                                PodSchedulingReadiness feature gate."
+                              description: |-
+                                SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                                If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                                scheduler will not attempt to schedule the pod.
+
+
+                                SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+
+
+                                This is a beta feature enabled by the PodSchedulingReadiness feature gate.
                               items:
                                 description: PodSchedulingGate is associated to a
                                   Pod to guard its scheduling.
                                 properties:
                                   name:
-                                    description: Name of the scheduling gate. Each
-                                      scheduling gate must have a unique name field.
+                                    description: |-
+                                      Name of the scheduling gate.
+                                      Each scheduling gate must have a unique name field.
                                     type: string
                                 required:
                                 - name
@@ -5558,70 +5094,67 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             securityContext:
-                              description: 'SecurityContext holds pod-level security
-                                attributes and common container settings. Optional:
-                                Defaults to empty.  See type description for default
-                                values of each field.'
+                              description: |-
+                                SecurityContext holds pod-level security attributes and common container settings.
+                                Optional: Defaults to empty.  See type description for default values of each field.
                               properties:
                                 fsGroup:
-                                  description: "A special supplemental group that
-                                    applies to all containers in a pod. Some volume
-                                    types allow the Kubelet to change the ownership
-                                    of that volume to be owned by the pod: \n 1. The
-                                    owning GID will be the FSGroup 2. The setgid bit
-                                    is set (new files created in the volume will be
-                                    owned by FSGroup) 3."
+                                  description: |-
+                                    A special supplemental group that applies to all containers in a pod.
+                                    Some volume types allow the Kubelet to change the ownership of that volume
+                                    to be owned by the pod:
+
+
+                                    1. The owning GID will be the FSGroup
+                                    2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                    3.
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior
-                                    of changing ownership and permission of the volume
-                                    before being exposed inside Pod. This field will
-                                    only apply to volume types which support fsGroup
-                                    based ownership(and permissions). It will have
-                                    no effect on ephemeral volume types such as: secret,
-                                    configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified, "Always" is used.'
+                                  description: |-
+                                    fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                    before being exposed inside Pod. This field will only apply to
+                                    volume types which support fsGroup based ownership(and permissions).
+                                    It will have no effect on ephemeral volume types such as: secret, configmaps
+                                    and emptydir.
+                                    Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
                                   type: string
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in SecurityContext.  If set in
-                                    both SecurityContext and PodSecurityContext, the
-                                    value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in SecurityContext.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in SecurityContext.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence for that container.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    all containers. If unspecified, the container
-                                    runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                  description: |-
+                                    The SELinux context to be applied to all containers.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in SecurityContext.  If set in
+                                    both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                    takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5641,49 +5174,45 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by the containers
-                                    in this pod. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by the containers in this pod.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must be set if type is "Localhost".
-                                        Must NOT be set for any other type.
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first
-                                    process run in each container, in addition to
-                                    the container's primary GID, the fsGroup (if specified),
-                                    and group memberships defined in the container
-                                    image for the uid of the container process. If
-                                    unspecified, no additional groups are added to
-                                    any container.
+                                  description: |-
+                                    A list of groups applied to the first process run in each container, in addition
+                                    to the container's primary GID, the fsGroup (if specified), and group memberships
+                                    defined in the container image for the uid of the container process. If unspecified,
+                                    no additional groups are added to any container.
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls
-                                    used for the pod. Pods with unsupported sysctls
-                                    (by the container runtime) might fail to launch.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                    sysctls (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   items:
                                     description: Sysctl defines a kernel parameter
                                       to be set
@@ -5700,173 +5229,151 @@ spec:
                                     type: object
                                   type: array
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    within a container's SecurityContext will be used.
-                                    If set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options within a container's SecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        All of a Pod's containers must have the same
-                                        effective HostProcess value (it is not allowed
-                                        to have a mix of HostProcess containers and
-                                        non-HostProcess containers). In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: 'DeprecatedServiceAccount is a depreciated
-                                alias for ServiceAccountName. Deprecated: Use serviceAccountName
-                                instead.'
+                              description: |-
+                                DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+                                Deprecated: Use serviceAccountName instead.
                               type: string
                             serviceAccountName:
-                              description: 'ServiceAccountName is the name of the
-                                ServiceAccount to use to run this pod. More info:
-                                https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                              description: |-
+                                ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                               type: string
                             setHostnameAsFQDN:
-                              description: If true the pod's hostname will be configured
-                                as the pod's FQDN, rather than the leaf name (the
-                                default). In Linux containers, this means setting
-                                the FQDN in the hostname field of the kernel (the
-                                nodename field of struct utsname).
+                              description: |-
+                                If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                                In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between
-                                all of the containers in a pod. When this is set containers
-                                will be able to view and signal processes from other
-                                containers in the same pod, and the first process
-                                in each container will not be assigned PID 1. HostPID
-                                and ShareProcessNamespace cannot both be set. Optional:
-                                Default to false.'
+                              description: |-
+                                Share a single process namespace between all of the containers in a pod.
+                                When this is set containers will be able to view and signal processes from other containers
+                                in the same pod, and the first process in each container will not be assigned PID 1.
+                                HostPID and ShareProcessNamespace cannot both be set.
+                                Optional: Default to false.
                               type: boolean
                             subdomain:
-                              description: If specified, the fully qualified Pod hostname
-                                will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                                domain>". If not specified, the pod will not have
-                                a domainname at all.
+                              description: |-
+                                If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                                If not specified, the pod will not have a domainname at all.
                               type: string
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs
-                                to terminate gracefully. May be decreased in delete
-                                request. Value must be non-negative integer. The value
-                                zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down). If this value is nil,
-                                the default grace period will be used instead.
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                If this value is nil, the default grace period will be used instead.
                               format: int64
                               type: integer
                             tolerations:
                               description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to
-                                  tolerates any taint that matches the triple <key,value,effect>
-                                  using the matching operator <operator>.
+                                description: |-
+                                  The pod this Toleration is attached to tolerates any taint that matches
+                                  the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect
-                                      to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule,
-                                      PreferNoSchedule and NoExecute.
+                                    description: |-
+                                      Effect indicates the taint effect to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration
-                                      applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists;
-                                      this combination means to match all values and
-                                      all keys.
+                                    description: |-
+                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship
-                                      to the value. Valid operators are Exists and
-                                      Equal. Defaults to Equal. Exists is equivalent
-                                      to wildcard for value, so that a pod can tolerate
-                                      all taints of a particular category.
+                                    description: |-
+                                      Operator represents a key's relationship to the value.
+                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Exists is equivalent to wildcard for value, so that a pod can
+                                      tolerate all taints of a particular category.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the
-                                      period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is
-                                      ignored) tolerates the taint. By default, it
-                                      is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
+                                    description: |-
+                                      TolerationSeconds represents the period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                      negative values will be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration
-                                      matches to. If the operator is Exists, the value
-                                      should be empty, otherwise just a regular string.
+                                    description: |-
+                                      Value is the taint value the toleration matches to.
+                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how
-                                a group of pods ought to spread across topology domains.
-                                Scheduler will schedule pods in a way which abides
-                                by the constraints. All topologySpreadConstraints
-                                are ANDed.
+                              description: |-
+                                TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                                domains. Scheduler will schedule pods in a way which abides by the constraints.
+                                All topologySpreadConstraints are ANDed.
                               items:
                                 description: TopologySpreadConstraint specifies how
                                   to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: LabelSelector is used to find matching
-                                      pods. Pods that match this label selector are
-                                      counted to determine the number of pods in their
-                                      corresponding topology domain.
+                                    description: |-
+                                      LabelSelector is used to find matching pods.
+                                      Pods that match this label selector are counted to determine the number of pods
+                                      in their corresponding topology domain.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
                                           label selector requirements. The requirements
                                           are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -5879,91 +5386,79 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label
-                                      keys to select the pods over which spreading
-                                      will be calculated. The keys are used to lookup
-                                      values from the incoming pod labels, those key-value
-                                      labels are ANDed with labelSelector to select
-                                      the group of existing pods over which spreading
-                                      will be calculated for the incoming pod. The
-                                      same key is forbidden to exist in both MatchLabelKeys
-                                      and LabelSelector.
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select the pods over which
+                                      spreading will be calculated. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are ANDed with labelSelector
+                                      to select the group of existing pods over which spreading will be calculated
+                                      for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   maxSkew:
-                                    description: MaxSkew describes the degree to which
-                                      pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                                      it is the maximum permitted difference between
-                                      the number of matching pods in the target topology
-                                      and the global minimum. The global minimum is
-                                      the minimum number of matching pods in an eligible
-                                      domain or zero if the number of eligible domains
-                                      is less than MinDomains.
+                                    description: |-
+                                      MaxSkew describes the degree to which pods may be unevenly distributed.
+                                      When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                      between the number of matching pods in the target topology and the global minimum.
+                                      The global minimum is the minimum number of matching pods in an eligible domain
+                                      or zero if the number of eligible domains is less than MinDomains.
                                     format: int32
                                     type: integer
                                   minDomains:
-                                    description: MinDomains indicates a minimum number
-                                      of eligible domains. When the number of eligible
-                                      domains with matching topology keys is less
-                                      than minDomains, Pod Topology Spread treats
-                                      "global minimum" as 0, and then the calculation
-                                      of Skew is performed. And when the number of
-                                      eligible domains with matching topology keys
-                                      equals or greater than minDomains, this value
-                                      has no effect on scheduling.
+                                    description: |-
+                                      MinDomains indicates a minimum number of eligible domains.
+                                      When the number of eligible domains with matching topology keys is less than minDomains,
+                                      Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                      And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                      this value has no effect on scheduling.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: "NodeAffinityPolicy indicates how
-                                      we will treat Pod's nodeAffinity/nodeSelector
-                                      when calculating pod topology spread skew. Options
-                                      are: - Honor: only nodes matching nodeAffinity/nodeSelector
-                                      are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored. All nodes
-                                      are included in the calculations. \n If this
-                                      value is nil, the behavior is equivalent to
-                                      the Honor policy."
+                                    description: |-
+                                      NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                      when calculating pod topology spread skew. Options are:
+                                      - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                      - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                                      If this value is nil, the behavior is equivalent to the Honor policy.
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: "NodeTaintsPolicy indicates how we
-                                      will treat node taints when calculating pod
-                                      topology spread skew. Options are: - Honor:
-                                      nodes without taints, along with tainted nodes
-                                      for which the incoming pod has a toleration,
-                                      are included. - Ignore: node taints are ignored.
-                                      All nodes are included. \n If this value is
-                                      nil, the behavior is equivalent to the Ignore
-                                      policy."
+                                    description: |-
+                                      NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                      pod topology spread skew. Options are:
+                                      - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                      has a toleration, are included.
+                                      - Ignore: node taints are ignored. All nodes are included.
+
+
+                                      If this value is nil, the behavior is equivalent to the Ignore policy.
                                     type: string
                                   topologyKey:
-                                    description: TopologyKey is the key of node labels.
-                                      Nodes that have a label with this key and identical
-                                      values are considered to be in the same topology.
-                                      We consider each <key, value> as a "bucket",
-                                      and try to put balanced number of pods into
-                                      each bucket. We define a domain as a particular
-                                      instance of a topology.
+                                    description: |-
+                                      TopologyKey is the key of node labels. Nodes that have a label with this key
+                                      and identical values are considered to be in the same topology.
+                                      We consider each <key, value> as a "bucket", and try to put balanced number
+                                      of pods into each bucket.
+                                      We define a domain as a particular instance of a topology.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: WhenUnsatisfiable indicates how to
-                                      deal with a pod if it doesn't satisfy the spread
-                                      constraint. - DoNotSchedule (default) tells
-                                      the scheduler not to schedule it. - ScheduleAnyway
-                                      tells the scheduler to schedule the pod in any
-                                      location, but giving higher precedence to topologies
-                                      that would help reduce the skew.
+                                    description: |-
+                                      WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                      the spread constraint.
+                                      - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                      - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                        but giving higher precedence to topologies that would help reduce the
+                                        skew.
                                     type: string
                                 required:
                                 - maxSkew
@@ -5976,49 +5471,45 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: 'List of volumes that can be mounted by
-                                containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                              description: |-
+                                List of volumes that can be mounted by containers belonging to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes
                               items:
                                 description: Volume represents a named volume in a
                                   pod that may be accessed by any container in the
                                   pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'awsElasticBlockStore represents
-                                      an AWS Disk resource that is attached to a kubelet''s
-                                      host machine and then exposed to the pod. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    description: |-
+                                      awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       partition:
-                                        description: 'partition is the partition in
-                                          the volume that you want to mount. If omitted,
-                                          the default is to mount by volume name.
-                                          Examples: For volume /dev/sda1, you specify
-                                          the partition as "1". Similarly, the volume
-                                          partition for /dev/sda is "0" (or you can
-                                          leave the property empty).'
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'readOnly value true will force
-                                          the readOnly setting in VolumeMounts. More
-                                          info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: |-
+                                          readOnly value true will force the readOnly setting in VolumeMounts.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                         type: boolean
                                       volumeID:
-                                        description: 'volumeID is unique ID of the
-                                          persistent disk resource in AWS (Amazon
-                                          EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: |-
+                                          volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                         type: string
                                     required:
                                     - volumeID
@@ -6041,11 +5532,10 @@ spec:
                                           in the blob storage
                                         type: string
                                       fsType:
-                                        description: fsType is Filesystem type to
-                                          mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is Filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       kind:
                                         description: 'kind expected values are Shared:
@@ -6055,9 +5545,9 @@ spec:
                                           availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: readOnly Defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                     required:
                                     - diskName
@@ -6069,9 +5559,9 @@ spec:
                                       the pod.
                                     properties:
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretName:
                                         description: secretName is the  name of secret
@@ -6091,9 +5581,9 @@ spec:
                                       on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'monitors is Required: Monitors
-                                          is a collection of Ceph monitors More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          monitors is Required: Monitors is a collection of Ceph monitors
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         items:
                                           type: string
                                         type: array
@@ -6103,71 +5593,72 @@ spec:
                                           tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'readOnly is Optional: Defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.
-                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: boolean
                                       secretFile:
-                                        description: 'secretFile is Optional: SecretFile
-                                          is the path to key ring for User, default
-                                          is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: string
                                       secretRef:
-                                        description: 'secretRef is Optional: SecretRef
-                                          is reference to the authentication secret
-                                          for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       user:
-                                        description: 'user is optional: User is the
-                                          rados user name, default is admin More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          user is optional: User is the rados user name, default is admin
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'cinder represents a cinder volume
-                                      attached and mounted on kubelets host machine.
-                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    description: |-
+                                      cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: string
                                       readOnly:
-                                        description: 'readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is optional: points
-                                          to a secret object containing parameters
-                                          used to connect to OpenStack.'
+                                        description: |-
+                                          secretRef is optional: points to a secret object containing parameters used to connect
+                                          to OpenStack.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       volumeID:
-                                        description: 'volumeID used to identify the
-                                          volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          volumeID used to identify the volume in cinder.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: string
                                     required:
                                     - volumeID
@@ -6177,25 +5668,21 @@ spec:
                                       that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'defaultMode is optional: mode
-                                          bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          defaultMode is optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
-                                        description: items if unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          ConfigMap will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present.
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -6204,23 +5691,19 @@ spec:
                                               description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'mode is Optional: mode
-                                                bits used to set permissions on this
-                                                file. Must be an octal value between
-                                                0000 and 0777 or a decimal value between
-                                                0 and 511. YAML accepts both octal
-                                                and decimal values, JSON requires
-                                                decimal values for mode bits. If not
-                                                specified, the volume defaultMode
-                                                will be used.'
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
-                                              description: path is the relative path
-                                                of the file to map the key to. May
-                                                not be an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -6228,10 +5711,10 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: optional specify whether the
@@ -6245,48 +5728,43 @@ spec:
                                       by certain external CSI drivers (Beta feature).
                                     properties:
                                       driver:
-                                        description: driver is the name of the CSI
-                                          driver that handles this volume. Consult
-                                          with your admin for the correct name as
-                                          registered in the cluster.
+                                        description: |-
+                                          driver is the name of the CSI driver that handles this volume.
+                                          Consult with your admin for the correct name as registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: fsType to mount. Ex. "ext4",
-                                          "xfs", "ntfs". If not provided, the empty
-                                          value is passed to the associated CSI driver
-                                          which will determine the default filesystem
-                                          to apply.
+                                        description: |-
+                                          fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                          If not provided, the empty value is passed to the associated CSI driver
+                                          which will determine the default filesystem to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: nodePublishSecretRef is a reference
-                                          to the secret object containing sensitive
-                                          information to pass to the CSI driver to
-                                          complete the CSI NodePublishVolume and NodeUnpublishVolume
-                                          calls. This field is optional, and  may
-                                          be empty if no secret is required. If the
-                                          secret object contains more than one secret,
-                                          all secret references are passed.
+                                        description: |-
+                                          nodePublishSecretRef is a reference to the secret object containing
+                                          sensitive information to pass to the CSI driver to complete the CSI
+                                          NodePublishVolume and NodeUnpublishVolume calls.
+                                          This field is optional, and  may be empty if no secret is required. If the
+                                          secret object contains more than one secret, all secret references are passed.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       readOnly:
-                                        description: readOnly specifies a read-only
-                                          configuration for the volume. Defaults to
-                                          false (read/write).
+                                        description: |-
+                                          readOnly specifies a read-only configuration for the volume.
+                                          Defaults to false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: volumeAttributes stores driver-specific
-                                          properties that are passed to the CSI driver.
-                                          Consult your driver's documentation for
-                                          supported values.
+                                        description: |-
+                                          volumeAttributes stores driver-specific properties that are passed to the CSI
+                                          driver. Consult your driver's documentation for supported values.
                                         type: object
                                     required:
                                     - driver
@@ -6296,16 +5774,13 @@ spec:
                                       about the pod that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on
-                                          created files by default. Must be a Optional:
-                                          mode bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          Optional: mode bits to use on created files by default. Must be a
+                                          Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
@@ -6335,14 +5810,11 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file, must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.'
+                                              description: |-
+                                                Optional: mode bits used to set permissions on this file, must be an octal value
+                                                between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
@@ -6354,11 +5826,9 @@ spec:
                                                 path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                requests.cpu and requests.memory)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -6388,56 +5858,51 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'emptyDir represents a temporary
-                                      directory that shares a pod''s lifetime. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    description: |-
+                                      emptyDir represents a temporary directory that shares a pod's lifetime.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     properties:
                                       medium:
-                                        description: 'medium represents what type
-                                          of storage medium should back this directory.
-                                          The default is "" which means to use the
-                                          node''s default medium. Must be an empty
-                                          string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: |-
+                                          medium represents what type of storage medium should back this directory.
+                                          The default is "" which means to use the node's default medium.
+                                          Must be an empty string (default) or Memory.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'sizeLimit is the total amount
-                                          of local storage required for this EmptyDir
-                                          volume. The size limit is also applicable
-                                          for memory medium. The maximum usage on
-                                          memory medium EmptyDir would be the minimum
-                                          value between the SizeLimit specified here
-                                          and the sum of memory limits of all containers
-                                          in a pod. The default is nil which means
-                                          that the limit is undefined. More info:
-                                          https://kubernetes.'
+                                        description: |-
+                                          sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                          The size limit is also applicable for memory medium.
+                                          The maximum usage on memory medium EmptyDir would be the minimum value between
+                                          the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                          The default is nil which means that the limit is undefined.
+                                          More info: https://kubernetes.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: ephemeral represents a volume that
-                                      is handled by a cluster storage driver. The
-                                      volume's lifecycle is tied to the pod that defines
-                                      it - it will be created before the pod starts,
+                                    description: |-
+                                      ephemeral represents a volume that is handled by a cluster storage driver.
+                                      The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                                       and deleted when the pod is removed.
                                     properties:
                                       volumeClaimTemplate:
-                                        description: Will be used to create a stand-alone
-                                          PVC to provision the volume. The pod in
-                                          which this EphemeralVolumeSource is embedded
-                                          will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.  The
-                                          name of the PVC will be `<pod name>-<volume
-                                          name>` where `<volume name>` is the name
-                                          from the `PodSpec.Volumes` array entry.
+                                        description: |-
+                                          Will be used to create a stand-alone PVC to provision the volume.
+                                          The pod in which this EphemeralVolumeSource is embedded will be the
+                                          owner of the PVC, i.e. the PVC will be deleted together with the
+                                          pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                          `<volume name>` is the name from the `PodSpec.Volumes` array
+                                          entry.
                                         properties:
                                           metadata:
-                                            description: May contain labels and annotations
-                                              that will be copied into the PVC when
-                                              creating it. No other fields are allowed
-                                              and will be rejected during validation.
+                                            description: |-
+                                              May contain labels and annotations that will be copied into the PVC
+                                              when creating it. No other fields are allowed and will be rejected during
+                                              validation.
                                             properties:
                                               annotations:
                                                 additionalProperties:
@@ -6457,39 +5922,32 @@ spec:
                                                 type: string
                                             type: object
                                           spec:
-                                            description: The specification for the
-                                              PersistentVolumeClaim. The entire content
-                                              is copied unchanged into the PVC that
-                                              gets created from this template. The
-                                              same fields as in a PersistentVolumeClaim
+                                            description: |-
+                                              The specification for the PersistentVolumeClaim. The entire content is
+                                              copied unchanged into the PVC that gets created from this
+                                              template. The same fields as in a PersistentVolumeClaim
                                               are also valid here.
                                             properties:
                                               accessModes:
-                                                description: 'accessModes contains
-                                                  the desired access modes the volume
-                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                description: |-
+                                                  accessModes contains the desired access modes the volume should have.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                                 items:
                                                   type: string
                                                 type: array
                                               dataSource:
-                                                description: 'dataSource field can
-                                                  be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                description: |-
+                                                  dataSource field can be used to specify either:
+                                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                                   * An existing PVC (PersistentVolumeClaim)
-                                                  If the provisioner or an external
-                                                  controller can support the specified
-                                                  data source, it will create a new
-                                                  volume based on the contents of
-                                                  the specified data source.'
+                                                  If the provisioner or an external controller can support the specified data source,
+                                                  it will create a new volume based on the contents of the specified data source.
                                                 properties:
                                                   apiGroup:
-                                                    description: APIGroup is the group
-                                                      for the resource being referenced.
-                                                      If APIGroup is not specified,
-                                                      the specified Kind must be in
-                                                      the core API group. For any
-                                                      other third-party types, APIGroup
-                                                      is required.
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
                                                     type: string
                                                   kind:
                                                     description: Kind is the type
@@ -6505,26 +5963,19 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               dataSourceRef:
-                                                description: dataSourceRef specifies
-                                                  the object from which to populate
-                                                  the volume with data, if a non-empty
-                                                  volume is desired. This may be any
-                                                  object from a non-empty API group
-                                                  (non core object) or a PersistentVolumeClaim
-                                                  object. When this field is specified,
-                                                  volume binding will only succeed
-                                                  if the type of the specified object
-                                                  matches some installed volume populator
-                                                  or dynamic provisioner.
+                                                description: |-
+                                                  dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                                  volume is desired. This may be any object from a non-empty API group (non
+                                                  core object) or a PersistentVolumeClaim object.
+                                                  When this field is specified, volume binding will only succeed if the type of
+                                                  the specified object matches some installed volume populator or dynamic
+                                                  provisioner.
                                                 properties:
                                                   apiGroup:
-                                                    description: APIGroup is the group
-                                                      for the resource being referenced.
-                                                      If APIGroup is not specified,
-                                                      the specified Kind must be in
-                                                      the core API group. For any
-                                                      other third-party types, APIGroup
-                                                      is required.
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
                                                     type: string
                                                   kind:
                                                     description: Kind is the type
@@ -6535,54 +5986,42 @@ spec:
                                                       of resource being referenced
                                                     type: string
                                                   namespace:
-                                                    description: Namespace is the
-                                                      namespace of resource being
-                                                      referenced Note that when a
-                                                      namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
-                                                      object is required in the referent
-                                                      namespace to allow that namespace's
-                                                      owner to accept the reference.
-                                                      See the ReferenceGrant documentation
-                                                      for details. (Alpha) This field
-                                                      requires the CrossNamespaceVolumeDataSource
-                                                      feature gate to be enabled.
+                                                    description: |-
+                                                      Namespace is the namespace of resource being referenced
+                                                      Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                      (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                                     type: string
                                                 required:
                                                 - kind
                                                 - name
                                                 type: object
                                               resources:
-                                                description: 'resources represents
-                                                  the minimum resources the volume
-                                                  should have. If RecoverVolumeExpansionFailure
-                                                  feature is enabled users are allowed
-                                                  to specify resource requirements
-                                                  that are lower than previous value
-                                                  but must still be higher than capacity
-                                                  recorded in the status field of
-                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                description: |-
+                                                  resources represents the minimum resources the volume should have.
+                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  that are lower than previous value but must still be higher than capacity recorded in the
+                                                  status field of the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                                 properties:
                                                   claims:
-                                                    description: "Claims lists the
-                                                      names of resources, defined
-                                                      in spec.resourceClaims, that
-                                                      are used by this container.
-                                                      \n This is an alpha field and
-                                                      requires enabling the DynamicResourceAllocation
-                                                      feature gate. \n This field
-                                                      is immutable. It can only be
-                                                      set for containers."
+                                                    description: |-
+                                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                                      that are used by this container.
+
+
+                                                      This is an alpha field and requires enabling the
+                                                      DynamicResourceAllocation feature gate.
+
+
+                                                      This field is immutable. It can only be set for containers.
                                                     items:
                                                       description: ResourceClaim references
                                                         one entry in PodSpec.ResourceClaims.
                                                       properties:
                                                         name:
-                                                          description: Name must match
-                                                            the name of one entry
-                                                            in pod.spec.resourceClaims
-                                                            of the Pod where this
-                                                            field is used. It makes
-                                                            that resource available
+                                                          description: |-
+                                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                                            the Pod where this field is used. It makes that resource available
                                                             inside a container.
                                                           type: string
                                                       required:
@@ -6599,10 +6038,9 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: 'Limits describes
-                                                      the maximum amount of compute
-                                                      resources allowed. More info:
-                                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    description: |-
+                                                      Limits describes the maximum amount of compute resources allowed.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -6611,15 +6049,11 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: 'Requests describes
-                                                      the minimum amount of compute
-                                                      resources required. If Requests
-                                                      is omitted for a container,
-                                                      it defaults to Limits if that
-                                                      is explicitly specified, otherwise
-                                                      to an implementation-defined
-                                                      value. Requests cannot exceed
-                                                      Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    description: |-
+                                                      Requests describes the minimum amount of compute resources required.
+                                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                 type: object
                                               selector:
@@ -6632,11 +6066,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -6644,23 +6076,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -6672,28 +6097,22 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               storageClassName:
-                                                description: 'storageClassName is
-                                                  the name of the StorageClass required
-                                                  by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                description: |-
+                                                  storageClassName is the name of the StorageClass required by the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                                 type: string
                                               volumeMode:
-                                                description: volumeMode defines what
-                                                  type of volume is required by the
-                                                  claim. Value of Filesystem is implied
-                                                  when not included in claim spec.
+                                                description: |-
+                                                  volumeMode defines what type of volume is required by the claim.
+                                                  Value of Filesystem is implied when not included in claim spec.
                                                 type: string
                                               volumeName:
                                                 description: volumeName is the binding
@@ -6711,13 +6130,11 @@ spec:
                                       and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. TODO: how do we prevent
-                                          errors in the filesystem from compromising
-                                          the machine'
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       lun:
                                         description: 'lun is Optional: FC target lun
@@ -6725,9 +6142,9 @@ spec:
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'readOnly is Optional: Defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.'
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       targetWWNs:
                                         description: 'targetWWNs is Optional: FC target
@@ -6736,29 +6153,27 @@ spec:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'wwids Optional: FC volume world
-                                          wide identifiers (wwids) Either wwids or
-                                          combination of targetWWNs and lun must be
-                                          set, but not both simultaneously.'
+                                        description: |-
+                                          wwids Optional: FC volume world wide identifiers (wwids)
+                                          Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: flexVolume represents a generic volume
-                                      resource that is provisioned/attached using
-                                      an exec based plugin.
+                                    description: |-
+                                      flexVolume represents a generic volume resource that is
+                                      provisioned/attached using an exec based plugin.
                                     properties:
                                       driver:
                                         description: driver is the name of the driver
                                           to use for this volume.
                                         type: string
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". The default filesystem depends
-                                          on FlexVolume script.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
@@ -6767,24 +6182,23 @@ spec:
                                           holds extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'readOnly is Optional: defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.'
+                                        description: |-
+                                          readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is Optional: secretRef
-                                          is reference to the secret object containing
-                                          sensitive information to pass to the plugin
-                                          scripts. This may be empty if no secret
-                                          object is specified. If the secret object
-                                          contains more than one secret, all secrets
-                                          are passed to the plugin scripts.'
+                                        description: |-
+                                          secretRef is Optional: secretRef is reference to the secret object containing
+                                          sensitive information to pass to the plugin scripts. This may be
+                                          empty if no secret object is specified. If the secret object
+                                          contains more than one secret, all secrets are passed to the plugin
+                                          scripts.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -6797,9 +6211,9 @@ spec:
                                       on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: datasetName is Name of the dataset
-                                          stored as metadata -> name on the dataset
-                                          for Flocker should be considered as deprecated
+                                        description: |-
+                                          datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                          should be considered as deprecated
                                         type: string
                                       datasetUUID:
                                         description: datasetUUID is the UUID of the
@@ -6808,60 +6222,55 @@ spec:
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'gcePersistentDisk represents a GCE
-                                      Disk resource that is attached to a kubelet''s
-                                      host machine and then exposed to the pod. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    description: |-
+                                      gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                     properties:
                                       fsType:
-                                        description: 'fsType is filesystem type of
-                                          the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       partition:
-                                        description: 'partition is the partition in
-                                          the volume that you want to mount. If omitted,
-                                          the default is to mount by volume name.
-                                          Examples: For volume /dev/sda1, you specify
-                                          the partition as "1". Similarly, the volume
-                                          partition for /dev/sda is "0" (or you can
-                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'pdName is unique name of the
-                                          PD resource in GCE. Used to identify the
-                                          disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         type: boolean
                                     required:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'gitRepo represents a git repository
-                                      at a particular revision. DEPRECATED: GitRepo
-                                      is deprecated. To provision a container with
-                                      a git repo, mount an EmptyDir into an InitContainer
-                                      that clones the repo using git, then mount the
-                                      EmptyDir into the Pod''s container.'
+                                    description: |-
+                                      gitRepo represents a git repository at a particular revision.
+                                      DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                      EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                      into the Pod's container.
                                     properties:
                                       directory:
-                                        description: directory is the target directory
-                                          name. Must not contain or start with '..'.  If
-                                          '.' is supplied, the volume directory will
-                                          be the git repository.  Otherwise, if specified,
-                                          the volume will contain the git repository
-                                          in the subdirectory with the given name.
+                                        description: |-
+                                          directory is the target directory name.
+                                          Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                          git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                          the subdirectory with the given name.
                                         type: string
                                       repository:
                                         description: repository is the URL
@@ -6874,54 +6283,58 @@ spec:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'glusterfs represents a Glusterfs
-                                      mount on the host that shares a pod''s lifetime.
-                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                    description: |-
+                                      glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                     properties:
                                       endpoints:
-                                        description: 'endpoints is the endpoint name
-                                          that details Glusterfs topology. More info:
-                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          endpoints is the endpoint name that details Glusterfs topology.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: string
                                       path:
-                                        description: 'path is the Glusterfs volume
-                                          path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          path is the Glusterfs volume path.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          Glusterfs volume to be mounted with read-only
-                                          permissions. Defaults to false. More info:
-                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: boolean
                                     required:
                                     - endpoints
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'hostPath represents a pre-existing
-                                      file or directory on the host machine that is
-                                      directly exposed to the container. This is generally
-                                      used for system agents or other privileged things
-                                      that are allowed to see the host machine. Most
-                                      containers will NOT need this. More info: https://kubernetes.'
+                                    description: |-
+                                      hostPath represents a pre-existing file or directory on the host
+                                      machine that is directly exposed to the container. This is generally
+                                      used for system agents or other privileged things that are allowed
+                                      to see the host machine. Most containers will NOT need this.
+                                      More info: https://kubernetes.
                                     properties:
                                       path:
-                                        description: 'path of the directory on the
-                                          host. If the path is a symlink, it will
-                                          follow the link to the real path. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        description: |-
+                                          path of the directory on the host.
+                                          If the path is a symlink, it will follow the link to the real path.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                         type: string
                                       type:
-                                        description: 'type for HostPath Volume Defaults
-                                          to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        description: |-
+                                          type for HostPath Volume
+                                          Defaults to ""
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'iscsi represents an ISCSI Disk resource
-                                      that is attached to a kubelet''s host machine
-                                      and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                    description: |-
+                                      iscsi represents an ISCSI Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://examples.k8s.io/volumes/iscsi/README.md
                                     properties:
                                       chapAuthDiscovery:
                                         description: chapAuthDiscovery defines whether
@@ -6932,31 +6345,27 @@ spec:
                                           support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       initiatorName:
-                                        description: initiatorName is the custom iSCSI
-                                          Initiator Name. If initiatorName is specified
-                                          with iscsiInterface simultaneously, new
-                                          iSCSI interface <target portal>:<volume
-                                          name> will be created for the connection.
+                                        description: |-
+                                          initiatorName is the custom iSCSI Initiator Name.
+                                          If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                          <target portal>:<volume name> will be created for the connection.
                                         type: string
                                       iqn:
                                         description: iqn is the target iSCSI Qualified
                                           Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iscsiInterface is the interface
-                                          Name that uses an iSCSI transport. Defaults
-                                          to 'default' (tcp).
+                                        description: |-
+                                          iscsiInterface is the interface Name that uses an iSCSI transport.
+                                          Defaults to 'default' (tcp).
                                         type: string
                                       lun:
                                         description: lun represents iSCSI Target Lun
@@ -6964,35 +6373,33 @@ spec:
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: portals is the iSCSI Target Portal
-                                          List. The portal is either an IP or ip_addr:port
-                                          if the port is other than default (typically
-                                          TCP ports 860 and 3260).
+                                        description: |-
+                                          portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false.
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
                                         type: boolean
                                       secretRef:
                                         description: secretRef is the CHAP Secret
                                           for iSCSI target and initiator authentication
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       targetPortal:
-                                        description: targetPortal is iSCSI Target
-                                          Portal. The Portal is either an IP or ip_addr:port
-                                          if the port is other than default (typically
-                                          TCP ports 860 and 3260).
+                                        description: |-
+                                          targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -7000,45 +6407,51 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'name of the volume. Must be a DNS_LABEL
-                                      and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: |-
+                                      name of the volume.
+                                      Must be a DNS_LABEL and unique within the pod.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                   nfs:
-                                    description: 'nfs represents an NFS mount on the
-                                      host that shares a pod''s lifetime More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    description: |-
+                                      nfs represents an NFS mount on the host that shares a pod's lifetime
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                     properties:
                                       path:
-                                        description: 'path that is exported by the
-                                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          path that is exported by the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          NFS export to be mounted with read-only
-                                          permissions. Defaults to false. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          readOnly here will force the NFS export to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: boolean
                                       server:
-                                        description: 'server is the hostname or IP
-                                          address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          server is the hostname or IP address of the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: string
                                     required:
                                     - path
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'persistentVolumeClaimVolumeSource
-                                      represents a reference to a PersistentVolumeClaim
-                                      in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    description: |-
+                                      persistentVolumeClaimVolumeSource represents a reference to a
+                                      PersistentVolumeClaim in the same namespace.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                     properties:
                                       claimName:
-                                        description: 'claimName is the name of a PersistentVolumeClaim
-                                          in the same namespace as the pod using this
-                                          volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        description: |-
+                                          claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                         type: string
                                       readOnly:
-                                        description: readOnly Will force the ReadOnly
-                                          setting in VolumeMounts. Default false.
+                                        description: |-
+                                          readOnly Will force the ReadOnly setting in VolumeMounts.
+                                          Default false.
                                         type: boolean
                                     required:
                                     - claimName
@@ -7049,11 +6462,10 @@ spec:
                                       mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       pdID:
                                         description: pdID is the ID that identifies
@@ -7068,16 +6480,15 @@ spec:
                                       machine
                                     properties:
                                       fsType:
-                                        description: fSType represents the filesystem
-                                          type to mount Must be a filesystem type
-                                          supported by the host operating system.
-                                          Ex. "ext4", "xfs". Implicitly inferred to
-                                          be "ext4" if unspecified.
+                                        description: |-
+                                          fSType represents the filesystem type to mount
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       volumeID:
                                         description: volumeID uniquely identifies
@@ -7091,14 +6502,11 @@ spec:
                                       secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: defaultMode are the mode bits
-                                          used to set permissions on created files
-                                          by default. Must be an octal value between
-                                          0000 and 0777 or a decimal value between
-                                          0 and 511. YAML accepts both octal and decimal
-                                          values, JSON requires decimal values for
-                                          mode bits. Directories within the path are
-                                          not affected by this setting.
+                                        description: |-
+                                          defaultMode are the mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       sources:
@@ -7113,15 +6521,12 @@ spec:
                                                 the configMap data to project
                                               properties:
                                                 items:
-                                                  description: items if unspecified,
-                                                    each key-value pair in the Data
-                                                    field of the referenced ConfigMap
-                                                    will be projected into the volume
-                                                    as a file whose name is the key
-                                                    and content is the value. If specified,
-                                                    the listed keys will be projected
-                                                    into the specified paths, and
-                                                    unlisted keys will not be present.
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    ConfigMap will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7131,27 +6536,19 @@ spec:
                                                           to project.
                                                         type: string
                                                       mode:
-                                                        description: 'mode is Optional:
-                                                          mode bits used to set permissions
-                                                          on this file. Must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: path is the relative
-                                                          path of the file to map
-                                                          the key to. May not be an
-                                                          absolute path. May not contain
-                                                          the path element '..'. May
-                                                          not start with the string
-                                                          '..'.
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -7159,10 +6556,10 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: optional specify whether
@@ -7206,17 +6603,11 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
-                                                          on this file, must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7231,12 +6622,9 @@ spec:
                                                           ''..'''
                                                         type: string
                                                       resourceFieldRef:
-                                                        description: 'Selects a resource
-                                                          of the container: only resources
-                                                          limits and requests (limits.cpu,
-                                                          limits.memory, requests.cpu
-                                                          and requests.memory) are
-                                                          currently supported.'
+                                                        description: |-
+                                                          Selects a resource of the container: only resources limits and requests
+                                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                         properties:
                                                           containerName:
                                                             description: 'Container
@@ -7271,15 +6659,12 @@ spec:
                                                 the secret data to project
                                               properties:
                                                 items:
-                                                  description: items if unspecified,
-                                                    each key-value pair in the Data
-                                                    field of the referenced Secret
-                                                    will be projected into the volume
-                                                    as a file whose name is the key
-                                                    and content is the value. If specified,
-                                                    the listed keys will be projected
-                                                    into the specified paths, and
-                                                    unlisted keys will not be present.
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    Secret will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7289,27 +6674,19 @@ spec:
                                                           to project.
                                                         type: string
                                                       mode:
-                                                        description: 'mode is Optional:
-                                                          mode bits used to set permissions
-                                                          on this file. Must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: path is the relative
-                                                          path of the file to map
-                                                          the key to. May not be an
-                                                          absolute path. May not contain
-                                                          the path element '..'. May
-                                                          not start with the string
-                                                          '..'.
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -7317,10 +6694,10 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: optional field specify
@@ -7335,35 +6712,26 @@ spec:
                                                 data to project
                                               properties:
                                                 audience:
-                                                  description: audience is the intended
-                                                    audience of the token. A recipient
-                                                    of a token must identify itself
-                                                    with an identifier specified in
-                                                    the audience of the token, and
-                                                    otherwise should reject the token.
-                                                    The audience defaults to the identifier
-                                                    of the apiserver.
+                                                  description: |-
+                                                    audience is the intended audience of the token. A recipient of a token
+                                                    must identify itself with an identifier specified in the audience of the
+                                                    token, and otherwise should reject the token. The audience defaults to the
+                                                    identifier of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: expirationSeconds is
-                                                    the requested duration of validity
-                                                    of the service account token.
-                                                    As the token approaches expiration,
-                                                    the kubelet volume plugin will
-                                                    proactively rotate the service
-                                                    account token. The kubelet will
-                                                    start trying to rotate the token
-                                                    if the token is older than 80
-                                                    percent of its time to live or
-                                                    if the token is older than 24
-                                                    hours.Defaults to 1 hour and must
-                                                    be at least 10 minutes.
+                                                  description: |-
+                                                    expirationSeconds is the requested duration of validity of the service
+                                                    account token. As the token approaches expiration, the kubelet volume
+                                                    plugin will proactively rotate the service account token. The kubelet will
+                                                    start trying to rotate the token if the token is older than 80 percent of
+                                                    its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                    and must be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: path is the path relative
-                                                    to the mount point of the file
-                                                    to project the token into.
+                                                  description: |-
+                                                    path is the path relative to the mount point of the file to project the
+                                                    token into.
                                                   type: string
                                               required:
                                               - path
@@ -7376,29 +6744,29 @@ spec:
                                       on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: group to map volume access to
+                                        description: |-
+                                          group to map volume access to
                                           Default is no group
                                         type: string
                                       readOnly:
-                                        description: readOnly here will force the
-                                          Quobyte volume to be mounted with read-only
-                                          permissions. Defaults to false.
+                                        description: |-
+                                          readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                          Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: registry represents a single
-                                          or multiple Quobyte Registry services specified
-                                          as a string as host:port pair (multiple
-                                          entries are separated with commas) which
-                                          acts as the central registry for volumes
+                                        description: |-
+                                          registry represents a single or multiple Quobyte Registry services
+                                          specified as a string as host:port pair (multiple entries are separated with commas)
+                                          which acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: tenant owning the given Quobyte
-                                          volume in the Backend Used with dynamically
-                                          provisioned Quobyte volumes, value is set
-                                          by the plugin
+                                        description: |-
+                                          tenant owning the given Quobyte volume in the Backend
+                                          Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                         type: string
                                       user:
-                                        description: user to map volume access to
+                                        description: |-
+                                          user to map volume access to
                                           Defaults to serivceaccount user
                                         type: string
                                       volume:
@@ -7410,61 +6778,68 @@ spec:
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'rbd represents a Rados Block Device
-                                      mount on the host that shares a pod''s lifetime.
-                                      More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                    description: |-
+                                      rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       image:
-                                        description: 'image is the rados image name.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       keyring:
-                                        description: 'keyring is the path to key ring
-                                          for RBDUser. Default is /etc/ceph/keyring.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          keyring is the path to key ring for RBDUser.
+                                          Default is /etc/ceph/keyring.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       monitors:
-                                        description: 'monitors is a collection of
-                                          Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          monitors is a collection of Ceph monitors.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'pool is the rados pool name.
-                                          Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          pool is the rados pool name.
+                                          Default is rbd.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is name of the authentication
-                                          secret for RBDUser. If provided overrides
-                                          keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          secretRef is name of the authentication secret for RBDUser. If provided
+                                          overrides keyring.
+                                          Default is nil.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       user:
-                                        description: 'user is the rados user name.
-                                          Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          user is the rados user name.
+                                          Default is admin.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                     required:
                                     - image
@@ -7475,10 +6850,11 @@ spec:
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Default is "xfs".
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs".
+                                          Default is "xfs".
                                         type: string
                                       gateway:
                                         description: gateway is the host address of
@@ -7490,21 +6866,20 @@ spec:
                                           configured storage.
                                         type: string
                                       readOnly:
-                                        description: readOnly Defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: secretRef references to the secret
-                                          for ScaleIO user and other sensitive information.
-                                          If this is not provided, Login operation
-                                          will fail.
+                                        description: |-
+                                          secretRef references to the secret for ScaleIO user and other
+                                          sensitive information. If this is not provided, Login operation will fail.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -7514,9 +6889,9 @@ spec:
                                           false
                                         type: boolean
                                       storageMode:
-                                        description: storageMode indicates whether
-                                          the storage for a volume should be ThickProvisioned
-                                          or ThinProvisioned. Default is ThinProvisioned.
+                                        description: |-
+                                          storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                          Default is ThinProvisioned.
                                         type: string
                                       storagePool:
                                         description: storagePool is the ScaleIO Storage
@@ -7527,9 +6902,9 @@ spec:
                                           system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: volumeName is the name of a volume
-                                          already created in the ScaleIO system that
-                                          is associated with this volume source.
+                                        description: |-
+                                          volumeName is the name of a volume already created in the ScaleIO system
+                                          that is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -7537,29 +6912,26 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'secret represents a secret that
-                                      should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    description: |-
+                                      secret represents a secret that should populate this volume.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                     properties:
                                       defaultMode:
-                                        description: 'defaultMode is Optional: mode
-                                          bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values
+                                          for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
-                                        description: items If unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          Secret will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present.
+                                        description: |-
+                                          items If unspecified, each key-value pair in the Data field of the referenced
+                                          Secret will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -7568,23 +6940,19 @@ spec:
                                               description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'mode is Optional: mode
-                                                bits used to set permissions on this
-                                                file. Must be an octal value between
-                                                0000 and 0777 or a decimal value between
-                                                0 and 511. YAML accepts both octal
-                                                and decimal values, JSON requires
-                                                decimal values for mode bits. If not
-                                                specified, the volume defaultMode
-                                                will be used.'
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
-                                              description: path is the relative path
-                                                of the file to map the key to. May
-                                                not be an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -7596,9 +6964,9 @@ spec:
                                           the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'secretName is the name of the
-                                          secret in the pod''s namespace to use. More
-                                          info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        description: |-
+                                          secretName is the name of the secret in the pod's namespace to use.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                         type: string
                                     type: object
                                   storageos:
@@ -7606,45 +6974,41 @@ spec:
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: secretRef specifies the secret
-                                          to use for obtaining the StorageOS API credentials.  If
-                                          not specified, default values will be attempted.
+                                        description: |-
+                                          secretRef specifies the secret to use for obtaining the StorageOS API
+                                          credentials.  If not specified, default values will be attempted.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       volumeName:
-                                        description: volumeName is the human-readable
-                                          name of the StorageOS volume.  Volume names
-                                          are only unique within a namespace.
+                                        description: |-
+                                          volumeName is the human-readable name of the StorageOS volume.  Volume
+                                          names are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: volumeNamespace specifies the
-                                          scope of the volume within StorageOS.  If
-                                          no namespace is specified then the Pod's
-                                          namespace will be used.  This allows the
-                                          Kubernetes name scoping to be mirrored within
-                                          StorageOS for tighter integration. Set VolumeName
-                                          to any name to override the default behaviour.
-                                          Set to "default" if you are not using namespaces
-                                          within StorageOS.
+                                        description: |-
+                                          volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                          namespace is specified then the Pod's namespace will be used.  This allows the
+                                          Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                          Set VolumeName to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces within StorageOS.
                                         type: string
                                     type: object
                                   vsphereVolume:
@@ -7653,11 +7017,10 @@ spec:
                                       machine
                                     properties:
                                       fsType:
-                                        description: fsType is filesystem type to
-                                          mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
                                         description: storagePolicyID is the storage
@@ -7684,18 +7047,20 @@ spec:
                           type: object
                       type: object
                   type: object
-                description: '`MPIReplicaSpecs` contains maps from `MPIReplicaType`
-                  to `ReplicaSpec` that specify the MPI replicas to run.'
+                description: |-
+                  `MPIReplicaSpecs` contains maps from `MPIReplicaType` to `ReplicaSpec` that
+                  specify the MPI replicas to run.
                 type: object
               runPolicy:
-                description: '`RunPolicy` encapsulates various runtime policies of
-                  the distributed training job, for example how to clean up resources
-                  and how long the job can stay active.'
+                description: |-
+                  `RunPolicy` encapsulates various runtime policies of the distributed training
+                  job, for example how to clean up resources and how long the job can stay
+                  active.
                 properties:
                   activeDeadlineSeconds:
-                    description: Specifies the duration in seconds relative to the
-                      startTime that the job may be active before the system tries
-                      to terminate it; value must be positive integer.
+                    description: |-
+                      Specifies the duration in seconds relative to the startTime that the job may be active
+                      before the system tries to terminate it; value must be positive integer.
                     format: int64
                     type: integer
                   backoffLimit:
@@ -7704,8 +7069,9 @@ spec:
                     format: int32
                     type: integer
                   cleanPodPolicy:
-                    description: CleanPodPolicy defines the policy to kill pods after
-                      the job completes. Default to None.
+                    description: |-
+                      CleanPodPolicy defines the policy to kill pods after the job completes.
+                      Default to None.
                     type: string
                   schedulingPolicy:
                     description: SchedulingPolicy defines the policy related to scheduling,
@@ -7732,23 +7098,26 @@ spec:
                     type: object
                   suspend:
                     default: false
-                    description: suspend specifies whether the Job controller should
-                      create Pods or not. If a Job is created with suspend set to
-                      true, no Pods are created by the Job controller. If a Job is
-                      suspended after creation (i.e. the flag goes from false to true),
-                      the Job controller will delete all active Pods and PodGroups
-                      associated with this Job. Users must design their workload to
-                      gracefully handle this.
+                    description: |-
+                      suspend specifies whether the Job controller should create Pods or not.
+                      If a Job is created with suspend set to true, no Pods are created by
+                      the Job controller. If a Job is suspended after creation (i.e. the
+                      flag goes from false to true), the Job controller will delete all
+                      active Pods and PodGroups associated with this Job.
+                      Users must design their workload to gracefully handle this.
                     type: boolean
                   ttlSecondsAfterFinished:
-                    description: TTLSecondsAfterFinished is the TTL to clean up jobs.
+                    description: |-
+                      TTLSecondsAfterFinished is the TTL to clean up jobs.
                       It may take extra ReconcilePeriod seconds for the cleanup, since
-                      reconcile gets called periodically. Default to infinite.
+                      reconcile gets called periodically.
+                      Default to infinite.
                     format: int32
                     type: integer
                 type: object
               slotsPerWorker:
-                description: Specifies the number of slots per worker used in hostfile.
+                description: |-
+                  Specifies the number of slots per worker used in hostfile.
                   Defaults to 1.
                 format: int32
                 type: integer
@@ -7760,8 +7129,9 @@ spec:
               Job.
             properties:
               completionTime:
-                description: Represents time when the job was completed. It is not
-                  guaranteed to be set in happens-before order across separate operations.
+                description: |-
+                  Represents time when the job was completed. It is not guaranteed to
+                  be set in happens-before order across separate operations.
                   It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
@@ -7799,9 +7169,10 @@ spec:
                   type: object
                 type: array
               lastReconcileTime:
-                description: Represents last time when the job was reconciled. It
-                  is not guaranteed to be set in happens-before order across separate
-                  operations. It is represented in RFC3339 form and is in UTC.
+                description: |-
+                  Represents last time when the job was reconciled. It is not guaranteed to
+                  be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               replicaStatuses:
@@ -7824,25 +7195,25 @@ spec:
                           description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -7854,33 +7225,33 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     selector:
-                      description: A Selector is a label query over a set of resources.
-                        The result of matchLabels and matchExpressions are ANDed.
-                        An empty Selector matches all objects. A null Selector matches
-                        no objects.
+                      description: |-
+                        A Selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty Selector matches all objects. A null
+                        Selector matches no objects.
                       type: string
                     succeeded:
                       description: The number of pods which reached phase Succeeded.
                       format: int32
                       type: integer
                   type: object
-                description: ReplicaStatuses is map of ReplicaType and ReplicaStatus,
+                description: |-
+                  ReplicaStatuses is map of ReplicaType and ReplicaStatus,
                   specifies the status of each replica.
                 type: object
               startTime:
-                description: Represents time when the job was acknowledged by the
-                  job controller. It is not guaranteed to be set in happens-before
-                  order across separate operations. It is represented in RFC3339 form
-                  and is in UTC.
+                description: |-
+                  Represents time when the job was acknowledged by the job controller.
+                  It is not guaranteed to be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
             type: object

--- a/manifests/base/crds/kubeflow.org_mxjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_mxjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: mxjobs.kubeflow.org
 spec:
   group: kubeflow.org
@@ -27,14 +27,19 @@ spec:
         description: MXJob is the Schema for the mxjobs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -42,29 +47,36 @@ spec:
             description: MXJobSpec defines the desired state of MXJob
             properties:
               jobMode:
-                description: JobMode specify the kind of MXjob to do. Different mode
-                  may have different MXReplicaSpecs request
+                description: |-
+                  JobMode specify the kind of MXjob to do. Different mode may have
+                  different MXReplicaSpecs request
                 type: string
               mxReplicaSpecs:
                 additionalProperties:
                   description: ReplicaSpec is a description of the replica
                   properties:
                     replicas:
-                      description: Replicas is the desired number of replicas of the
-                        given template. If unspecified, defaults to 1.
+                      description: |-
+                        Replicas is the desired number of replicas of the given template.
+                        If unspecified, defaults to 1.
                       format: int32
                       type: integer
                     restartPolicy:
-                      description: Restart policy for all replicas within the job.
-                        One of Always, OnFailure, Never and ExitCode. Default to Never.
+                      description: |-
+                        Restart policy for all replicas within the job.
+                        One of Always, OnFailure, Never and ExitCode.
+                        Default to Never.
                       type: string
                     template:
-                      description: Template is the object that describes the pod that
+                      description: |-
+                        Template is the object that describes the pod that
                         will be created for this replica. RestartPolicy in PodTemplateSpec
                         will be overide by RestartPolicy in ReplicaSpec
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          description: |-
+                            Standard object's metadata.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                           properties:
                             annotations:
                               additionalProperties:
@@ -84,15 +96,15 @@ spec:
                               type: string
                           type: object
                         spec:
-                          description: 'Specification of the desired behavior of the
-                            pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                          description: |-
+                            Specification of the desired behavior of the pod.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                           properties:
                             activeDeadlineSeconds:
-                              description: Optional duration in seconds the pod may
-                                be active on the node relative to StartTime before
-                                the system will actively try to mark it failed and
-                                kill associated containers. Value must be a positive
-                                integer.
+                              description: |-
+                                Optional duration in seconds the pod may be active on the node relative to
+                                StartTime before the system will actively try to mark it failed and kill associated containers.
+                                Value must be a positive integer.
                               format: int64
                               type: integer
                             affinity:
@@ -103,21 +115,17 @@ spec:
                                     rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.
                                       items:
-                                        description: An empty preferred scheduling
-                                          term matches all objects with implicit weight
-                                          0 (i.e. it's a no-op). A null preferred
-                                          scheduling term matches no objects (i.e.
-                                          is also a no-op).
+                                        description: |-
+                                          An empty preferred scheduling term matches all objects with implicit weight 0
+                                          (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                         properties:
                                           preference:
                                             description: A node selector term, associated
@@ -127,35 +135,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -168,35 +167,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -219,57 +209,46 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified
-                                        by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to an update), the
-                                        system may or may not try to eventually evict
-                                        the pod from its node.
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to an update), the system
+                                        may or may not try to eventually evict the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
                                             terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector
-                                              term matches no objects. The requirements
-                                              of them are ANDed. The TopologySelectorTerm
-                                              type implements a subset of the NodeSelectorTerm.
+                                            description: |-
+                                              A null or empty node selector term matches no objects. The requirements of
+                                              them are ANDed.
+                                              The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
                                                 description: A list of node selector
                                                   requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -282,35 +261,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -333,15 +303,13 @@ spec:
                                     etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -362,11 +330,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -374,23 +340,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -402,29 +361,20 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaceSelector:
-                                                description: A label query over the
-                                                  set of namespaces that the term
-                                                  applies to. The term is applied
-                                                  to the union of the namespaces selected
-                                                  by this field and the ones listed
-                                                  in the namespaces field. null selector
-                                                  and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -432,11 +382,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -444,23 +392,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -472,50 +413,37 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaces:
-                                                description: namespaces specifies
-                                                  a static list of namespace names
-                                                  that the term applies to. The term
-                                                  is applied to the union of the namespaces
-                                                  listed in this field and the ones
-                                                  selected by namespaceSelector. null
-                                                  or empty namespaces list and null
-                                                  namespaceSelector means "this pod's
-                                                  namespace".
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching
-                                              the corresponding podAffinityTerm, in
-                                              the range 1-100.
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -524,24 +452,20 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified
-                                        by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to a pod label update),
-                                        the system may or may not try to eventually
-                                        evict the pod from its node.
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
                                       items:
-                                        description: Defines a set of pods (namely
-                                          those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -552,10 +476,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -563,21 +486,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -590,25 +507,19 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
@@ -616,10 +527,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -627,21 +537,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -654,39 +558,29 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace".
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -699,13 +593,11 @@ spec:
                                     node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the anti-affinity
-                                        expressions specified by this field, but it
-                                        may choose a node that violates one or more
-                                        of the expressions. The node that is most
-                                        preferred is the one with the greatest sum
-                                        of weights, i.e.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the anti-affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -726,11 +618,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -738,23 +628,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -766,29 +649,20 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaceSelector:
-                                                description: A label query over the
-                                                  set of namespaces that the term
-                                                  applies to. The term is applied
-                                                  to the union of the namespaces selected
-                                                  by this field and the ones listed
-                                                  in the namespaces field. null selector
-                                                  and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -796,11 +670,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -808,23 +680,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -836,50 +701,37 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaces:
-                                                description: namespaces specifies
-                                                  a static list of namespace names
-                                                  that the term applies to. The term
-                                                  is applied to the union of the namespaces
-                                                  listed in this field and the ones
-                                                  selected by namespaceSelector. null
-                                                  or empty namespaces list and null
-                                                  namespaceSelector means "this pod's
-                                                  namespace".
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching
-                                              the corresponding podAffinityTerm, in
-                                              the range 1-100.
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -888,24 +740,20 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements
-                                        specified by this field are not met at scheduling
-                                        time, the pod will not be scheduled onto the
-                                        node. If the anti-affinity requirements specified
-                                        by this field cease to be met at some point
-                                        during pod execution (e.g. due to a pod label
-                                        update), the system may or may not try to
-                                        eventually evict the pod from its node.
+                                      description: |-
+                                        If the anti-affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the anti-affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
                                       items:
-                                        description: Defines a set of pods (namely
-                                          those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -916,10 +764,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -927,21 +774,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -954,25 +795,19 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
@@ -980,10 +815,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -991,21 +825,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -1018,39 +846,29 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace".
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1064,41 +882,39 @@ spec:
                                 mounted.
                               type: boolean
                             containers:
-                              description: List of containers belonging to the pod.
-                                Containers cannot currently be added or removed. There
-                                must be at least one container in a Pod. Cannot be
-                                updated.
+                              description: |-
+                                List of containers belonging to the pod.
+                                Containers cannot currently be added or removed.
+                                There must be at least one container in a Pod.
+                                Cannot be updated.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
-                                      provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The container image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
-                                      used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The container image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -1108,16 +924,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1131,10 +944,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1145,11 +958,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -1165,12 +976,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -1204,10 +1012,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1223,15 +1031,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1240,10 +1046,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -1260,10 +1066,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -1274,48 +1080,43 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images
-                                      This field is optional to allow higher level
-                                      config management to default or override container
-                                      images in workload controllers like Deployments
-                                      and StatefulSets.'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system
-                                      should take in response to container lifecycle
-                                      events. Cannot be updated.
+                                    description: |-
+                                      Actions that the management system should take in response to container lifecycle events.
+                                      Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1325,10 +1126,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -1340,11 +1140,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -1363,25 +1161,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1392,41 +1189,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1436,10 +1226,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -1451,11 +1240,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -1474,25 +1261,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1503,10 +1289,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -1514,35 +1300,31 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness.
+                                    description: |-
+                                      Periodic probe of container liveness.
                                       Container will be restarted if the probe fails.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -1555,11 +1337,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -1569,9 +1352,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -1581,11 +1364,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -1603,36 +1384,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -1647,55 +1427,52 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as
-                                      a DNS_LABEL. Each container in a pod must have
-                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    description: |-
+                                      Name of the container specified as a DNS_LABEL.
+                                      Each container in a pod must have a unique name (DNS_LABEL).
+                                      Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the
-                                      container. Not specifying a port here DOES NOT
-                                      prevent that port from being exposed. Any port
-                                      which is listening on the default "0.0.0.0"
-                                      address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
+                                    description: |-
+                                      List of ports to expose from the container. Not specifying a port here
+                                      DOES NOT prevent that port from being exposed. Any port which is
+                                      listening on the default "0.0.0.0" address inside a container will be
+                                      accessible from the network.
+                                      Modifying this array with strategic merge patch may corrupt the data.
                                       For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -1703,24 +1480,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -1731,36 +1508,31 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service
-                                      readiness. Container will be removed from service
-                                      endpoints if the probe fails. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Periodic probe of container service readiness.
+                                      Container will be removed from service endpoints if the probe fails.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -1773,11 +1545,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -1787,9 +1560,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -1799,11 +1572,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -1821,36 +1592,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -1865,30 +1635,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -1899,14 +1666,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -1915,26 +1682,31 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Compute Resources required by this container.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -1950,9 +1722,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1961,48 +1733,41 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: RestartPolicy defines the restart
-                                      behavior of individual containers in a pod.
-                                      This field may only be set for init containers,
-                                      and the only allowed value is "Always". For
-                                      non-init containers or when this field is not
-                                      specified, the restart behavior is defined by
-                                      the Pod's restart policy and the container type.
+                                    description: |-
+                                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                                      This field may only be set for init containers, and the only allowed value is "Always".
+                                      For non-init containers or when this field is not specified,
+                                      the restart behavior is defined by the Pod's restart policy and the container type.
                                     type: string
                                   securityContext:
-                                    description: 'SecurityContext defines the security
-                                      options the container should be run with. If
-                                      set, the fields of SecurityContext override
-                                      the equivalent fields of PodSecurityContext.
-                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    description: |-
+                                      SecurityContext defines the security options the container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -2020,68 +1785,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2101,52 +1857,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -2154,60 +1902,46 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: StartupProbe indicates that the Pod
-                                      has successfully initialized. If specified,
-                                      no other probes are executed until this completes
-                                      successfully. If this probe fails, the Pod will
-                                      be restarted, just as if the livenessProbe failed.
+                                    description: |-
+                                      StartupProbe indicates that the Pod has successfully initialized.
+                                      If specified, no other probes are executed until this completes successfully.
+                                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -2220,11 +1954,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -2234,9 +1969,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -2246,11 +1981,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -2268,36 +2001,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -2312,72 +2044,62 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -2401,46 +2123,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -2448,34 +2169,36 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             dnsConfig:
-                              description: Specifies the DNS parameters of a pod.
-                                Parameters specified here will be merged to the generated
-                                DNS configuration based on DNSPolicy.
+                              description: |-
+                                Specifies the DNS parameters of a pod.
+                                Parameters specified here will be merged to the generated DNS
+                                configuration based on DNSPolicy.
                               properties:
                                 nameservers:
-                                  description: A list of DNS name server IP addresses.
-                                    This will be appended to the base nameservers
-                                    generated from DNSPolicy. Duplicated nameservers
-                                    will be removed.
+                                  description: |-
+                                    A list of DNS name server IP addresses.
+                                    This will be appended to the base nameservers generated from DNSPolicy.
+                                    Duplicated nameservers will be removed.
                                   items:
                                     type: string
                                   type: array
                                 options:
-                                  description: A list of DNS resolver options. This
-                                    will be merged with the base options generated
-                                    from DNSPolicy. Duplicated entries will be removed.
-                                    Resolution options given in Options will override
-                                    those that appear in the base DNSPolicy.
+                                  description: |-
+                                    A list of DNS resolver options.
+                                    This will be merged with the base options generated from DNSPolicy.
+                                    Duplicated entries will be removed. Resolution options given in Options
+                                    will override those that appear in the base DNSPolicy.
                                   items:
                                     description: PodDNSConfigOption defines DNS resolver
                                       options of a pod.
@@ -2488,75 +2211,68 @@ spec:
                                     type: object
                                   type: array
                                 searches:
-                                  description: A list of DNS search domains for host-name
-                                    lookup. This will be appended to the base search
-                                    paths generated from DNSPolicy. Duplicated search
-                                    paths will be removed.
+                                  description: |-
+                                    A list of DNS search domains for host-name lookup.
+                                    This will be appended to the base search paths generated from DNSPolicy.
+                                    Duplicated search paths will be removed.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
-                              description: Set DNS policy for the pod. Defaults to
-                                "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
-                                'ClusterFirst', 'Default' or 'None'. DNS parameters
-                                given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy. To have DNS options set along
-                                with hostNetwork, you have to specify DNS policy explicitly
-                                to 'ClusterFirstWithHostNet'.
+                              description: |-
+                                Set DNS policy for the pod.
+                                Defaults to "ClusterFirst".
+                                Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                                DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                                To have DNS options set along with hostNetwork, you have to specify DNS policy
+                                explicitly to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
-                              description: 'EnableServiceLinks indicates whether information
-                                about services should be injected into pod''s environment
-                                variables, matching the syntax of Docker links. Optional:
-                                Defaults to true.'
+                              description: |-
+                                EnableServiceLinks indicates whether information about services should be injected into pod's
+                                environment variables, matching the syntax of Docker links.
+                                Optional: Defaults to true.
                               type: boolean
                             ephemeralContainers:
-                              description: List of ephemeral containers run in this
-                                pod. Ephemeral containers may be run in an existing
-                                pod to perform user-initiated actions such as debugging.
-                                This list cannot be specified when creating a pod,
-                                and it cannot be modified by updating the pod spec.
-                                In order to add an ephemeral container to an existing
-                                pod, use the pod's ephemeralcontainers subresource.
+                              description: |-
+                                List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                                pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                                creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                                ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
                               items:
-                                description: An EphemeralContainer is a temporary
-                                  container that you may add to an existing Pod for
-                                  user-initiated activities such as debugging. Ephemeral
-                                  containers have no resource or scheduling guarantees,
-                                  and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted. The kubelet
-                                  may evict a Pod if an ephemeral container causes
-                                  the Pod to exceed its resource allocation.
+                                description: |-
+                                  An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                                  user-initiated activities such as debugging. Ephemeral containers have no resource or
+                                  scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                                  removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                                  Pod to exceed its resource allocation.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the
-                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                      produce the string literal "$(VAR_NAME)".'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)".
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The image''s ENTRYPOINT is used if
-                                      this is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -2566,16 +2282,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -2589,10 +2302,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -2603,11 +2316,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -2623,12 +2334,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -2662,10 +2370,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -2681,15 +2389,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -2698,10 +2404,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -2718,10 +2424,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -2732,43 +2438,40 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
                                     description: Lifecycle is not allowed for ephemeral
                                       containers.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2778,10 +2481,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -2793,11 +2495,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -2816,25 +2516,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2845,41 +2544,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2889,10 +2581,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -2904,11 +2595,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -2927,25 +2616,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2956,10 +2644,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -2975,26 +2663,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -3007,11 +2689,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -3021,9 +2704,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -3033,11 +2716,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3055,36 +2736,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -3099,38 +2779,34 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the ephemeral container specified
-                                      as a DNS_LABEL. This name must be unique among
-                                      all containers, init containers and ephemeral
-                                      containers.
+                                    description: |-
+                                      Name of the ephemeral container specified as a DNS_LABEL.
+                                      This name must be unique among all containers, init containers and ephemeral containers.
                                     type: string
                                   ports:
                                     description: Ports are not allowed for ephemeral
@@ -3140,9 +2816,9 @@ spec:
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -3150,24 +2826,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -3186,26 +2862,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -3218,11 +2888,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -3232,9 +2903,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -3244,11 +2915,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3266,36 +2935,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -3310,30 +2978,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -3344,14 +3009,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -3360,27 +3025,30 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: Resources are not allowed for ephemeral
-                                      containers. Ephemeral containers use spare resources
+                                    description: |-
+                                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
                                       already allocated to the pod.
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -3396,9 +3064,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -3407,45 +3075,40 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: Restart policy for the container
-                                      to manage the restart behavior of each container
-                                      within a pod. This may only be set for init
-                                      containers. You cannot set this field on ephemeral
-                                      containers.
+                                    description: |-
+                                      Restart policy for the container to manage the restart behavior of each
+                                      container within a pod.
+                                      This may only be set for init containers. You cannot set this field on
+                                      ephemeral containers.
                                     type: string
                                   securityContext:
-                                    description: 'Optional: SecurityContext defines
-                                      the security options the ephemeral container
-                                      should be run with. If set, the fields of SecurityContext
-                                      override the equivalent fields of PodSecurityContext.'
+                                    description: |-
+                                      Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -3463,68 +3126,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3544,52 +3198,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -3597,25 +3243,18 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
@@ -3628,26 +3267,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -3660,11 +3293,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -3674,9 +3308,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -3686,11 +3320,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3708,36 +3340,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -3752,81 +3383,71 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: "If set, the name of the container
-                                      from PodSpec that this ephemeral container targets.
-                                      The ephemeral container will be run in the namespaces
-                                      (IPC, PID, etc) of this container. If not set
-                                      then the ephemeral container uses the namespaces
-                                      configured in the Pod spec. \n The container
-                                      runtime must implement support for this feature."
+                                    description: |-
+                                      If set, the name of the container from PodSpec that this ephemeral container targets.
+                                      The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                      If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+
+                                      The container runtime must implement support for this feature.
                                     type: string
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -3850,47 +3471,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Subpath mounts are not allowed for
-                                      ephemeral containers. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -3898,24 +3517,24 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             hostAliases:
-                              description: HostAliases is an optional list of hosts
-                                and IPs that will be injected into the pod's hosts
-                                file if specified. This is only valid for non-hostNetwork
-                                pods.
+                              description: |-
+                                HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                file if specified. This is only valid for non-hostNetwork pods.
                               items:
-                                description: HostAlias holds the mapping between IP
-                                  and hostnames that will be injected as an entry
-                                  in the pod's hosts file.
+                                description: |-
+                                  HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                  pod's hosts file.
                                 properties:
                                   hostnames:
                                     description: Hostnames for the above IP address.
@@ -3928,93 +3547,89 @@ spec:
                                 type: object
                               type: array
                             hostIPC:
-                              description: 'Use the host''s ipc namespace. Optional:
-                                Default to false.'
+                              description: |-
+                                Use the host's ipc namespace.
+                                Optional: Default to false.
                               type: boolean
                             hostNetwork:
-                              description: Host networking requested for this pod.
-                                Use the host's network namespace. If this option is
-                                set, the ports that will be used must be specified.
+                              description: |-
+                                Host networking requested for this pod. Use the host's network namespace.
+                                If this option is set, the ports that will be used must be specified.
                                 Default to false.
                               type: boolean
                             hostPID:
-                              description: 'Use the host''s pid namespace. Optional:
-                                Default to false.'
+                              description: |-
+                                Use the host's pid namespace.
+                                Optional: Default to false.
                               type: boolean
                             hostUsers:
-                              description: 'Use the host''s user namespace. Optional:
-                                Default to true. If set to true or not present, the
-                                pod will be run in the host user namespace, useful
-                                for when the pod needs a feature only available to
-                                the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE. When set to false, a new
-                                userns is created for the pod.'
+                              description: |-
+                                Use the host's user namespace.
+                                Optional: Default to true.
+                                If set to true or not present, the pod will be run in the host user namespace, useful
+                                for when the pod needs a feature only available to the host user namespace, such as
+                                loading a kernel module with CAP_SYS_MODULE.
+                                When set to false, a new userns is created for the pod.
                               type: boolean
                             hostname:
-                              description: Specifies the hostname of the Pod If not
-                                specified, the pod's hostname will be set to a system-defined
-                                value.
+                              description: |-
+                                Specifies the hostname of the Pod
+                                If not specified, the pod's hostname will be set to a system-defined value.
                               type: string
                             imagePullSecrets:
-                              description: 'ImagePullSecrets is an optional list of
-                                references to secrets in the same namespace to use
-                                for pulling any of the images used by this PodSpec.
-                                If specified, these secrets will be passed to individual
-                                puller implementations for them to use. More info:
-                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                              description: |-
+                                ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                If specified, these secrets will be passed to individual puller implementations for them to use.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                               items:
-                                description: LocalObjectReference contains enough
-                                  information to let you locate the referenced object
-                                  inside the same namespace.
+                                description: |-
+                                  LocalObjectReference contains enough information to let you locate the
+                                  referenced object inside the same namespace.
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               type: array
                             initContainers:
-                              description: List of initialization containers belonging
-                                to the pod. Init containers are executed in order
-                                prior to containers being started. If any init container
-                                fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy. The name for
-                                an init container or normal container must be unique
-                                among all containers.
+                              description: |-
+                                List of initialization containers belonging to the pod.
+                                Init containers are executed in order prior to containers being started. If any
+                                init container fails, the pod is considered to have failed and is handled according
+                                to its restartPolicy. The name for an init container or normal container must be
+                                unique among all containers.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
-                                      provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The container image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
-                                      used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The container image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -4024,16 +3639,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -4047,10 +3659,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -4061,11 +3673,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -4081,12 +3691,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -4120,10 +3727,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -4139,15 +3746,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -4156,10 +3761,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -4176,10 +3781,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -4190,48 +3795,43 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images
-                                      This field is optional to allow higher level
-                                      config management to default or override container
-                                      images in workload controllers like Deployments
-                                      and StatefulSets.'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system
-                                      should take in response to container lifecycle
-                                      events. Cannot be updated.
+                                    description: |-
+                                      Actions that the management system should take in response to container lifecycle events.
+                                      Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4241,10 +3841,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -4256,11 +3855,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -4279,25 +3876,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -4308,41 +3904,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4352,10 +3941,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -4367,11 +3955,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -4390,25 +3976,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -4419,10 +4004,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -4430,35 +4015,31 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness.
+                                    description: |-
+                                      Periodic probe of container liveness.
                                       Container will be restarted if the probe fails.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -4471,11 +4052,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -4485,9 +4067,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -4497,11 +4079,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -4519,36 +4099,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -4563,55 +4142,52 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as
-                                      a DNS_LABEL. Each container in a pod must have
-                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    description: |-
+                                      Name of the container specified as a DNS_LABEL.
+                                      Each container in a pod must have a unique name (DNS_LABEL).
+                                      Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the
-                                      container. Not specifying a port here DOES NOT
-                                      prevent that port from being exposed. Any port
-                                      which is listening on the default "0.0.0.0"
-                                      address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
+                                    description: |-
+                                      List of ports to expose from the container. Not specifying a port here
+                                      DOES NOT prevent that port from being exposed. Any port which is
+                                      listening on the default "0.0.0.0" address inside a container will be
+                                      accessible from the network.
+                                      Modifying this array with strategic merge patch may corrupt the data.
                                       For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -4619,24 +4195,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -4647,36 +4223,31 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service
-                                      readiness. Container will be removed from service
-                                      endpoints if the probe fails. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Periodic probe of container service readiness.
+                                      Container will be removed from service endpoints if the probe fails.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -4689,11 +4260,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -4703,9 +4275,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -4715,11 +4287,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -4737,36 +4307,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -4781,30 +4350,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -4815,14 +4381,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -4831,26 +4397,31 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Compute Resources required by this container.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -4866,9 +4437,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -4877,48 +4448,41 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: RestartPolicy defines the restart
-                                      behavior of individual containers in a pod.
-                                      This field may only be set for init containers,
-                                      and the only allowed value is "Always". For
-                                      non-init containers or when this field is not
-                                      specified, the restart behavior is defined by
-                                      the Pod's restart policy and the container type.
+                                    description: |-
+                                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                                      This field may only be set for init containers, and the only allowed value is "Always".
+                                      For non-init containers or when this field is not specified,
+                                      the restart behavior is defined by the Pod's restart policy and the container type.
                                     type: string
                                   securityContext:
-                                    description: 'SecurityContext defines the security
-                                      options the container should be run with. If
-                                      set, the fields of SecurityContext override
-                                      the equivalent fields of PodSecurityContext.
-                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    description: |-
+                                      SecurityContext defines the security options the container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -4936,68 +4500,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -5017,52 +4572,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -5070,60 +4617,46 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: StartupProbe indicates that the Pod
-                                      has successfully initialized. If specified,
-                                      no other probes are executed until this completes
-                                      successfully. If this probe fails, the Pod will
-                                      be restarted, just as if the livenessProbe failed.
+                                    description: |-
+                                      StartupProbe indicates that the Pod has successfully initialized.
+                                      If specified, no other probes are executed until this completes successfully.
+                                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -5136,11 +4669,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -5150,9 +4684,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -5162,11 +4696,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -5184,36 +4716,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -5228,72 +4759,62 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -5317,46 +4838,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -5364,47 +4884,54 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             nodeName:
-                              description: NodeName is a request to schedule this
-                                pod onto a specific node. If it is non-empty, the
-                                scheduler simply schedules this pod onto that node,
-                                assuming that it fits resource requirements.
+                              description: |-
+                                NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
+                                the scheduler simply schedules this pod onto that node, assuming that it fits resource
+                                requirements.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: 'NodeSelector is a selector which must
-                                be true for the pod to fit on a node. Selector which
-                                must match a node''s labels for the pod to be scheduled
-                                on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                              description: |-
+                                NodeSelector is a selector which must be true for the pod to fit on a node.
+                                Selector which must match a node's labels for the pod to be scheduled on that node.
+                                More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                               type: object
                               x-kubernetes-map-type: atomic
                             os:
-                              description: "Specifies the OS of the containers in
-                                the pod. Some pod and container fields are restricted
-                                if this is set. \n If the OS field is set to linux,
-                                the following fields must be unset: -securityContext.windowsOptions
-                                \n If the OS field is set to windows, following fields
-                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
-                                - spec.securityContext.seLinuxOptions - spec.securityContext."
+                              description: |-
+                                Specifies the OS of the containers in the pod.
+                                Some pod and container fields are restricted if this is set.
+
+
+                                If the OS field is set to linux, the following fields must be unset:
+                                -securityContext.windowsOptions
+
+
+                                If the OS field is set to windows, following fields must be unset:
+                                - spec.hostPID
+                                - spec.hostIPC
+                                - spec.hostUsers
+                                - spec.securityContext.seLinuxOptions
+                                - spec.securityContext.
                               properties:
                                 name:
-                                  description: 'Name is the name of the operating
-                                    system. The currently supported values are linux
-                                    and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                    Clients should expect to handle additional values
-                                    and treat unrecognized values in this field as
-                                    os: null'
+                                  description: |-
+                                    Name is the name of the operating system. The currently supported values are linux and windows.
+                                    Additional value may be defined in future and can be one of:
+                                    https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values and treat unrecognized values in this field as os: null
                                   type: string
                               required:
                               - name
@@ -5416,44 +4943,43 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: Overhead represents the resource overhead
-                                associated with running a pod for a given RuntimeClass.
-                                This field will be autopopulated at admission time
-                                by the RuntimeClass admission controller. If the RuntimeClass
-                                admission controller is enabled, overhead must not
-                                be set in Pod create requests. The RuntimeClass admission
-                                controller will reject Pod create requests which have
-                                the overhead already set.
+                              description: |-
+                                Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                                This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                                the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                                The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                                set.
                               type: object
                             preemptionPolicy:
-                              description: PreemptionPolicy is the Policy for preempting
-                                pods with lower priority. One of Never, PreemptLowerPriority.
+                              description: |-
+                                PreemptionPolicy is the Policy for preempting pods with lower priority.
+                                One of Never, PreemptLowerPriority.
                                 Defaults to PreemptLowerPriority if unset.
                               type: string
                             priority:
-                              description: The priority value. Various system components
-                                use this field to find the priority of the pod. When
-                                Priority Admission Controller is enabled, it prevents
-                                users from setting this field. The admission controller
-                                populates this field from PriorityClassName. The higher
-                                the value, the higher the priority.
+                              description: |-
+                                The priority value. Various system components use this field to find the
+                                priority of the pod. When Priority Admission Controller is enabled, it
+                                prevents users from setting this field. The admission controller populates
+                                this field from PriorityClassName.
+                                The higher the value, the higher the priority.
                               format: int32
                               type: integer
                             priorityClassName:
-                              description: If specified, indicates the pod's priority.
-                                "system-node-critical" and "system-cluster-critical"
-                                are two special keywords which indicate the highest
-                                priorities with the former being the highest priority.
-                                Any other name must be defined by creating a PriorityClass
-                                object with that name. If not specified, the pod priority
-                                will be default or zero if there is no default.
+                              description: |-
+                                If specified, indicates the pod's priority. "system-node-critical" and
+                                "system-cluster-critical" are two special keywords which indicate the
+                                highest priorities with the former being the highest priority. Any other
+                                name must be defined by creating a PriorityClass object with that name.
+                                If not specified, the pod priority will be default or zero if there is no
+                                default.
                               type: string
                             readinessGates:
-                              description: 'If specified, all readiness gates will
-                                be evaluated for pod readiness. A pod is ready when
-                                all its containers are ready AND all conditions specified
-                                in the readiness gates have status equal to "True"
-                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                              description: |-
+                                If specified, all readiness gates will be evaluated for pod readiness.
+                                A pod is ready when all its containers are ready AND
+                                all conditions specified in the readiness gates have status equal to "True"
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
                               items:
                                 description: PodReadinessGate contains the reference
                                   to a pod condition
@@ -5467,40 +4993,47 @@ spec:
                                 type: object
                               type: array
                             resourceClaims:
-                              description: "ResourceClaims defines which ResourceClaims
-                                must be allocated and reserved before the Pod is allowed
-                                to start. The resources will be made available to
-                                those containers which consume them by name. \n This
-                                is an alpha field and requires enabling the DynamicResourceAllocation
-                                feature gate. \n This field is immutable."
+                              description: |-
+                                ResourceClaims defines which ResourceClaims must be allocated
+                                and reserved before the Pod is allowed to start. The resources
+                                will be made available to those containers which consume them
+                                by name.
+
+
+                                This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate.
+
+
+                                This field is immutable.
                               items:
-                                description: PodResourceClaim references exactly one
-                                  ResourceClaim through a ClaimSource. It adds a name
-                                  to it that uniquely identifies the ResourceClaim
-                                  inside the Pod. Containers that need access to the
-                                  ResourceClaim reference it with this name.
+                                description: |-
+                                  PodResourceClaim references exactly one ResourceClaim through a ClaimSource.
+                                  It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                                  Containers that need access to the ResourceClaim reference it with this name.
                                 properties:
                                   name:
-                                    description: Name uniquely identifies this resource
-                                      claim inside the pod. This must be a DNS_LABEL.
+                                    description: |-
+                                      Name uniquely identifies this resource claim inside the pod.
+                                      This must be a DNS_LABEL.
                                     type: string
                                   source:
                                     description: Source describes where to find the
                                       ResourceClaim.
                                     properties:
                                       resourceClaimName:
-                                        description: ResourceClaimName is the name
-                                          of a ResourceClaim object in the same namespace
-                                          as this pod.
+                                        description: |-
+                                          ResourceClaimName is the name of a ResourceClaim object in the same
+                                          namespace as this pod.
                                         type: string
                                       resourceClaimTemplateName:
-                                        description: "ResourceClaimTemplateName is
-                                          the name of a ResourceClaimTemplate object
-                                          in the same namespace as this pod. \n The
-                                          template will be used to create a new ResourceClaim,
-                                          which will be bound to this pod. When this
-                                          pod is deleted, the ResourceClaim will also
-                                          be deleted."
+                                        description: |-
+                                          ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                          object in the same namespace as this pod.
+
+
+                                          The template will be used to create a new ResourceClaim, which will
+                                          be bound to this pod. When this pod is deleted, the ResourceClaim
+                                          will also be deleted.
                                         type: string
                                     type: object
                                 required:
@@ -5511,42 +5044,44 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             restartPolicy:
-                              description: 'Restart policy for all containers within
-                                the pod. One of Always, OnFailure, Never. In some
-                                contexts, only a subset of those values may be permitted.
-                                Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                              description: |-
+                                Restart policy for all containers within the pod.
+                                One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                                Default to Always.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass
-                                object in the node.k8s.io group, which should be used
-                                to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run. If unset
-                                or empty, the "legacy" RuntimeClass will be used,
-                                which is an implicit class with an empty definition
-                                that uses the default runtime handler. More info:
-                                https://git.k8s.'
+                              description: |-
+                                RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                                to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                                If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                                empty definition that uses the default runtime handler.
+                                More info: https://git.k8s.
                               type: string
                             schedulerName:
-                              description: If specified, the pod will be dispatched
-                                by specified scheduler. If not specified, the pod
-                                will be dispatched by default scheduler.
+                              description: |-
+                                If specified, the pod will be dispatched by specified scheduler.
+                                If not specified, the pod will be dispatched by default scheduler.
                               type: string
                             schedulingGates:
-                              description: "SchedulingGates is an opaque list of values
-                                that if specified will block scheduling the pod. If
-                                schedulingGates is not empty, the pod will stay in
-                                the SchedulingGated state and the scheduler will not
-                                attempt to schedule the pod. \n SchedulingGates can
-                                only be set at pod creation time, and be removed only
-                                afterwards. \n This is a beta feature enabled by the
-                                PodSchedulingReadiness feature gate."
+                              description: |-
+                                SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                                If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                                scheduler will not attempt to schedule the pod.
+
+
+                                SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+
+
+                                This is a beta feature enabled by the PodSchedulingReadiness feature gate.
                               items:
                                 description: PodSchedulingGate is associated to a
                                   Pod to guard its scheduling.
                                 properties:
                                   name:
-                                    description: Name of the scheduling gate. Each
-                                      scheduling gate must have a unique name field.
+                                    description: |-
+                                      Name of the scheduling gate.
+                                      Each scheduling gate must have a unique name field.
                                     type: string
                                 required:
                                 - name
@@ -5556,70 +5091,67 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             securityContext:
-                              description: 'SecurityContext holds pod-level security
-                                attributes and common container settings. Optional:
-                                Defaults to empty.  See type description for default
-                                values of each field.'
+                              description: |-
+                                SecurityContext holds pod-level security attributes and common container settings.
+                                Optional: Defaults to empty.  See type description for default values of each field.
                               properties:
                                 fsGroup:
-                                  description: "A special supplemental group that
-                                    applies to all containers in a pod. Some volume
-                                    types allow the Kubelet to change the ownership
-                                    of that volume to be owned by the pod: \n 1. The
-                                    owning GID will be the FSGroup 2. The setgid bit
-                                    is set (new files created in the volume will be
-                                    owned by FSGroup) 3."
+                                  description: |-
+                                    A special supplemental group that applies to all containers in a pod.
+                                    Some volume types allow the Kubelet to change the ownership of that volume
+                                    to be owned by the pod:
+
+
+                                    1. The owning GID will be the FSGroup
+                                    2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                    3.
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior
-                                    of changing ownership and permission of the volume
-                                    before being exposed inside Pod. This field will
-                                    only apply to volume types which support fsGroup
-                                    based ownership(and permissions). It will have
-                                    no effect on ephemeral volume types such as: secret,
-                                    configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified, "Always" is used.'
+                                  description: |-
+                                    fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                    before being exposed inside Pod. This field will only apply to
+                                    volume types which support fsGroup based ownership(and permissions).
+                                    It will have no effect on ephemeral volume types such as: secret, configmaps
+                                    and emptydir.
+                                    Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
                                   type: string
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in SecurityContext.  If set in
-                                    both SecurityContext and PodSecurityContext, the
-                                    value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in SecurityContext.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in SecurityContext.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence for that container.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    all containers. If unspecified, the container
-                                    runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                  description: |-
+                                    The SELinux context to be applied to all containers.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in SecurityContext.  If set in
+                                    both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                    takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5639,49 +5171,45 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by the containers
-                                    in this pod. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by the containers in this pod.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must be set if type is "Localhost".
-                                        Must NOT be set for any other type.
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first
-                                    process run in each container, in addition to
-                                    the container's primary GID, the fsGroup (if specified),
-                                    and group memberships defined in the container
-                                    image for the uid of the container process. If
-                                    unspecified, no additional groups are added to
-                                    any container.
+                                  description: |-
+                                    A list of groups applied to the first process run in each container, in addition
+                                    to the container's primary GID, the fsGroup (if specified), and group memberships
+                                    defined in the container image for the uid of the container process. If unspecified,
+                                    no additional groups are added to any container.
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls
-                                    used for the pod. Pods with unsupported sysctls
-                                    (by the container runtime) might fail to launch.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                    sysctls (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   items:
                                     description: Sysctl defines a kernel parameter
                                       to be set
@@ -5698,173 +5226,151 @@ spec:
                                     type: object
                                   type: array
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    within a container's SecurityContext will be used.
-                                    If set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options within a container's SecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        All of a Pod's containers must have the same
-                                        effective HostProcess value (it is not allowed
-                                        to have a mix of HostProcess containers and
-                                        non-HostProcess containers). In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: 'DeprecatedServiceAccount is a depreciated
-                                alias for ServiceAccountName. Deprecated: Use serviceAccountName
-                                instead.'
+                              description: |-
+                                DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+                                Deprecated: Use serviceAccountName instead.
                               type: string
                             serviceAccountName:
-                              description: 'ServiceAccountName is the name of the
-                                ServiceAccount to use to run this pod. More info:
-                                https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                              description: |-
+                                ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                               type: string
                             setHostnameAsFQDN:
-                              description: If true the pod's hostname will be configured
-                                as the pod's FQDN, rather than the leaf name (the
-                                default). In Linux containers, this means setting
-                                the FQDN in the hostname field of the kernel (the
-                                nodename field of struct utsname).
+                              description: |-
+                                If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                                In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between
-                                all of the containers in a pod. When this is set containers
-                                will be able to view and signal processes from other
-                                containers in the same pod, and the first process
-                                in each container will not be assigned PID 1. HostPID
-                                and ShareProcessNamespace cannot both be set. Optional:
-                                Default to false.'
+                              description: |-
+                                Share a single process namespace between all of the containers in a pod.
+                                When this is set containers will be able to view and signal processes from other containers
+                                in the same pod, and the first process in each container will not be assigned PID 1.
+                                HostPID and ShareProcessNamespace cannot both be set.
+                                Optional: Default to false.
                               type: boolean
                             subdomain:
-                              description: If specified, the fully qualified Pod hostname
-                                will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                                domain>". If not specified, the pod will not have
-                                a domainname at all.
+                              description: |-
+                                If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                                If not specified, the pod will not have a domainname at all.
                               type: string
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs
-                                to terminate gracefully. May be decreased in delete
-                                request. Value must be non-negative integer. The value
-                                zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down). If this value is nil,
-                                the default grace period will be used instead.
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                If this value is nil, the default grace period will be used instead.
                               format: int64
                               type: integer
                             tolerations:
                               description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to
-                                  tolerates any taint that matches the triple <key,value,effect>
-                                  using the matching operator <operator>.
+                                description: |-
+                                  The pod this Toleration is attached to tolerates any taint that matches
+                                  the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect
-                                      to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule,
-                                      PreferNoSchedule and NoExecute.
+                                    description: |-
+                                      Effect indicates the taint effect to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration
-                                      applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists;
-                                      this combination means to match all values and
-                                      all keys.
+                                    description: |-
+                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship
-                                      to the value. Valid operators are Exists and
-                                      Equal. Defaults to Equal. Exists is equivalent
-                                      to wildcard for value, so that a pod can tolerate
-                                      all taints of a particular category.
+                                    description: |-
+                                      Operator represents a key's relationship to the value.
+                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Exists is equivalent to wildcard for value, so that a pod can
+                                      tolerate all taints of a particular category.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the
-                                      period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is
-                                      ignored) tolerates the taint. By default, it
-                                      is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
+                                    description: |-
+                                      TolerationSeconds represents the period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                      negative values will be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration
-                                      matches to. If the operator is Exists, the value
-                                      should be empty, otherwise just a regular string.
+                                    description: |-
+                                      Value is the taint value the toleration matches to.
+                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how
-                                a group of pods ought to spread across topology domains.
-                                Scheduler will schedule pods in a way which abides
-                                by the constraints. All topologySpreadConstraints
-                                are ANDed.
+                              description: |-
+                                TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                                domains. Scheduler will schedule pods in a way which abides by the constraints.
+                                All topologySpreadConstraints are ANDed.
                               items:
                                 description: TopologySpreadConstraint specifies how
                                   to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: LabelSelector is used to find matching
-                                      pods. Pods that match this label selector are
-                                      counted to determine the number of pods in their
-                                      corresponding topology domain.
+                                    description: |-
+                                      LabelSelector is used to find matching pods.
+                                      Pods that match this label selector are counted to determine the number of pods
+                                      in their corresponding topology domain.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
                                           label selector requirements. The requirements
                                           are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -5877,91 +5383,79 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label
-                                      keys to select the pods over which spreading
-                                      will be calculated. The keys are used to lookup
-                                      values from the incoming pod labels, those key-value
-                                      labels are ANDed with labelSelector to select
-                                      the group of existing pods over which spreading
-                                      will be calculated for the incoming pod. The
-                                      same key is forbidden to exist in both MatchLabelKeys
-                                      and LabelSelector.
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select the pods over which
+                                      spreading will be calculated. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are ANDed with labelSelector
+                                      to select the group of existing pods over which spreading will be calculated
+                                      for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   maxSkew:
-                                    description: MaxSkew describes the degree to which
-                                      pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                                      it is the maximum permitted difference between
-                                      the number of matching pods in the target topology
-                                      and the global minimum. The global minimum is
-                                      the minimum number of matching pods in an eligible
-                                      domain or zero if the number of eligible domains
-                                      is less than MinDomains.
+                                    description: |-
+                                      MaxSkew describes the degree to which pods may be unevenly distributed.
+                                      When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                      between the number of matching pods in the target topology and the global minimum.
+                                      The global minimum is the minimum number of matching pods in an eligible domain
+                                      or zero if the number of eligible domains is less than MinDomains.
                                     format: int32
                                     type: integer
                                   minDomains:
-                                    description: MinDomains indicates a minimum number
-                                      of eligible domains. When the number of eligible
-                                      domains with matching topology keys is less
-                                      than minDomains, Pod Topology Spread treats
-                                      "global minimum" as 0, and then the calculation
-                                      of Skew is performed. And when the number of
-                                      eligible domains with matching topology keys
-                                      equals or greater than minDomains, this value
-                                      has no effect on scheduling.
+                                    description: |-
+                                      MinDomains indicates a minimum number of eligible domains.
+                                      When the number of eligible domains with matching topology keys is less than minDomains,
+                                      Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                      And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                      this value has no effect on scheduling.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: "NodeAffinityPolicy indicates how
-                                      we will treat Pod's nodeAffinity/nodeSelector
-                                      when calculating pod topology spread skew. Options
-                                      are: - Honor: only nodes matching nodeAffinity/nodeSelector
-                                      are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored. All nodes
-                                      are included in the calculations. \n If this
-                                      value is nil, the behavior is equivalent to
-                                      the Honor policy."
+                                    description: |-
+                                      NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                      when calculating pod topology spread skew. Options are:
+                                      - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                      - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                                      If this value is nil, the behavior is equivalent to the Honor policy.
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: "NodeTaintsPolicy indicates how we
-                                      will treat node taints when calculating pod
-                                      topology spread skew. Options are: - Honor:
-                                      nodes without taints, along with tainted nodes
-                                      for which the incoming pod has a toleration,
-                                      are included. - Ignore: node taints are ignored.
-                                      All nodes are included. \n If this value is
-                                      nil, the behavior is equivalent to the Ignore
-                                      policy."
+                                    description: |-
+                                      NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                      pod topology spread skew. Options are:
+                                      - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                      has a toleration, are included.
+                                      - Ignore: node taints are ignored. All nodes are included.
+
+
+                                      If this value is nil, the behavior is equivalent to the Ignore policy.
                                     type: string
                                   topologyKey:
-                                    description: TopologyKey is the key of node labels.
-                                      Nodes that have a label with this key and identical
-                                      values are considered to be in the same topology.
-                                      We consider each <key, value> as a "bucket",
-                                      and try to put balanced number of pods into
-                                      each bucket. We define a domain as a particular
-                                      instance of a topology.
+                                    description: |-
+                                      TopologyKey is the key of node labels. Nodes that have a label with this key
+                                      and identical values are considered to be in the same topology.
+                                      We consider each <key, value> as a "bucket", and try to put balanced number
+                                      of pods into each bucket.
+                                      We define a domain as a particular instance of a topology.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: WhenUnsatisfiable indicates how to
-                                      deal with a pod if it doesn't satisfy the spread
-                                      constraint. - DoNotSchedule (default) tells
-                                      the scheduler not to schedule it. - ScheduleAnyway
-                                      tells the scheduler to schedule the pod in any
-                                      location, but giving higher precedence to topologies
-                                      that would help reduce the skew.
+                                    description: |-
+                                      WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                      the spread constraint.
+                                      - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                      - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                        but giving higher precedence to topologies that would help reduce the
+                                        skew.
                                     type: string
                                 required:
                                 - maxSkew
@@ -5974,49 +5468,45 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: 'List of volumes that can be mounted by
-                                containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                              description: |-
+                                List of volumes that can be mounted by containers belonging to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes
                               items:
                                 description: Volume represents a named volume in a
                                   pod that may be accessed by any container in the
                                   pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'awsElasticBlockStore represents
-                                      an AWS Disk resource that is attached to a kubelet''s
-                                      host machine and then exposed to the pod. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    description: |-
+                                      awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       partition:
-                                        description: 'partition is the partition in
-                                          the volume that you want to mount. If omitted,
-                                          the default is to mount by volume name.
-                                          Examples: For volume /dev/sda1, you specify
-                                          the partition as "1". Similarly, the volume
-                                          partition for /dev/sda is "0" (or you can
-                                          leave the property empty).'
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'readOnly value true will force
-                                          the readOnly setting in VolumeMounts. More
-                                          info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: |-
+                                          readOnly value true will force the readOnly setting in VolumeMounts.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                         type: boolean
                                       volumeID:
-                                        description: 'volumeID is unique ID of the
-                                          persistent disk resource in AWS (Amazon
-                                          EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: |-
+                                          volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                         type: string
                                     required:
                                     - volumeID
@@ -6039,11 +5529,10 @@ spec:
                                           in the blob storage
                                         type: string
                                       fsType:
-                                        description: fsType is Filesystem type to
-                                          mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is Filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       kind:
                                         description: 'kind expected values are Shared:
@@ -6053,9 +5542,9 @@ spec:
                                           availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: readOnly Defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                     required:
                                     - diskName
@@ -6067,9 +5556,9 @@ spec:
                                       the pod.
                                     properties:
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretName:
                                         description: secretName is the  name of secret
@@ -6089,9 +5578,9 @@ spec:
                                       on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'monitors is Required: Monitors
-                                          is a collection of Ceph monitors More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          monitors is Required: Monitors is a collection of Ceph monitors
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         items:
                                           type: string
                                         type: array
@@ -6101,71 +5590,72 @@ spec:
                                           tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'readOnly is Optional: Defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.
-                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: boolean
                                       secretFile:
-                                        description: 'secretFile is Optional: SecretFile
-                                          is the path to key ring for User, default
-                                          is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: string
                                       secretRef:
-                                        description: 'secretRef is Optional: SecretRef
-                                          is reference to the authentication secret
-                                          for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       user:
-                                        description: 'user is optional: User is the
-                                          rados user name, default is admin More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          user is optional: User is the rados user name, default is admin
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'cinder represents a cinder volume
-                                      attached and mounted on kubelets host machine.
-                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    description: |-
+                                      cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: string
                                       readOnly:
-                                        description: 'readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is optional: points
-                                          to a secret object containing parameters
-                                          used to connect to OpenStack.'
+                                        description: |-
+                                          secretRef is optional: points to a secret object containing parameters used to connect
+                                          to OpenStack.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       volumeID:
-                                        description: 'volumeID used to identify the
-                                          volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          volumeID used to identify the volume in cinder.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: string
                                     required:
                                     - volumeID
@@ -6175,25 +5665,21 @@ spec:
                                       that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'defaultMode is optional: mode
-                                          bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          defaultMode is optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
-                                        description: items if unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          ConfigMap will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present.
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -6202,23 +5688,19 @@ spec:
                                               description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'mode is Optional: mode
-                                                bits used to set permissions on this
-                                                file. Must be an octal value between
-                                                0000 and 0777 or a decimal value between
-                                                0 and 511. YAML accepts both octal
-                                                and decimal values, JSON requires
-                                                decimal values for mode bits. If not
-                                                specified, the volume defaultMode
-                                                will be used.'
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
-                                              description: path is the relative path
-                                                of the file to map the key to. May
-                                                not be an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -6226,10 +5708,10 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: optional specify whether the
@@ -6243,48 +5725,43 @@ spec:
                                       by certain external CSI drivers (Beta feature).
                                     properties:
                                       driver:
-                                        description: driver is the name of the CSI
-                                          driver that handles this volume. Consult
-                                          with your admin for the correct name as
-                                          registered in the cluster.
+                                        description: |-
+                                          driver is the name of the CSI driver that handles this volume.
+                                          Consult with your admin for the correct name as registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: fsType to mount. Ex. "ext4",
-                                          "xfs", "ntfs". If not provided, the empty
-                                          value is passed to the associated CSI driver
-                                          which will determine the default filesystem
-                                          to apply.
+                                        description: |-
+                                          fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                          If not provided, the empty value is passed to the associated CSI driver
+                                          which will determine the default filesystem to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: nodePublishSecretRef is a reference
-                                          to the secret object containing sensitive
-                                          information to pass to the CSI driver to
-                                          complete the CSI NodePublishVolume and NodeUnpublishVolume
-                                          calls. This field is optional, and  may
-                                          be empty if no secret is required. If the
-                                          secret object contains more than one secret,
-                                          all secret references are passed.
+                                        description: |-
+                                          nodePublishSecretRef is a reference to the secret object containing
+                                          sensitive information to pass to the CSI driver to complete the CSI
+                                          NodePublishVolume and NodeUnpublishVolume calls.
+                                          This field is optional, and  may be empty if no secret is required. If the
+                                          secret object contains more than one secret, all secret references are passed.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       readOnly:
-                                        description: readOnly specifies a read-only
-                                          configuration for the volume. Defaults to
-                                          false (read/write).
+                                        description: |-
+                                          readOnly specifies a read-only configuration for the volume.
+                                          Defaults to false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: volumeAttributes stores driver-specific
-                                          properties that are passed to the CSI driver.
-                                          Consult your driver's documentation for
-                                          supported values.
+                                        description: |-
+                                          volumeAttributes stores driver-specific properties that are passed to the CSI
+                                          driver. Consult your driver's documentation for supported values.
                                         type: object
                                     required:
                                     - driver
@@ -6294,16 +5771,13 @@ spec:
                                       about the pod that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on
-                                          created files by default. Must be a Optional:
-                                          mode bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          Optional: mode bits to use on created files by default. Must be a
+                                          Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
@@ -6333,14 +5807,11 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file, must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.'
+                                              description: |-
+                                                Optional: mode bits used to set permissions on this file, must be an octal value
+                                                between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
@@ -6352,11 +5823,9 @@ spec:
                                                 path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                requests.cpu and requests.memory)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -6386,56 +5855,51 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'emptyDir represents a temporary
-                                      directory that shares a pod''s lifetime. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    description: |-
+                                      emptyDir represents a temporary directory that shares a pod's lifetime.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     properties:
                                       medium:
-                                        description: 'medium represents what type
-                                          of storage medium should back this directory.
-                                          The default is "" which means to use the
-                                          node''s default medium. Must be an empty
-                                          string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: |-
+                                          medium represents what type of storage medium should back this directory.
+                                          The default is "" which means to use the node's default medium.
+                                          Must be an empty string (default) or Memory.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'sizeLimit is the total amount
-                                          of local storage required for this EmptyDir
-                                          volume. The size limit is also applicable
-                                          for memory medium. The maximum usage on
-                                          memory medium EmptyDir would be the minimum
-                                          value between the SizeLimit specified here
-                                          and the sum of memory limits of all containers
-                                          in a pod. The default is nil which means
-                                          that the limit is undefined. More info:
-                                          https://kubernetes.'
+                                        description: |-
+                                          sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                          The size limit is also applicable for memory medium.
+                                          The maximum usage on memory medium EmptyDir would be the minimum value between
+                                          the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                          The default is nil which means that the limit is undefined.
+                                          More info: https://kubernetes.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: ephemeral represents a volume that
-                                      is handled by a cluster storage driver. The
-                                      volume's lifecycle is tied to the pod that defines
-                                      it - it will be created before the pod starts,
+                                    description: |-
+                                      ephemeral represents a volume that is handled by a cluster storage driver.
+                                      The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                                       and deleted when the pod is removed.
                                     properties:
                                       volumeClaimTemplate:
-                                        description: Will be used to create a stand-alone
-                                          PVC to provision the volume. The pod in
-                                          which this EphemeralVolumeSource is embedded
-                                          will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.  The
-                                          name of the PVC will be `<pod name>-<volume
-                                          name>` where `<volume name>` is the name
-                                          from the `PodSpec.Volumes` array entry.
+                                        description: |-
+                                          Will be used to create a stand-alone PVC to provision the volume.
+                                          The pod in which this EphemeralVolumeSource is embedded will be the
+                                          owner of the PVC, i.e. the PVC will be deleted together with the
+                                          pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                          `<volume name>` is the name from the `PodSpec.Volumes` array
+                                          entry.
                                         properties:
                                           metadata:
-                                            description: May contain labels and annotations
-                                              that will be copied into the PVC when
-                                              creating it. No other fields are allowed
-                                              and will be rejected during validation.
+                                            description: |-
+                                              May contain labels and annotations that will be copied into the PVC
+                                              when creating it. No other fields are allowed and will be rejected during
+                                              validation.
                                             properties:
                                               annotations:
                                                 additionalProperties:
@@ -6455,39 +5919,32 @@ spec:
                                                 type: string
                                             type: object
                                           spec:
-                                            description: The specification for the
-                                              PersistentVolumeClaim. The entire content
-                                              is copied unchanged into the PVC that
-                                              gets created from this template. The
-                                              same fields as in a PersistentVolumeClaim
+                                            description: |-
+                                              The specification for the PersistentVolumeClaim. The entire content is
+                                              copied unchanged into the PVC that gets created from this
+                                              template. The same fields as in a PersistentVolumeClaim
                                               are also valid here.
                                             properties:
                                               accessModes:
-                                                description: 'accessModes contains
-                                                  the desired access modes the volume
-                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                description: |-
+                                                  accessModes contains the desired access modes the volume should have.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                                 items:
                                                   type: string
                                                 type: array
                                               dataSource:
-                                                description: 'dataSource field can
-                                                  be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                description: |-
+                                                  dataSource field can be used to specify either:
+                                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                                   * An existing PVC (PersistentVolumeClaim)
-                                                  If the provisioner or an external
-                                                  controller can support the specified
-                                                  data source, it will create a new
-                                                  volume based on the contents of
-                                                  the specified data source.'
+                                                  If the provisioner or an external controller can support the specified data source,
+                                                  it will create a new volume based on the contents of the specified data source.
                                                 properties:
                                                   apiGroup:
-                                                    description: APIGroup is the group
-                                                      for the resource being referenced.
-                                                      If APIGroup is not specified,
-                                                      the specified Kind must be in
-                                                      the core API group. For any
-                                                      other third-party types, APIGroup
-                                                      is required.
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
                                                     type: string
                                                   kind:
                                                     description: Kind is the type
@@ -6503,26 +5960,19 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               dataSourceRef:
-                                                description: dataSourceRef specifies
-                                                  the object from which to populate
-                                                  the volume with data, if a non-empty
-                                                  volume is desired. This may be any
-                                                  object from a non-empty API group
-                                                  (non core object) or a PersistentVolumeClaim
-                                                  object. When this field is specified,
-                                                  volume binding will only succeed
-                                                  if the type of the specified object
-                                                  matches some installed volume populator
-                                                  or dynamic provisioner.
+                                                description: |-
+                                                  dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                                  volume is desired. This may be any object from a non-empty API group (non
+                                                  core object) or a PersistentVolumeClaim object.
+                                                  When this field is specified, volume binding will only succeed if the type of
+                                                  the specified object matches some installed volume populator or dynamic
+                                                  provisioner.
                                                 properties:
                                                   apiGroup:
-                                                    description: APIGroup is the group
-                                                      for the resource being referenced.
-                                                      If APIGroup is not specified,
-                                                      the specified Kind must be in
-                                                      the core API group. For any
-                                                      other third-party types, APIGroup
-                                                      is required.
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
                                                     type: string
                                                   kind:
                                                     description: Kind is the type
@@ -6533,54 +5983,42 @@ spec:
                                                       of resource being referenced
                                                     type: string
                                                   namespace:
-                                                    description: Namespace is the
-                                                      namespace of resource being
-                                                      referenced Note that when a
-                                                      namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
-                                                      object is required in the referent
-                                                      namespace to allow that namespace's
-                                                      owner to accept the reference.
-                                                      See the ReferenceGrant documentation
-                                                      for details. (Alpha) This field
-                                                      requires the CrossNamespaceVolumeDataSource
-                                                      feature gate to be enabled.
+                                                    description: |-
+                                                      Namespace is the namespace of resource being referenced
+                                                      Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                      (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                                     type: string
                                                 required:
                                                 - kind
                                                 - name
                                                 type: object
                                               resources:
-                                                description: 'resources represents
-                                                  the minimum resources the volume
-                                                  should have. If RecoverVolumeExpansionFailure
-                                                  feature is enabled users are allowed
-                                                  to specify resource requirements
-                                                  that are lower than previous value
-                                                  but must still be higher than capacity
-                                                  recorded in the status field of
-                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                description: |-
+                                                  resources represents the minimum resources the volume should have.
+                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  that are lower than previous value but must still be higher than capacity recorded in the
+                                                  status field of the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                                 properties:
                                                   claims:
-                                                    description: "Claims lists the
-                                                      names of resources, defined
-                                                      in spec.resourceClaims, that
-                                                      are used by this container.
-                                                      \n This is an alpha field and
-                                                      requires enabling the DynamicResourceAllocation
-                                                      feature gate. \n This field
-                                                      is immutable. It can only be
-                                                      set for containers."
+                                                    description: |-
+                                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                                      that are used by this container.
+
+
+                                                      This is an alpha field and requires enabling the
+                                                      DynamicResourceAllocation feature gate.
+
+
+                                                      This field is immutable. It can only be set for containers.
                                                     items:
                                                       description: ResourceClaim references
                                                         one entry in PodSpec.ResourceClaims.
                                                       properties:
                                                         name:
-                                                          description: Name must match
-                                                            the name of one entry
-                                                            in pod.spec.resourceClaims
-                                                            of the Pod where this
-                                                            field is used. It makes
-                                                            that resource available
+                                                          description: |-
+                                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                                            the Pod where this field is used. It makes that resource available
                                                             inside a container.
                                                           type: string
                                                       required:
@@ -6597,10 +6035,9 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: 'Limits describes
-                                                      the maximum amount of compute
-                                                      resources allowed. More info:
-                                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    description: |-
+                                                      Limits describes the maximum amount of compute resources allowed.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -6609,15 +6046,11 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: 'Requests describes
-                                                      the minimum amount of compute
-                                                      resources required. If Requests
-                                                      is omitted for a container,
-                                                      it defaults to Limits if that
-                                                      is explicitly specified, otherwise
-                                                      to an implementation-defined
-                                                      value. Requests cannot exceed
-                                                      Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    description: |-
+                                                      Requests describes the minimum amount of compute resources required.
+                                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                 type: object
                                               selector:
@@ -6630,11 +6063,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -6642,23 +6073,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -6670,28 +6094,22 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               storageClassName:
-                                                description: 'storageClassName is
-                                                  the name of the StorageClass required
-                                                  by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                description: |-
+                                                  storageClassName is the name of the StorageClass required by the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                                 type: string
                                               volumeMode:
-                                                description: volumeMode defines what
-                                                  type of volume is required by the
-                                                  claim. Value of Filesystem is implied
-                                                  when not included in claim spec.
+                                                description: |-
+                                                  volumeMode defines what type of volume is required by the claim.
+                                                  Value of Filesystem is implied when not included in claim spec.
                                                 type: string
                                               volumeName:
                                                 description: volumeName is the binding
@@ -6709,13 +6127,11 @@ spec:
                                       and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. TODO: how do we prevent
-                                          errors in the filesystem from compromising
-                                          the machine'
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       lun:
                                         description: 'lun is Optional: FC target lun
@@ -6723,9 +6139,9 @@ spec:
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'readOnly is Optional: Defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.'
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       targetWWNs:
                                         description: 'targetWWNs is Optional: FC target
@@ -6734,29 +6150,27 @@ spec:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'wwids Optional: FC volume world
-                                          wide identifiers (wwids) Either wwids or
-                                          combination of targetWWNs and lun must be
-                                          set, but not both simultaneously.'
+                                        description: |-
+                                          wwids Optional: FC volume world wide identifiers (wwids)
+                                          Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: flexVolume represents a generic volume
-                                      resource that is provisioned/attached using
-                                      an exec based plugin.
+                                    description: |-
+                                      flexVolume represents a generic volume resource that is
+                                      provisioned/attached using an exec based plugin.
                                     properties:
                                       driver:
                                         description: driver is the name of the driver
                                           to use for this volume.
                                         type: string
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". The default filesystem depends
-                                          on FlexVolume script.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
@@ -6765,24 +6179,23 @@ spec:
                                           holds extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'readOnly is Optional: defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.'
+                                        description: |-
+                                          readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is Optional: secretRef
-                                          is reference to the secret object containing
-                                          sensitive information to pass to the plugin
-                                          scripts. This may be empty if no secret
-                                          object is specified. If the secret object
-                                          contains more than one secret, all secrets
-                                          are passed to the plugin scripts.'
+                                        description: |-
+                                          secretRef is Optional: secretRef is reference to the secret object containing
+                                          sensitive information to pass to the plugin scripts. This may be
+                                          empty if no secret object is specified. If the secret object
+                                          contains more than one secret, all secrets are passed to the plugin
+                                          scripts.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -6795,9 +6208,9 @@ spec:
                                       on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: datasetName is Name of the dataset
-                                          stored as metadata -> name on the dataset
-                                          for Flocker should be considered as deprecated
+                                        description: |-
+                                          datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                          should be considered as deprecated
                                         type: string
                                       datasetUUID:
                                         description: datasetUUID is the UUID of the
@@ -6806,60 +6219,55 @@ spec:
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'gcePersistentDisk represents a GCE
-                                      Disk resource that is attached to a kubelet''s
-                                      host machine and then exposed to the pod. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    description: |-
+                                      gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                     properties:
                                       fsType:
-                                        description: 'fsType is filesystem type of
-                                          the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       partition:
-                                        description: 'partition is the partition in
-                                          the volume that you want to mount. If omitted,
-                                          the default is to mount by volume name.
-                                          Examples: For volume /dev/sda1, you specify
-                                          the partition as "1". Similarly, the volume
-                                          partition for /dev/sda is "0" (or you can
-                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'pdName is unique name of the
-                                          PD resource in GCE. Used to identify the
-                                          disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         type: boolean
                                     required:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'gitRepo represents a git repository
-                                      at a particular revision. DEPRECATED: GitRepo
-                                      is deprecated. To provision a container with
-                                      a git repo, mount an EmptyDir into an InitContainer
-                                      that clones the repo using git, then mount the
-                                      EmptyDir into the Pod''s container.'
+                                    description: |-
+                                      gitRepo represents a git repository at a particular revision.
+                                      DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                      EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                      into the Pod's container.
                                     properties:
                                       directory:
-                                        description: directory is the target directory
-                                          name. Must not contain or start with '..'.  If
-                                          '.' is supplied, the volume directory will
-                                          be the git repository.  Otherwise, if specified,
-                                          the volume will contain the git repository
-                                          in the subdirectory with the given name.
+                                        description: |-
+                                          directory is the target directory name.
+                                          Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                          git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                          the subdirectory with the given name.
                                         type: string
                                       repository:
                                         description: repository is the URL
@@ -6872,54 +6280,58 @@ spec:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'glusterfs represents a Glusterfs
-                                      mount on the host that shares a pod''s lifetime.
-                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                    description: |-
+                                      glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                     properties:
                                       endpoints:
-                                        description: 'endpoints is the endpoint name
-                                          that details Glusterfs topology. More info:
-                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          endpoints is the endpoint name that details Glusterfs topology.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: string
                                       path:
-                                        description: 'path is the Glusterfs volume
-                                          path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          path is the Glusterfs volume path.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          Glusterfs volume to be mounted with read-only
-                                          permissions. Defaults to false. More info:
-                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: boolean
                                     required:
                                     - endpoints
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'hostPath represents a pre-existing
-                                      file or directory on the host machine that is
-                                      directly exposed to the container. This is generally
-                                      used for system agents or other privileged things
-                                      that are allowed to see the host machine. Most
-                                      containers will NOT need this. More info: https://kubernetes.'
+                                    description: |-
+                                      hostPath represents a pre-existing file or directory on the host
+                                      machine that is directly exposed to the container. This is generally
+                                      used for system agents or other privileged things that are allowed
+                                      to see the host machine. Most containers will NOT need this.
+                                      More info: https://kubernetes.
                                     properties:
                                       path:
-                                        description: 'path of the directory on the
-                                          host. If the path is a symlink, it will
-                                          follow the link to the real path. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        description: |-
+                                          path of the directory on the host.
+                                          If the path is a symlink, it will follow the link to the real path.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                         type: string
                                       type:
-                                        description: 'type for HostPath Volume Defaults
-                                          to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        description: |-
+                                          type for HostPath Volume
+                                          Defaults to ""
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'iscsi represents an ISCSI Disk resource
-                                      that is attached to a kubelet''s host machine
-                                      and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                    description: |-
+                                      iscsi represents an ISCSI Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://examples.k8s.io/volumes/iscsi/README.md
                                     properties:
                                       chapAuthDiscovery:
                                         description: chapAuthDiscovery defines whether
@@ -6930,31 +6342,27 @@ spec:
                                           support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       initiatorName:
-                                        description: initiatorName is the custom iSCSI
-                                          Initiator Name. If initiatorName is specified
-                                          with iscsiInterface simultaneously, new
-                                          iSCSI interface <target portal>:<volume
-                                          name> will be created for the connection.
+                                        description: |-
+                                          initiatorName is the custom iSCSI Initiator Name.
+                                          If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                          <target portal>:<volume name> will be created for the connection.
                                         type: string
                                       iqn:
                                         description: iqn is the target iSCSI Qualified
                                           Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iscsiInterface is the interface
-                                          Name that uses an iSCSI transport. Defaults
-                                          to 'default' (tcp).
+                                        description: |-
+                                          iscsiInterface is the interface Name that uses an iSCSI transport.
+                                          Defaults to 'default' (tcp).
                                         type: string
                                       lun:
                                         description: lun represents iSCSI Target Lun
@@ -6962,35 +6370,33 @@ spec:
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: portals is the iSCSI Target Portal
-                                          List. The portal is either an IP or ip_addr:port
-                                          if the port is other than default (typically
-                                          TCP ports 860 and 3260).
+                                        description: |-
+                                          portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false.
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
                                         type: boolean
                                       secretRef:
                                         description: secretRef is the CHAP Secret
                                           for iSCSI target and initiator authentication
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       targetPortal:
-                                        description: targetPortal is iSCSI Target
-                                          Portal. The Portal is either an IP or ip_addr:port
-                                          if the port is other than default (typically
-                                          TCP ports 860 and 3260).
+                                        description: |-
+                                          targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -6998,45 +6404,51 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'name of the volume. Must be a DNS_LABEL
-                                      and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: |-
+                                      name of the volume.
+                                      Must be a DNS_LABEL and unique within the pod.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                   nfs:
-                                    description: 'nfs represents an NFS mount on the
-                                      host that shares a pod''s lifetime More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    description: |-
+                                      nfs represents an NFS mount on the host that shares a pod's lifetime
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                     properties:
                                       path:
-                                        description: 'path that is exported by the
-                                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          path that is exported by the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          NFS export to be mounted with read-only
-                                          permissions. Defaults to false. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          readOnly here will force the NFS export to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: boolean
                                       server:
-                                        description: 'server is the hostname or IP
-                                          address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          server is the hostname or IP address of the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: string
                                     required:
                                     - path
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'persistentVolumeClaimVolumeSource
-                                      represents a reference to a PersistentVolumeClaim
-                                      in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    description: |-
+                                      persistentVolumeClaimVolumeSource represents a reference to a
+                                      PersistentVolumeClaim in the same namespace.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                     properties:
                                       claimName:
-                                        description: 'claimName is the name of a PersistentVolumeClaim
-                                          in the same namespace as the pod using this
-                                          volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        description: |-
+                                          claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                         type: string
                                       readOnly:
-                                        description: readOnly Will force the ReadOnly
-                                          setting in VolumeMounts. Default false.
+                                        description: |-
+                                          readOnly Will force the ReadOnly setting in VolumeMounts.
+                                          Default false.
                                         type: boolean
                                     required:
                                     - claimName
@@ -7047,11 +6459,10 @@ spec:
                                       mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       pdID:
                                         description: pdID is the ID that identifies
@@ -7066,16 +6477,15 @@ spec:
                                       machine
                                     properties:
                                       fsType:
-                                        description: fSType represents the filesystem
-                                          type to mount Must be a filesystem type
-                                          supported by the host operating system.
-                                          Ex. "ext4", "xfs". Implicitly inferred to
-                                          be "ext4" if unspecified.
+                                        description: |-
+                                          fSType represents the filesystem type to mount
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       volumeID:
                                         description: volumeID uniquely identifies
@@ -7089,14 +6499,11 @@ spec:
                                       secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: defaultMode are the mode bits
-                                          used to set permissions on created files
-                                          by default. Must be an octal value between
-                                          0000 and 0777 or a decimal value between
-                                          0 and 511. YAML accepts both octal and decimal
-                                          values, JSON requires decimal values for
-                                          mode bits. Directories within the path are
-                                          not affected by this setting.
+                                        description: |-
+                                          defaultMode are the mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       sources:
@@ -7111,15 +6518,12 @@ spec:
                                                 the configMap data to project
                                               properties:
                                                 items:
-                                                  description: items if unspecified,
-                                                    each key-value pair in the Data
-                                                    field of the referenced ConfigMap
-                                                    will be projected into the volume
-                                                    as a file whose name is the key
-                                                    and content is the value. If specified,
-                                                    the listed keys will be projected
-                                                    into the specified paths, and
-                                                    unlisted keys will not be present.
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    ConfigMap will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7129,27 +6533,19 @@ spec:
                                                           to project.
                                                         type: string
                                                       mode:
-                                                        description: 'mode is Optional:
-                                                          mode bits used to set permissions
-                                                          on this file. Must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: path is the relative
-                                                          path of the file to map
-                                                          the key to. May not be an
-                                                          absolute path. May not contain
-                                                          the path element '..'. May
-                                                          not start with the string
-                                                          '..'.
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -7157,10 +6553,10 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: optional specify whether
@@ -7204,17 +6600,11 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
-                                                          on this file, must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7229,12 +6619,9 @@ spec:
                                                           ''..'''
                                                         type: string
                                                       resourceFieldRef:
-                                                        description: 'Selects a resource
-                                                          of the container: only resources
-                                                          limits and requests (limits.cpu,
-                                                          limits.memory, requests.cpu
-                                                          and requests.memory) are
-                                                          currently supported.'
+                                                        description: |-
+                                                          Selects a resource of the container: only resources limits and requests
+                                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                         properties:
                                                           containerName:
                                                             description: 'Container
@@ -7269,15 +6656,12 @@ spec:
                                                 the secret data to project
                                               properties:
                                                 items:
-                                                  description: items if unspecified,
-                                                    each key-value pair in the Data
-                                                    field of the referenced Secret
-                                                    will be projected into the volume
-                                                    as a file whose name is the key
-                                                    and content is the value. If specified,
-                                                    the listed keys will be projected
-                                                    into the specified paths, and
-                                                    unlisted keys will not be present.
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    Secret will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7287,27 +6671,19 @@ spec:
                                                           to project.
                                                         type: string
                                                       mode:
-                                                        description: 'mode is Optional:
-                                                          mode bits used to set permissions
-                                                          on this file. Must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: path is the relative
-                                                          path of the file to map
-                                                          the key to. May not be an
-                                                          absolute path. May not contain
-                                                          the path element '..'. May
-                                                          not start with the string
-                                                          '..'.
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -7315,10 +6691,10 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: optional field specify
@@ -7333,35 +6709,26 @@ spec:
                                                 data to project
                                               properties:
                                                 audience:
-                                                  description: audience is the intended
-                                                    audience of the token. A recipient
-                                                    of a token must identify itself
-                                                    with an identifier specified in
-                                                    the audience of the token, and
-                                                    otherwise should reject the token.
-                                                    The audience defaults to the identifier
-                                                    of the apiserver.
+                                                  description: |-
+                                                    audience is the intended audience of the token. A recipient of a token
+                                                    must identify itself with an identifier specified in the audience of the
+                                                    token, and otherwise should reject the token. The audience defaults to the
+                                                    identifier of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: expirationSeconds is
-                                                    the requested duration of validity
-                                                    of the service account token.
-                                                    As the token approaches expiration,
-                                                    the kubelet volume plugin will
-                                                    proactively rotate the service
-                                                    account token. The kubelet will
-                                                    start trying to rotate the token
-                                                    if the token is older than 80
-                                                    percent of its time to live or
-                                                    if the token is older than 24
-                                                    hours.Defaults to 1 hour and must
-                                                    be at least 10 minutes.
+                                                  description: |-
+                                                    expirationSeconds is the requested duration of validity of the service
+                                                    account token. As the token approaches expiration, the kubelet volume
+                                                    plugin will proactively rotate the service account token. The kubelet will
+                                                    start trying to rotate the token if the token is older than 80 percent of
+                                                    its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                    and must be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: path is the path relative
-                                                    to the mount point of the file
-                                                    to project the token into.
+                                                  description: |-
+                                                    path is the path relative to the mount point of the file to project the
+                                                    token into.
                                                   type: string
                                               required:
                                               - path
@@ -7374,29 +6741,29 @@ spec:
                                       on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: group to map volume access to
+                                        description: |-
+                                          group to map volume access to
                                           Default is no group
                                         type: string
                                       readOnly:
-                                        description: readOnly here will force the
-                                          Quobyte volume to be mounted with read-only
-                                          permissions. Defaults to false.
+                                        description: |-
+                                          readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                          Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: registry represents a single
-                                          or multiple Quobyte Registry services specified
-                                          as a string as host:port pair (multiple
-                                          entries are separated with commas) which
-                                          acts as the central registry for volumes
+                                        description: |-
+                                          registry represents a single or multiple Quobyte Registry services
+                                          specified as a string as host:port pair (multiple entries are separated with commas)
+                                          which acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: tenant owning the given Quobyte
-                                          volume in the Backend Used with dynamically
-                                          provisioned Quobyte volumes, value is set
-                                          by the plugin
+                                        description: |-
+                                          tenant owning the given Quobyte volume in the Backend
+                                          Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                         type: string
                                       user:
-                                        description: user to map volume access to
+                                        description: |-
+                                          user to map volume access to
                                           Defaults to serivceaccount user
                                         type: string
                                       volume:
@@ -7408,61 +6775,68 @@ spec:
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'rbd represents a Rados Block Device
-                                      mount on the host that shares a pod''s lifetime.
-                                      More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                    description: |-
+                                      rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       image:
-                                        description: 'image is the rados image name.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       keyring:
-                                        description: 'keyring is the path to key ring
-                                          for RBDUser. Default is /etc/ceph/keyring.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          keyring is the path to key ring for RBDUser.
+                                          Default is /etc/ceph/keyring.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       monitors:
-                                        description: 'monitors is a collection of
-                                          Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          monitors is a collection of Ceph monitors.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'pool is the rados pool name.
-                                          Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          pool is the rados pool name.
+                                          Default is rbd.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is name of the authentication
-                                          secret for RBDUser. If provided overrides
-                                          keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          secretRef is name of the authentication secret for RBDUser. If provided
+                                          overrides keyring.
+                                          Default is nil.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       user:
-                                        description: 'user is the rados user name.
-                                          Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          user is the rados user name.
+                                          Default is admin.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                     required:
                                     - image
@@ -7473,10 +6847,11 @@ spec:
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Default is "xfs".
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs".
+                                          Default is "xfs".
                                         type: string
                                       gateway:
                                         description: gateway is the host address of
@@ -7488,21 +6863,20 @@ spec:
                                           configured storage.
                                         type: string
                                       readOnly:
-                                        description: readOnly Defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: secretRef references to the secret
-                                          for ScaleIO user and other sensitive information.
-                                          If this is not provided, Login operation
-                                          will fail.
+                                        description: |-
+                                          secretRef references to the secret for ScaleIO user and other
+                                          sensitive information. If this is not provided, Login operation will fail.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -7512,9 +6886,9 @@ spec:
                                           false
                                         type: boolean
                                       storageMode:
-                                        description: storageMode indicates whether
-                                          the storage for a volume should be ThickProvisioned
-                                          or ThinProvisioned. Default is ThinProvisioned.
+                                        description: |-
+                                          storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                          Default is ThinProvisioned.
                                         type: string
                                       storagePool:
                                         description: storagePool is the ScaleIO Storage
@@ -7525,9 +6899,9 @@ spec:
                                           system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: volumeName is the name of a volume
-                                          already created in the ScaleIO system that
-                                          is associated with this volume source.
+                                        description: |-
+                                          volumeName is the name of a volume already created in the ScaleIO system
+                                          that is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -7535,29 +6909,26 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'secret represents a secret that
-                                      should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    description: |-
+                                      secret represents a secret that should populate this volume.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                     properties:
                                       defaultMode:
-                                        description: 'defaultMode is Optional: mode
-                                          bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values
+                                          for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
-                                        description: items If unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          Secret will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present.
+                                        description: |-
+                                          items If unspecified, each key-value pair in the Data field of the referenced
+                                          Secret will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -7566,23 +6937,19 @@ spec:
                                               description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'mode is Optional: mode
-                                                bits used to set permissions on this
-                                                file. Must be an octal value between
-                                                0000 and 0777 or a decimal value between
-                                                0 and 511. YAML accepts both octal
-                                                and decimal values, JSON requires
-                                                decimal values for mode bits. If not
-                                                specified, the volume defaultMode
-                                                will be used.'
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
-                                              description: path is the relative path
-                                                of the file to map the key to. May
-                                                not be an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -7594,9 +6961,9 @@ spec:
                                           the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'secretName is the name of the
-                                          secret in the pod''s namespace to use. More
-                                          info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        description: |-
+                                          secretName is the name of the secret in the pod's namespace to use.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                         type: string
                                     type: object
                                   storageos:
@@ -7604,45 +6971,41 @@ spec:
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: secretRef specifies the secret
-                                          to use for obtaining the StorageOS API credentials.  If
-                                          not specified, default values will be attempted.
+                                        description: |-
+                                          secretRef specifies the secret to use for obtaining the StorageOS API
+                                          credentials.  If not specified, default values will be attempted.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       volumeName:
-                                        description: volumeName is the human-readable
-                                          name of the StorageOS volume.  Volume names
-                                          are only unique within a namespace.
+                                        description: |-
+                                          volumeName is the human-readable name of the StorageOS volume.  Volume
+                                          names are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: volumeNamespace specifies the
-                                          scope of the volume within StorageOS.  If
-                                          no namespace is specified then the Pod's
-                                          namespace will be used.  This allows the
-                                          Kubernetes name scoping to be mirrored within
-                                          StorageOS for tighter integration. Set VolumeName
-                                          to any name to override the default behaviour.
-                                          Set to "default" if you are not using namespaces
-                                          within StorageOS.
+                                        description: |-
+                                          volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                          namespace is specified then the Pod's namespace will be used.  This allows the
+                                          Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                          Set VolumeName to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces within StorageOS.
                                         type: string
                                     type: object
                                   vsphereVolume:
@@ -7651,11 +7014,10 @@ spec:
                                       machine
                                     properties:
                                       fsType:
-                                        description: fsType is filesystem type to
-                                          mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
                                         description: storagePolicyID is the storage
@@ -7682,19 +7044,26 @@ spec:
                           type: object
                       type: object
                   type: object
-                description: 'MXReplicaSpecs is map of ReplicaType and ReplicaSpec
-                  specifies the MX replicas to run. For example, { "Scheduler": ReplicaSpec,
-                  "Server": ReplicaSpec, "Worker": ReplicaSpec, }'
+                description: |-
+                  MXReplicaSpecs is map of ReplicaType and ReplicaSpec
+                  specifies the MX replicas to run.
+                  For example,
+                    {
+                      "Scheduler": ReplicaSpec,
+                      "Server": ReplicaSpec,
+                      "Worker": ReplicaSpec,
+                    }
                 type: object
               runPolicy:
-                description: RunPolicy encapsulates various runtime policies of the
-                  distributed training job, for example how to clean up resources
-                  and how long the job can stay active.
+                description: |-
+                  RunPolicy encapsulates various runtime policies of the distributed training
+                  job, for example how to clean up resources and how long the job can stay
+                  active.
                 properties:
                   activeDeadlineSeconds:
-                    description: Specifies the duration in seconds relative to the
-                      startTime that the job may be active before the system tries
-                      to terminate it; value must be positive integer.
+                    description: |-
+                      Specifies the duration in seconds relative to the startTime that the job may be active
+                      before the system tries to terminate it; value must be positive integer.
                     format: int64
                     type: integer
                   backoffLimit:
@@ -7703,8 +7072,9 @@ spec:
                     format: int32
                     type: integer
                   cleanPodPolicy:
-                    description: CleanPodPolicy defines the policy to kill pods after
-                      the job completes. Default to None.
+                    description: |-
+                      CleanPodPolicy defines the policy to kill pods after the job completes.
+                      Default to None.
                     type: string
                   schedulingPolicy:
                     description: SchedulingPolicy defines the policy related to scheduling,
@@ -7731,18 +7101,20 @@ spec:
                     type: object
                   suspend:
                     default: false
-                    description: suspend specifies whether the Job controller should
-                      create Pods or not. If a Job is created with suspend set to
-                      true, no Pods are created by the Job controller. If a Job is
-                      suspended after creation (i.e. the flag goes from false to true),
-                      the Job controller will delete all active Pods and PodGroups
-                      associated with this Job. Users must design their workload to
-                      gracefully handle this.
+                    description: |-
+                      suspend specifies whether the Job controller should create Pods or not.
+                      If a Job is created with suspend set to true, no Pods are created by
+                      the Job controller. If a Job is suspended after creation (i.e. the
+                      flag goes from false to true), the Job controller will delete all
+                      active Pods and PodGroups associated with this Job.
+                      Users must design their workload to gracefully handle this.
                     type: boolean
                   ttlSecondsAfterFinished:
-                    description: TTLSecondsAfterFinished is the TTL to clean up jobs.
+                    description: |-
+                      TTLSecondsAfterFinished is the TTL to clean up jobs.
                       It may take extra ReconcilePeriod seconds for the cleanup, since
-                      reconcile gets called periodically. Default to infinite.
+                      reconcile gets called periodically.
+                      Default to infinite.
                     format: int32
                     type: integer
                 type: object
@@ -7755,8 +7127,9 @@ spec:
               Job.
             properties:
               completionTime:
-                description: Represents time when the job was completed. It is not
-                  guaranteed to be set in happens-before order across separate operations.
+                description: |-
+                  Represents time when the job was completed. It is not guaranteed to
+                  be set in happens-before order across separate operations.
                   It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
@@ -7794,9 +7167,10 @@ spec:
                   type: object
                 type: array
               lastReconcileTime:
-                description: Represents last time when the job was reconciled. It
-                  is not guaranteed to be set in happens-before order across separate
-                  operations. It is represented in RFC3339 form and is in UTC.
+                description: |-
+                  Represents last time when the job was reconciled. It is not guaranteed to
+                  be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               replicaStatuses:
@@ -7819,25 +7193,25 @@ spec:
                           description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -7849,33 +7223,33 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     selector:
-                      description: A Selector is a label query over a set of resources.
-                        The result of matchLabels and matchExpressions are ANDed.
-                        An empty Selector matches all objects. A null Selector matches
-                        no objects.
+                      description: |-
+                        A Selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty Selector matches all objects. A null
+                        Selector matches no objects.
                       type: string
                     succeeded:
                       description: The number of pods which reached phase Succeeded.
                       format: int32
                       type: integer
                   type: object
-                description: ReplicaStatuses is map of ReplicaType and ReplicaStatus,
+                description: |-
+                  ReplicaStatuses is map of ReplicaType and ReplicaStatus,
                   specifies the status of each replica.
                 type: object
               startTime:
-                description: Represents time when the job was acknowledged by the
-                  job controller. It is not guaranteed to be set in happens-before
-                  order across separate operations. It is represented in RFC3339 form
-                  and is in UTC.
+                description: |-
+                  Represents time when the job was acknowledged by the job controller.
+                  It is not guaranteed to be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
             type: object

--- a/manifests/base/crds/kubeflow.org_paddlejobs.yaml
+++ b/manifests/base/crds/kubeflow.org_paddlejobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: paddlejobs.kubeflow.org
 spec:
   group: kubeflow.org
@@ -27,14 +27,19 @@ spec:
         description: PaddleJob Represents a PaddleJob resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -56,26 +61,25 @@ spec:
                     format: int32
                     type: integer
                   metrics:
-                    description: Metrics contains the specifications which are used
-                      to calculate the desired replica count (the maximum replica
-                      count across all metrics will be used).  The desired replica
-                      count is calculated with multiplying the ratio between the target
-                      value and the current value by the current number of pods. Ergo,
-                      metrics used must decrease as the pod count is increased, and
-                      vice-versa.
+                    description: |-
+                      Metrics contains the specifications which are used to calculate the
+                      desired replica count (the maximum replica count across all metrics will
+                      be used).  The desired replica count is calculated with multiplying the
+                      ratio between the target value and the current value by the current
+                      number of pods. Ergo, metrics used must decrease as the pod count is
+                      increased, and vice-versa.
                     items:
-                      description: MetricSpec specifies how to scale based on a single
-                        metric (only `type` and one other matching field should be
-                        set at once).
+                      description: |-
+                        MetricSpec specifies how to scale based on a single metric
+                        (only `type` and one other matching field should be set at once).
                       properties:
                         containerResource:
-                          description: containerResource refers to a resource metric
-                            (such as those specified in requests and limits) known
-                            to Kubernetes describing a single container in each pod
-                            of the current scale target (e.g. CPU or memory). Such
-                            metrics are built in to Kubernetes, and have special scaling
-                            options on top of those available to normal per-pod metrics
-                            using the "pods" source.
+                          description: |-
+                            containerResource refers to a resource metric (such as those specified in
+                            requests and limits) known to Kubernetes describing a single container in
+                            each pod of the current scale target (e.g. CPU or memory). Such metrics are
+                            built in to Kubernetes, and have special scaling options on top of those
+                            available to normal per-pod metrics using the "pods" source.
                           properties:
                             container:
                               description: container is the name of the container
@@ -89,21 +93,20 @@ spec:
                                 given metric
                               properties:
                                 averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a percentage of
                                     the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
+                                    Currently only valid for Resource metric source type
                                   format: int32
                                   type: integer
                                 averageValue:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 type:
@@ -127,11 +130,12 @@ spec:
                           - target
                           type: object
                         external:
-                          description: external refers to a global metric that is
-                            not associated with any Kubernetes object. It allows autoscaling
-                            based on information coming from components running outside
-                            of cluster (for example length of queue in cloud messaging
-                            service, or QPS from loadbalancer running outside of cluster).
+                          description: |-
+                            external refers to a global metric that is not associated
+                            with any Kubernetes object. It allows autoscaling based on information
+                            coming from components running outside of cluster
+                            (for example length of queue in cloud messaging service, or
+                            QPS from loadbalancer running outside of cluster).
                           properties:
                             metric:
                               description: metric identifies the target metric by
@@ -141,40 +145,34 @@ spec:
                                   description: name is the name of the given metric
                                   type: string
                                 selector:
-                                  description: selector is the string-encoded form
-                                    of a standard kubernetes label selector for the
-                                    given metric When set, it is passed as an additional
-                                    parameter to the metrics server for more specific
-                                    metrics scoping. When unset, just the metricName
-                                    will be used to gather metrics.
+                                  description: |-
+                                    selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                    When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                    When unset, just the metricName will be used to gather metrics.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
                                         selector requirements. The requirements are
                                         ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
                                             description: key is the label key that
                                               the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
                                               merge patch.
                                             items:
                                               type: string
@@ -187,12 +185,10 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -204,21 +200,20 @@ spec:
                                 given metric
                               properties:
                                 averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a percentage of
                                     the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
+                                    Currently only valid for Resource metric source type
                                   format: int32
                                   type: integer
                                 averageValue:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 type:
@@ -241,9 +236,9 @@ spec:
                           - target
                           type: object
                         object:
-                          description: object refers to a metric describing a single
-                            kubernetes object (for example, hits-per-second on an
-                            Ingress object).
+                          description: |-
+                            object refers to a metric describing a single kubernetes object
+                            (for example, hits-per-second on an Ingress object).
                           properties:
                             describedObject:
                               description: describedObject specifies the descriptions
@@ -273,40 +268,34 @@ spec:
                                   description: name is the name of the given metric
                                   type: string
                                 selector:
-                                  description: selector is the string-encoded form
-                                    of a standard kubernetes label selector for the
-                                    given metric When set, it is passed as an additional
-                                    parameter to the metrics server for more specific
-                                    metrics scoping. When unset, just the metricName
-                                    will be used to gather metrics.
+                                  description: |-
+                                    selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                    When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                    When unset, just the metricName will be used to gather metrics.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
                                         selector requirements. The requirements are
                                         ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
                                             description: key is the label key that
                                               the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
                                               merge patch.
                                             items:
                                               type: string
@@ -319,12 +308,10 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -336,21 +323,20 @@ spec:
                                 given metric
                               properties:
                                 averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a percentage of
                                     the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
+                                    Currently only valid for Resource metric source type
                                   format: int32
                                   type: integer
                                 averageValue:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 type:
@@ -374,10 +360,10 @@ spec:
                           - target
                           type: object
                         pods:
-                          description: pods refers to a metric describing each pod
-                            in the current scale target (for example, transactions-processed-per-second).  The
-                            values will be averaged together before being compared
-                            to the target value.
+                          description: |-
+                            pods refers to a metric describing each pod in the current scale target
+                            (for example, transactions-processed-per-second).  The values will be
+                            averaged together before being compared to the target value.
                           properties:
                             metric:
                               description: metric identifies the target metric by
@@ -387,40 +373,34 @@ spec:
                                   description: name is the name of the given metric
                                   type: string
                                 selector:
-                                  description: selector is the string-encoded form
-                                    of a standard kubernetes label selector for the
-                                    given metric When set, it is passed as an additional
-                                    parameter to the metrics server for more specific
-                                    metrics scoping. When unset, just the metricName
-                                    will be used to gather metrics.
+                                  description: |-
+                                    selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                    When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                    When unset, just the metricName will be used to gather metrics.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
                                         selector requirements. The requirements are
                                         ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
                                             description: key is the label key that
                                               the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
                                               merge patch.
                                             items:
                                               type: string
@@ -433,12 +413,10 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -450,21 +428,20 @@ spec:
                                 given metric
                               properties:
                                 averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a percentage of
                                     the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
+                                    Currently only valid for Resource metric source type
                                   format: int32
                                   type: integer
                                 averageValue:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 type:
@@ -487,11 +464,11 @@ spec:
                           - target
                           type: object
                         resource:
-                          description: resource refers to a resource metric (such
-                            as those specified in requests and limits) known to Kubernetes
-                            describing each pod in the current scale target (e.g.
-                            CPU or memory). Such metrics are built in to Kubernetes,
-                            and have special scaling options on top of those available
+                          description: |-
+                            resource refers to a resource metric (such as those specified in
+                            requests and limits) known to Kubernetes describing each pod in the
+                            current scale target (e.g. CPU or memory). Such metrics are built in to
+                            Kubernetes, and have special scaling options on top of those available
                             to normal per-pod metrics using the "pods" source.
                           properties:
                             name:
@@ -502,21 +479,20 @@ spec:
                                 given metric
                               properties:
                                 averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a percentage of
                                     the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
+                                    Currently only valid for Resource metric source type
                                   format: int32
                                   type: integer
                                 averageValue:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 type:
@@ -539,20 +515,20 @@ spec:
                           - target
                           type: object
                         type:
-                          description: 'type is the type of metric source.  It should
-                            be one of "ContainerResource", "External", "Object", "Pods"
-                            or "Resource", each mapping to a matching field in the
-                            object. Note: "ContainerResource" type is available on
-                            when the feature-gate HPAContainerMetrics is enabled'
+                          description: |-
+                            type is the type of metric source.  It should be one of "ContainerResource", "External",
+                            "Object", "Pods" or "Resource", each mapping to a matching field in the object.
+                            Note: "ContainerResource" type is available on when the feature-gate
+                            HPAContainerMetrics is enabled
                           type: string
                       required:
                       - type
                       type: object
                     type: array
                   minReplicas:
-                    description: minReplicas is the lower limit for the number of
-                      replicas to which the training job can scale down.  It defaults
-                      to null.
+                    description: |-
+                      minReplicas is the lower limit for the number of replicas to which the training job
+                      can scale down.  It defaults to null.
                     format: int32
                     type: integer
                 type: object
@@ -561,21 +537,27 @@ spec:
                   description: ReplicaSpec is a description of the replica
                   properties:
                     replicas:
-                      description: Replicas is the desired number of replicas of the
-                        given template. If unspecified, defaults to 1.
+                      description: |-
+                        Replicas is the desired number of replicas of the given template.
+                        If unspecified, defaults to 1.
                       format: int32
                       type: integer
                     restartPolicy:
-                      description: Restart policy for all replicas within the job.
-                        One of Always, OnFailure, Never and ExitCode. Default to Never.
+                      description: |-
+                        Restart policy for all replicas within the job.
+                        One of Always, OnFailure, Never and ExitCode.
+                        Default to Never.
                       type: string
                     template:
-                      description: Template is the object that describes the pod that
+                      description: |-
+                        Template is the object that describes the pod that
                         will be created for this replica. RestartPolicy in PodTemplateSpec
                         will be overide by RestartPolicy in ReplicaSpec
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          description: |-
+                            Standard object's metadata.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                           properties:
                             annotations:
                               additionalProperties:
@@ -595,15 +577,15 @@ spec:
                               type: string
                           type: object
                         spec:
-                          description: 'Specification of the desired behavior of the
-                            pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                          description: |-
+                            Specification of the desired behavior of the pod.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                           properties:
                             activeDeadlineSeconds:
-                              description: Optional duration in seconds the pod may
-                                be active on the node relative to StartTime before
-                                the system will actively try to mark it failed and
-                                kill associated containers. Value must be a positive
-                                integer.
+                              description: |-
+                                Optional duration in seconds the pod may be active on the node relative to
+                                StartTime before the system will actively try to mark it failed and kill associated containers.
+                                Value must be a positive integer.
                               format: int64
                               type: integer
                             affinity:
@@ -614,21 +596,17 @@ spec:
                                     rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.
                                       items:
-                                        description: An empty preferred scheduling
-                                          term matches all objects with implicit weight
-                                          0 (i.e. it's a no-op). A null preferred
-                                          scheduling term matches no objects (i.e.
-                                          is also a no-op).
+                                        description: |-
+                                          An empty preferred scheduling term matches all objects with implicit weight 0
+                                          (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                         properties:
                                           preference:
                                             description: A node selector term, associated
@@ -638,35 +616,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -679,35 +648,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -730,57 +690,46 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified
-                                        by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to an update), the
-                                        system may or may not try to eventually evict
-                                        the pod from its node.
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to an update), the system
+                                        may or may not try to eventually evict the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
                                             terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector
-                                              term matches no objects. The requirements
-                                              of them are ANDed. The TopologySelectorTerm
-                                              type implements a subset of the NodeSelectorTerm.
+                                            description: |-
+                                              A null or empty node selector term matches no objects. The requirements of
+                                              them are ANDed.
+                                              The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
                                                 description: A list of node selector
                                                   requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -793,35 +742,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -844,15 +784,13 @@ spec:
                                     etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -873,11 +811,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -885,23 +821,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -913,29 +842,20 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaceSelector:
-                                                description: A label query over the
-                                                  set of namespaces that the term
-                                                  applies to. The term is applied
-                                                  to the union of the namespaces selected
-                                                  by this field and the ones listed
-                                                  in the namespaces field. null selector
-                                                  and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -943,11 +863,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -955,23 +873,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -983,50 +894,37 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaces:
-                                                description: namespaces specifies
-                                                  a static list of namespace names
-                                                  that the term applies to. The term
-                                                  is applied to the union of the namespaces
-                                                  listed in this field and the ones
-                                                  selected by namespaceSelector. null
-                                                  or empty namespaces list and null
-                                                  namespaceSelector means "this pod's
-                                                  namespace".
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching
-                                              the corresponding podAffinityTerm, in
-                                              the range 1-100.
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -1035,24 +933,20 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified
-                                        by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to a pod label update),
-                                        the system may or may not try to eventually
-                                        evict the pod from its node.
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
                                       items:
-                                        description: Defines a set of pods (namely
-                                          those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -1063,10 +957,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -1074,21 +967,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -1101,25 +988,19 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
@@ -1127,10 +1008,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -1138,21 +1018,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -1165,39 +1039,29 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace".
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1210,13 +1074,11 @@ spec:
                                     node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the anti-affinity
-                                        expressions specified by this field, but it
-                                        may choose a node that violates one or more
-                                        of the expressions. The node that is most
-                                        preferred is the one with the greatest sum
-                                        of weights, i.e.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the anti-affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -1237,11 +1099,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -1249,23 +1109,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -1277,29 +1130,20 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaceSelector:
-                                                description: A label query over the
-                                                  set of namespaces that the term
-                                                  applies to. The term is applied
-                                                  to the union of the namespaces selected
-                                                  by this field and the ones listed
-                                                  in the namespaces field. null selector
-                                                  and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -1307,11 +1151,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -1319,23 +1161,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -1347,50 +1182,37 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaces:
-                                                description: namespaces specifies
-                                                  a static list of namespace names
-                                                  that the term applies to. The term
-                                                  is applied to the union of the namespaces
-                                                  listed in this field and the ones
-                                                  selected by namespaceSelector. null
-                                                  or empty namespaces list and null
-                                                  namespaceSelector means "this pod's
-                                                  namespace".
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching
-                                              the corresponding podAffinityTerm, in
-                                              the range 1-100.
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -1399,24 +1221,20 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements
-                                        specified by this field are not met at scheduling
-                                        time, the pod will not be scheduled onto the
-                                        node. If the anti-affinity requirements specified
-                                        by this field cease to be met at some point
-                                        during pod execution (e.g. due to a pod label
-                                        update), the system may or may not try to
-                                        eventually evict the pod from its node.
+                                      description: |-
+                                        If the anti-affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the anti-affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
                                       items:
-                                        description: Defines a set of pods (namely
-                                          those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -1427,10 +1245,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -1438,21 +1255,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -1465,25 +1276,19 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
@@ -1491,10 +1296,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -1502,21 +1306,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -1529,39 +1327,29 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace".
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1575,41 +1363,39 @@ spec:
                                 mounted.
                               type: boolean
                             containers:
-                              description: List of containers belonging to the pod.
-                                Containers cannot currently be added or removed. There
-                                must be at least one container in a Pod. Cannot be
-                                updated.
+                              description: |-
+                                List of containers belonging to the pod.
+                                Containers cannot currently be added or removed.
+                                There must be at least one container in a Pod.
+                                Cannot be updated.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
-                                      provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The container image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
-                                      used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The container image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -1619,16 +1405,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1642,10 +1425,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1656,11 +1439,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -1676,12 +1457,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -1715,10 +1493,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1734,15 +1512,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1751,10 +1527,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -1771,10 +1547,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -1785,48 +1561,43 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images
-                                      This field is optional to allow higher level
-                                      config management to default or override container
-                                      images in workload controllers like Deployments
-                                      and StatefulSets.'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system
-                                      should take in response to container lifecycle
-                                      events. Cannot be updated.
+                                    description: |-
+                                      Actions that the management system should take in response to container lifecycle events.
+                                      Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1836,10 +1607,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -1851,11 +1621,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -1874,25 +1642,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1903,41 +1670,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1947,10 +1707,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -1962,11 +1721,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -1985,25 +1742,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2014,10 +1770,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -2025,35 +1781,31 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness.
+                                    description: |-
+                                      Periodic probe of container liveness.
                                       Container will be restarted if the probe fails.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -2066,11 +1818,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -2080,9 +1833,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -2092,11 +1845,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -2114,36 +1865,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -2158,55 +1908,52 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as
-                                      a DNS_LABEL. Each container in a pod must have
-                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    description: |-
+                                      Name of the container specified as a DNS_LABEL.
+                                      Each container in a pod must have a unique name (DNS_LABEL).
+                                      Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the
-                                      container. Not specifying a port here DOES NOT
-                                      prevent that port from being exposed. Any port
-                                      which is listening on the default "0.0.0.0"
-                                      address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
+                                    description: |-
+                                      List of ports to expose from the container. Not specifying a port here
+                                      DOES NOT prevent that port from being exposed. Any port which is
+                                      listening on the default "0.0.0.0" address inside a container will be
+                                      accessible from the network.
+                                      Modifying this array with strategic merge patch may corrupt the data.
                                       For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -2214,24 +1961,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -2242,36 +1989,31 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service
-                                      readiness. Container will be removed from service
-                                      endpoints if the probe fails. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Periodic probe of container service readiness.
+                                      Container will be removed from service endpoints if the probe fails.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -2284,11 +2026,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -2298,9 +2041,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -2310,11 +2053,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -2332,36 +2073,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -2376,30 +2116,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -2410,14 +2147,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -2426,26 +2163,31 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Compute Resources required by this container.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -2461,9 +2203,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2472,48 +2214,41 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: RestartPolicy defines the restart
-                                      behavior of individual containers in a pod.
-                                      This field may only be set for init containers,
-                                      and the only allowed value is "Always". For
-                                      non-init containers or when this field is not
-                                      specified, the restart behavior is defined by
-                                      the Pod's restart policy and the container type.
+                                    description: |-
+                                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                                      This field may only be set for init containers, and the only allowed value is "Always".
+                                      For non-init containers or when this field is not specified,
+                                      the restart behavior is defined by the Pod's restart policy and the container type.
                                     type: string
                                   securityContext:
-                                    description: 'SecurityContext defines the security
-                                      options the container should be run with. If
-                                      set, the fields of SecurityContext override
-                                      the equivalent fields of PodSecurityContext.
-                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    description: |-
+                                      SecurityContext defines the security options the container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -2531,68 +2266,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2612,52 +2338,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -2665,60 +2383,46 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: StartupProbe indicates that the Pod
-                                      has successfully initialized. If specified,
-                                      no other probes are executed until this completes
-                                      successfully. If this probe fails, the Pod will
-                                      be restarted, just as if the livenessProbe failed.
+                                    description: |-
+                                      StartupProbe indicates that the Pod has successfully initialized.
+                                      If specified, no other probes are executed until this completes successfully.
+                                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -2731,11 +2435,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -2745,9 +2450,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -2757,11 +2462,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -2779,36 +2482,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -2823,72 +2525,62 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -2912,46 +2604,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -2959,34 +2650,36 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             dnsConfig:
-                              description: Specifies the DNS parameters of a pod.
-                                Parameters specified here will be merged to the generated
-                                DNS configuration based on DNSPolicy.
+                              description: |-
+                                Specifies the DNS parameters of a pod.
+                                Parameters specified here will be merged to the generated DNS
+                                configuration based on DNSPolicy.
                               properties:
                                 nameservers:
-                                  description: A list of DNS name server IP addresses.
-                                    This will be appended to the base nameservers
-                                    generated from DNSPolicy. Duplicated nameservers
-                                    will be removed.
+                                  description: |-
+                                    A list of DNS name server IP addresses.
+                                    This will be appended to the base nameservers generated from DNSPolicy.
+                                    Duplicated nameservers will be removed.
                                   items:
                                     type: string
                                   type: array
                                 options:
-                                  description: A list of DNS resolver options. This
-                                    will be merged with the base options generated
-                                    from DNSPolicy. Duplicated entries will be removed.
-                                    Resolution options given in Options will override
-                                    those that appear in the base DNSPolicy.
+                                  description: |-
+                                    A list of DNS resolver options.
+                                    This will be merged with the base options generated from DNSPolicy.
+                                    Duplicated entries will be removed. Resolution options given in Options
+                                    will override those that appear in the base DNSPolicy.
                                   items:
                                     description: PodDNSConfigOption defines DNS resolver
                                       options of a pod.
@@ -2999,75 +2692,68 @@ spec:
                                     type: object
                                   type: array
                                 searches:
-                                  description: A list of DNS search domains for host-name
-                                    lookup. This will be appended to the base search
-                                    paths generated from DNSPolicy. Duplicated search
-                                    paths will be removed.
+                                  description: |-
+                                    A list of DNS search domains for host-name lookup.
+                                    This will be appended to the base search paths generated from DNSPolicy.
+                                    Duplicated search paths will be removed.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
-                              description: Set DNS policy for the pod. Defaults to
-                                "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
-                                'ClusterFirst', 'Default' or 'None'. DNS parameters
-                                given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy. To have DNS options set along
-                                with hostNetwork, you have to specify DNS policy explicitly
-                                to 'ClusterFirstWithHostNet'.
+                              description: |-
+                                Set DNS policy for the pod.
+                                Defaults to "ClusterFirst".
+                                Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                                DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                                To have DNS options set along with hostNetwork, you have to specify DNS policy
+                                explicitly to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
-                              description: 'EnableServiceLinks indicates whether information
-                                about services should be injected into pod''s environment
-                                variables, matching the syntax of Docker links. Optional:
-                                Defaults to true.'
+                              description: |-
+                                EnableServiceLinks indicates whether information about services should be injected into pod's
+                                environment variables, matching the syntax of Docker links.
+                                Optional: Defaults to true.
                               type: boolean
                             ephemeralContainers:
-                              description: List of ephemeral containers run in this
-                                pod. Ephemeral containers may be run in an existing
-                                pod to perform user-initiated actions such as debugging.
-                                This list cannot be specified when creating a pod,
-                                and it cannot be modified by updating the pod spec.
-                                In order to add an ephemeral container to an existing
-                                pod, use the pod's ephemeralcontainers subresource.
+                              description: |-
+                                List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                                pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                                creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                                ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
                               items:
-                                description: An EphemeralContainer is a temporary
-                                  container that you may add to an existing Pod for
-                                  user-initiated activities such as debugging. Ephemeral
-                                  containers have no resource or scheduling guarantees,
-                                  and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted. The kubelet
-                                  may evict a Pod if an ephemeral container causes
-                                  the Pod to exceed its resource allocation.
+                                description: |-
+                                  An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                                  user-initiated activities such as debugging. Ephemeral containers have no resource or
+                                  scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                                  removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                                  Pod to exceed its resource allocation.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the
-                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                      produce the string literal "$(VAR_NAME)".'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)".
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The image''s ENTRYPOINT is used if
-                                      this is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -3077,16 +2763,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -3100,10 +2783,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -3114,11 +2797,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -3134,12 +2815,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -3173,10 +2851,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -3192,15 +2870,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -3209,10 +2885,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -3229,10 +2905,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -3243,43 +2919,40 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
                                     description: Lifecycle is not allowed for ephemeral
                                       containers.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3289,10 +2962,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -3304,11 +2976,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -3327,25 +2997,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -3356,41 +3025,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3400,10 +3062,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -3415,11 +3076,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -3438,25 +3097,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -3467,10 +3125,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -3486,26 +3144,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -3518,11 +3170,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -3532,9 +3185,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -3544,11 +3197,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3566,36 +3217,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -3610,38 +3260,34 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the ephemeral container specified
-                                      as a DNS_LABEL. This name must be unique among
-                                      all containers, init containers and ephemeral
-                                      containers.
+                                    description: |-
+                                      Name of the ephemeral container specified as a DNS_LABEL.
+                                      This name must be unique among all containers, init containers and ephemeral containers.
                                     type: string
                                   ports:
                                     description: Ports are not allowed for ephemeral
@@ -3651,9 +3297,9 @@ spec:
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -3661,24 +3307,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -3697,26 +3343,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -3729,11 +3369,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -3743,9 +3384,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -3755,11 +3396,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3777,36 +3416,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -3821,30 +3459,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -3855,14 +3490,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -3871,27 +3506,30 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: Resources are not allowed for ephemeral
-                                      containers. Ephemeral containers use spare resources
+                                    description: |-
+                                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
                                       already allocated to the pod.
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -3907,9 +3545,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -3918,45 +3556,40 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: Restart policy for the container
-                                      to manage the restart behavior of each container
-                                      within a pod. This may only be set for init
-                                      containers. You cannot set this field on ephemeral
-                                      containers.
+                                    description: |-
+                                      Restart policy for the container to manage the restart behavior of each
+                                      container within a pod.
+                                      This may only be set for init containers. You cannot set this field on
+                                      ephemeral containers.
                                     type: string
                                   securityContext:
-                                    description: 'Optional: SecurityContext defines
-                                      the security options the ephemeral container
-                                      should be run with. If set, the fields of SecurityContext
-                                      override the equivalent fields of PodSecurityContext.'
+                                    description: |-
+                                      Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -3974,68 +3607,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -4055,52 +3679,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -4108,25 +3724,18 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
@@ -4139,26 +3748,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -4171,11 +3774,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -4185,9 +3789,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -4197,11 +3801,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -4219,36 +3821,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -4263,81 +3864,71 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: "If set, the name of the container
-                                      from PodSpec that this ephemeral container targets.
-                                      The ephemeral container will be run in the namespaces
-                                      (IPC, PID, etc) of this container. If not set
-                                      then the ephemeral container uses the namespaces
-                                      configured in the Pod spec. \n The container
-                                      runtime must implement support for this feature."
+                                    description: |-
+                                      If set, the name of the container from PodSpec that this ephemeral container targets.
+                                      The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                      If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+
+                                      The container runtime must implement support for this feature.
                                     type: string
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -4361,47 +3952,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Subpath mounts are not allowed for
-                                      ephemeral containers. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -4409,24 +3998,24 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             hostAliases:
-                              description: HostAliases is an optional list of hosts
-                                and IPs that will be injected into the pod's hosts
-                                file if specified. This is only valid for non-hostNetwork
-                                pods.
+                              description: |-
+                                HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                file if specified. This is only valid for non-hostNetwork pods.
                               items:
-                                description: HostAlias holds the mapping between IP
-                                  and hostnames that will be injected as an entry
-                                  in the pod's hosts file.
+                                description: |-
+                                  HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                  pod's hosts file.
                                 properties:
                                   hostnames:
                                     description: Hostnames for the above IP address.
@@ -4439,93 +4028,89 @@ spec:
                                 type: object
                               type: array
                             hostIPC:
-                              description: 'Use the host''s ipc namespace. Optional:
-                                Default to false.'
+                              description: |-
+                                Use the host's ipc namespace.
+                                Optional: Default to false.
                               type: boolean
                             hostNetwork:
-                              description: Host networking requested for this pod.
-                                Use the host's network namespace. If this option is
-                                set, the ports that will be used must be specified.
+                              description: |-
+                                Host networking requested for this pod. Use the host's network namespace.
+                                If this option is set, the ports that will be used must be specified.
                                 Default to false.
                               type: boolean
                             hostPID:
-                              description: 'Use the host''s pid namespace. Optional:
-                                Default to false.'
+                              description: |-
+                                Use the host's pid namespace.
+                                Optional: Default to false.
                               type: boolean
                             hostUsers:
-                              description: 'Use the host''s user namespace. Optional:
-                                Default to true. If set to true or not present, the
-                                pod will be run in the host user namespace, useful
-                                for when the pod needs a feature only available to
-                                the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE. When set to false, a new
-                                userns is created for the pod.'
+                              description: |-
+                                Use the host's user namespace.
+                                Optional: Default to true.
+                                If set to true or not present, the pod will be run in the host user namespace, useful
+                                for when the pod needs a feature only available to the host user namespace, such as
+                                loading a kernel module with CAP_SYS_MODULE.
+                                When set to false, a new userns is created for the pod.
                               type: boolean
                             hostname:
-                              description: Specifies the hostname of the Pod If not
-                                specified, the pod's hostname will be set to a system-defined
-                                value.
+                              description: |-
+                                Specifies the hostname of the Pod
+                                If not specified, the pod's hostname will be set to a system-defined value.
                               type: string
                             imagePullSecrets:
-                              description: 'ImagePullSecrets is an optional list of
-                                references to secrets in the same namespace to use
-                                for pulling any of the images used by this PodSpec.
-                                If specified, these secrets will be passed to individual
-                                puller implementations for them to use. More info:
-                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                              description: |-
+                                ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                If specified, these secrets will be passed to individual puller implementations for them to use.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                               items:
-                                description: LocalObjectReference contains enough
-                                  information to let you locate the referenced object
-                                  inside the same namespace.
+                                description: |-
+                                  LocalObjectReference contains enough information to let you locate the
+                                  referenced object inside the same namespace.
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               type: array
                             initContainers:
-                              description: List of initialization containers belonging
-                                to the pod. Init containers are executed in order
-                                prior to containers being started. If any init container
-                                fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy. The name for
-                                an init container or normal container must be unique
-                                among all containers.
+                              description: |-
+                                List of initialization containers belonging to the pod.
+                                Init containers are executed in order prior to containers being started. If any
+                                init container fails, the pod is considered to have failed and is handled according
+                                to its restartPolicy. The name for an init container or normal container must be
+                                unique among all containers.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
-                                      provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The container image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
-                                      used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The container image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -4535,16 +4120,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -4558,10 +4140,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -4572,11 +4154,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -4592,12 +4172,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -4631,10 +4208,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -4650,15 +4227,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -4667,10 +4242,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -4687,10 +4262,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -4701,48 +4276,43 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images
-                                      This field is optional to allow higher level
-                                      config management to default or override container
-                                      images in workload controllers like Deployments
-                                      and StatefulSets.'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system
-                                      should take in response to container lifecycle
-                                      events. Cannot be updated.
+                                    description: |-
+                                      Actions that the management system should take in response to container lifecycle events.
+                                      Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4752,10 +4322,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -4767,11 +4336,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -4790,25 +4357,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -4819,41 +4385,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4863,10 +4422,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -4878,11 +4436,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -4901,25 +4457,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -4930,10 +4485,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -4941,35 +4496,31 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness.
+                                    description: |-
+                                      Periodic probe of container liveness.
                                       Container will be restarted if the probe fails.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -4982,11 +4533,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -4996,9 +4548,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -5008,11 +4560,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -5030,36 +4580,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -5074,55 +4623,52 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as
-                                      a DNS_LABEL. Each container in a pod must have
-                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    description: |-
+                                      Name of the container specified as a DNS_LABEL.
+                                      Each container in a pod must have a unique name (DNS_LABEL).
+                                      Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the
-                                      container. Not specifying a port here DOES NOT
-                                      prevent that port from being exposed. Any port
-                                      which is listening on the default "0.0.0.0"
-                                      address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
+                                    description: |-
+                                      List of ports to expose from the container. Not specifying a port here
+                                      DOES NOT prevent that port from being exposed. Any port which is
+                                      listening on the default "0.0.0.0" address inside a container will be
+                                      accessible from the network.
+                                      Modifying this array with strategic merge patch may corrupt the data.
                                       For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -5130,24 +4676,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -5158,36 +4704,31 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service
-                                      readiness. Container will be removed from service
-                                      endpoints if the probe fails. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Periodic probe of container service readiness.
+                                      Container will be removed from service endpoints if the probe fails.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -5200,11 +4741,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -5214,9 +4756,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -5226,11 +4768,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -5248,36 +4788,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -5292,30 +4831,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -5326,14 +4862,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -5342,26 +4878,31 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Compute Resources required by this container.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -5377,9 +4918,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -5388,48 +4929,41 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: RestartPolicy defines the restart
-                                      behavior of individual containers in a pod.
-                                      This field may only be set for init containers,
-                                      and the only allowed value is "Always". For
-                                      non-init containers or when this field is not
-                                      specified, the restart behavior is defined by
-                                      the Pod's restart policy and the container type.
+                                    description: |-
+                                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                                      This field may only be set for init containers, and the only allowed value is "Always".
+                                      For non-init containers or when this field is not specified,
+                                      the restart behavior is defined by the Pod's restart policy and the container type.
                                     type: string
                                   securityContext:
-                                    description: 'SecurityContext defines the security
-                                      options the container should be run with. If
-                                      set, the fields of SecurityContext override
-                                      the equivalent fields of PodSecurityContext.
-                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    description: |-
+                                      SecurityContext defines the security options the container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -5447,68 +4981,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -5528,52 +5053,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -5581,60 +5098,46 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: StartupProbe indicates that the Pod
-                                      has successfully initialized. If specified,
-                                      no other probes are executed until this completes
-                                      successfully. If this probe fails, the Pod will
-                                      be restarted, just as if the livenessProbe failed.
+                                    description: |-
+                                      StartupProbe indicates that the Pod has successfully initialized.
+                                      If specified, no other probes are executed until this completes successfully.
+                                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -5647,11 +5150,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -5661,9 +5165,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -5673,11 +5177,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -5695,36 +5197,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -5739,72 +5240,62 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -5828,46 +5319,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -5875,47 +5365,54 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             nodeName:
-                              description: NodeName is a request to schedule this
-                                pod onto a specific node. If it is non-empty, the
-                                scheduler simply schedules this pod onto that node,
-                                assuming that it fits resource requirements.
+                              description: |-
+                                NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
+                                the scheduler simply schedules this pod onto that node, assuming that it fits resource
+                                requirements.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: 'NodeSelector is a selector which must
-                                be true for the pod to fit on a node. Selector which
-                                must match a node''s labels for the pod to be scheduled
-                                on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                              description: |-
+                                NodeSelector is a selector which must be true for the pod to fit on a node.
+                                Selector which must match a node's labels for the pod to be scheduled on that node.
+                                More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                               type: object
                               x-kubernetes-map-type: atomic
                             os:
-                              description: "Specifies the OS of the containers in
-                                the pod. Some pod and container fields are restricted
-                                if this is set. \n If the OS field is set to linux,
-                                the following fields must be unset: -securityContext.windowsOptions
-                                \n If the OS field is set to windows, following fields
-                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
-                                - spec.securityContext.seLinuxOptions - spec.securityContext."
+                              description: |-
+                                Specifies the OS of the containers in the pod.
+                                Some pod and container fields are restricted if this is set.
+
+
+                                If the OS field is set to linux, the following fields must be unset:
+                                -securityContext.windowsOptions
+
+
+                                If the OS field is set to windows, following fields must be unset:
+                                - spec.hostPID
+                                - spec.hostIPC
+                                - spec.hostUsers
+                                - spec.securityContext.seLinuxOptions
+                                - spec.securityContext.
                               properties:
                                 name:
-                                  description: 'Name is the name of the operating
-                                    system. The currently supported values are linux
-                                    and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                    Clients should expect to handle additional values
-                                    and treat unrecognized values in this field as
-                                    os: null'
+                                  description: |-
+                                    Name is the name of the operating system. The currently supported values are linux and windows.
+                                    Additional value may be defined in future and can be one of:
+                                    https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values and treat unrecognized values in this field as os: null
                                   type: string
                               required:
                               - name
@@ -5927,44 +5424,43 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: Overhead represents the resource overhead
-                                associated with running a pod for a given RuntimeClass.
-                                This field will be autopopulated at admission time
-                                by the RuntimeClass admission controller. If the RuntimeClass
-                                admission controller is enabled, overhead must not
-                                be set in Pod create requests. The RuntimeClass admission
-                                controller will reject Pod create requests which have
-                                the overhead already set.
+                              description: |-
+                                Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                                This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                                the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                                The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                                set.
                               type: object
                             preemptionPolicy:
-                              description: PreemptionPolicy is the Policy for preempting
-                                pods with lower priority. One of Never, PreemptLowerPriority.
+                              description: |-
+                                PreemptionPolicy is the Policy for preempting pods with lower priority.
+                                One of Never, PreemptLowerPriority.
                                 Defaults to PreemptLowerPriority if unset.
                               type: string
                             priority:
-                              description: The priority value. Various system components
-                                use this field to find the priority of the pod. When
-                                Priority Admission Controller is enabled, it prevents
-                                users from setting this field. The admission controller
-                                populates this field from PriorityClassName. The higher
-                                the value, the higher the priority.
+                              description: |-
+                                The priority value. Various system components use this field to find the
+                                priority of the pod. When Priority Admission Controller is enabled, it
+                                prevents users from setting this field. The admission controller populates
+                                this field from PriorityClassName.
+                                The higher the value, the higher the priority.
                               format: int32
                               type: integer
                             priorityClassName:
-                              description: If specified, indicates the pod's priority.
-                                "system-node-critical" and "system-cluster-critical"
-                                are two special keywords which indicate the highest
-                                priorities with the former being the highest priority.
-                                Any other name must be defined by creating a PriorityClass
-                                object with that name. If not specified, the pod priority
-                                will be default or zero if there is no default.
+                              description: |-
+                                If specified, indicates the pod's priority. "system-node-critical" and
+                                "system-cluster-critical" are two special keywords which indicate the
+                                highest priorities with the former being the highest priority. Any other
+                                name must be defined by creating a PriorityClass object with that name.
+                                If not specified, the pod priority will be default or zero if there is no
+                                default.
                               type: string
                             readinessGates:
-                              description: 'If specified, all readiness gates will
-                                be evaluated for pod readiness. A pod is ready when
-                                all its containers are ready AND all conditions specified
-                                in the readiness gates have status equal to "True"
-                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                              description: |-
+                                If specified, all readiness gates will be evaluated for pod readiness.
+                                A pod is ready when all its containers are ready AND
+                                all conditions specified in the readiness gates have status equal to "True"
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
                               items:
                                 description: PodReadinessGate contains the reference
                                   to a pod condition
@@ -5978,40 +5474,47 @@ spec:
                                 type: object
                               type: array
                             resourceClaims:
-                              description: "ResourceClaims defines which ResourceClaims
-                                must be allocated and reserved before the Pod is allowed
-                                to start. The resources will be made available to
-                                those containers which consume them by name. \n This
-                                is an alpha field and requires enabling the DynamicResourceAllocation
-                                feature gate. \n This field is immutable."
+                              description: |-
+                                ResourceClaims defines which ResourceClaims must be allocated
+                                and reserved before the Pod is allowed to start. The resources
+                                will be made available to those containers which consume them
+                                by name.
+
+
+                                This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate.
+
+
+                                This field is immutable.
                               items:
-                                description: PodResourceClaim references exactly one
-                                  ResourceClaim through a ClaimSource. It adds a name
-                                  to it that uniquely identifies the ResourceClaim
-                                  inside the Pod. Containers that need access to the
-                                  ResourceClaim reference it with this name.
+                                description: |-
+                                  PodResourceClaim references exactly one ResourceClaim through a ClaimSource.
+                                  It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                                  Containers that need access to the ResourceClaim reference it with this name.
                                 properties:
                                   name:
-                                    description: Name uniquely identifies this resource
-                                      claim inside the pod. This must be a DNS_LABEL.
+                                    description: |-
+                                      Name uniquely identifies this resource claim inside the pod.
+                                      This must be a DNS_LABEL.
                                     type: string
                                   source:
                                     description: Source describes where to find the
                                       ResourceClaim.
                                     properties:
                                       resourceClaimName:
-                                        description: ResourceClaimName is the name
-                                          of a ResourceClaim object in the same namespace
-                                          as this pod.
+                                        description: |-
+                                          ResourceClaimName is the name of a ResourceClaim object in the same
+                                          namespace as this pod.
                                         type: string
                                       resourceClaimTemplateName:
-                                        description: "ResourceClaimTemplateName is
-                                          the name of a ResourceClaimTemplate object
-                                          in the same namespace as this pod. \n The
-                                          template will be used to create a new ResourceClaim,
-                                          which will be bound to this pod. When this
-                                          pod is deleted, the ResourceClaim will also
-                                          be deleted."
+                                        description: |-
+                                          ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                          object in the same namespace as this pod.
+
+
+                                          The template will be used to create a new ResourceClaim, which will
+                                          be bound to this pod. When this pod is deleted, the ResourceClaim
+                                          will also be deleted.
                                         type: string
                                     type: object
                                 required:
@@ -6022,42 +5525,44 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             restartPolicy:
-                              description: 'Restart policy for all containers within
-                                the pod. One of Always, OnFailure, Never. In some
-                                contexts, only a subset of those values may be permitted.
-                                Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                              description: |-
+                                Restart policy for all containers within the pod.
+                                One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                                Default to Always.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass
-                                object in the node.k8s.io group, which should be used
-                                to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run. If unset
-                                or empty, the "legacy" RuntimeClass will be used,
-                                which is an implicit class with an empty definition
-                                that uses the default runtime handler. More info:
-                                https://git.k8s.'
+                              description: |-
+                                RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                                to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                                If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                                empty definition that uses the default runtime handler.
+                                More info: https://git.k8s.
                               type: string
                             schedulerName:
-                              description: If specified, the pod will be dispatched
-                                by specified scheduler. If not specified, the pod
-                                will be dispatched by default scheduler.
+                              description: |-
+                                If specified, the pod will be dispatched by specified scheduler.
+                                If not specified, the pod will be dispatched by default scheduler.
                               type: string
                             schedulingGates:
-                              description: "SchedulingGates is an opaque list of values
-                                that if specified will block scheduling the pod. If
-                                schedulingGates is not empty, the pod will stay in
-                                the SchedulingGated state and the scheduler will not
-                                attempt to schedule the pod. \n SchedulingGates can
-                                only be set at pod creation time, and be removed only
-                                afterwards. \n This is a beta feature enabled by the
-                                PodSchedulingReadiness feature gate."
+                              description: |-
+                                SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                                If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                                scheduler will not attempt to schedule the pod.
+
+
+                                SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+
+
+                                This is a beta feature enabled by the PodSchedulingReadiness feature gate.
                               items:
                                 description: PodSchedulingGate is associated to a
                                   Pod to guard its scheduling.
                                 properties:
                                   name:
-                                    description: Name of the scheduling gate. Each
-                                      scheduling gate must have a unique name field.
+                                    description: |-
+                                      Name of the scheduling gate.
+                                      Each scheduling gate must have a unique name field.
                                     type: string
                                 required:
                                 - name
@@ -6067,70 +5572,67 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             securityContext:
-                              description: 'SecurityContext holds pod-level security
-                                attributes and common container settings. Optional:
-                                Defaults to empty.  See type description for default
-                                values of each field.'
+                              description: |-
+                                SecurityContext holds pod-level security attributes and common container settings.
+                                Optional: Defaults to empty.  See type description for default values of each field.
                               properties:
                                 fsGroup:
-                                  description: "A special supplemental group that
-                                    applies to all containers in a pod. Some volume
-                                    types allow the Kubelet to change the ownership
-                                    of that volume to be owned by the pod: \n 1. The
-                                    owning GID will be the FSGroup 2. The setgid bit
-                                    is set (new files created in the volume will be
-                                    owned by FSGroup) 3."
+                                  description: |-
+                                    A special supplemental group that applies to all containers in a pod.
+                                    Some volume types allow the Kubelet to change the ownership of that volume
+                                    to be owned by the pod:
+
+
+                                    1. The owning GID will be the FSGroup
+                                    2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                    3.
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior
-                                    of changing ownership and permission of the volume
-                                    before being exposed inside Pod. This field will
-                                    only apply to volume types which support fsGroup
-                                    based ownership(and permissions). It will have
-                                    no effect on ephemeral volume types such as: secret,
-                                    configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified, "Always" is used.'
+                                  description: |-
+                                    fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                    before being exposed inside Pod. This field will only apply to
+                                    volume types which support fsGroup based ownership(and permissions).
+                                    It will have no effect on ephemeral volume types such as: secret, configmaps
+                                    and emptydir.
+                                    Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
                                   type: string
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in SecurityContext.  If set in
-                                    both SecurityContext and PodSecurityContext, the
-                                    value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in SecurityContext.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in SecurityContext.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence for that container.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    all containers. If unspecified, the container
-                                    runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                  description: |-
+                                    The SELinux context to be applied to all containers.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in SecurityContext.  If set in
+                                    both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                    takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -6150,49 +5652,45 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by the containers
-                                    in this pod. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by the containers in this pod.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must be set if type is "Localhost".
-                                        Must NOT be set for any other type.
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first
-                                    process run in each container, in addition to
-                                    the container's primary GID, the fsGroup (if specified),
-                                    and group memberships defined in the container
-                                    image for the uid of the container process. If
-                                    unspecified, no additional groups are added to
-                                    any container.
+                                  description: |-
+                                    A list of groups applied to the first process run in each container, in addition
+                                    to the container's primary GID, the fsGroup (if specified), and group memberships
+                                    defined in the container image for the uid of the container process. If unspecified,
+                                    no additional groups are added to any container.
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls
-                                    used for the pod. Pods with unsupported sysctls
-                                    (by the container runtime) might fail to launch.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                    sysctls (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   items:
                                     description: Sysctl defines a kernel parameter
                                       to be set
@@ -6209,173 +5707,151 @@ spec:
                                     type: object
                                   type: array
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    within a container's SecurityContext will be used.
-                                    If set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options within a container's SecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        All of a Pod's containers must have the same
-                                        effective HostProcess value (it is not allowed
-                                        to have a mix of HostProcess containers and
-                                        non-HostProcess containers). In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: 'DeprecatedServiceAccount is a depreciated
-                                alias for ServiceAccountName. Deprecated: Use serviceAccountName
-                                instead.'
+                              description: |-
+                                DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+                                Deprecated: Use serviceAccountName instead.
                               type: string
                             serviceAccountName:
-                              description: 'ServiceAccountName is the name of the
-                                ServiceAccount to use to run this pod. More info:
-                                https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                              description: |-
+                                ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                               type: string
                             setHostnameAsFQDN:
-                              description: If true the pod's hostname will be configured
-                                as the pod's FQDN, rather than the leaf name (the
-                                default). In Linux containers, this means setting
-                                the FQDN in the hostname field of the kernel (the
-                                nodename field of struct utsname).
+                              description: |-
+                                If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                                In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between
-                                all of the containers in a pod. When this is set containers
-                                will be able to view and signal processes from other
-                                containers in the same pod, and the first process
-                                in each container will not be assigned PID 1. HostPID
-                                and ShareProcessNamespace cannot both be set. Optional:
-                                Default to false.'
+                              description: |-
+                                Share a single process namespace between all of the containers in a pod.
+                                When this is set containers will be able to view and signal processes from other containers
+                                in the same pod, and the first process in each container will not be assigned PID 1.
+                                HostPID and ShareProcessNamespace cannot both be set.
+                                Optional: Default to false.
                               type: boolean
                             subdomain:
-                              description: If specified, the fully qualified Pod hostname
-                                will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                                domain>". If not specified, the pod will not have
-                                a domainname at all.
+                              description: |-
+                                If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                                If not specified, the pod will not have a domainname at all.
                               type: string
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs
-                                to terminate gracefully. May be decreased in delete
-                                request. Value must be non-negative integer. The value
-                                zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down). If this value is nil,
-                                the default grace period will be used instead.
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                If this value is nil, the default grace period will be used instead.
                               format: int64
                               type: integer
                             tolerations:
                               description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to
-                                  tolerates any taint that matches the triple <key,value,effect>
-                                  using the matching operator <operator>.
+                                description: |-
+                                  The pod this Toleration is attached to tolerates any taint that matches
+                                  the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect
-                                      to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule,
-                                      PreferNoSchedule and NoExecute.
+                                    description: |-
+                                      Effect indicates the taint effect to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration
-                                      applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists;
-                                      this combination means to match all values and
-                                      all keys.
+                                    description: |-
+                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship
-                                      to the value. Valid operators are Exists and
-                                      Equal. Defaults to Equal. Exists is equivalent
-                                      to wildcard for value, so that a pod can tolerate
-                                      all taints of a particular category.
+                                    description: |-
+                                      Operator represents a key's relationship to the value.
+                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Exists is equivalent to wildcard for value, so that a pod can
+                                      tolerate all taints of a particular category.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the
-                                      period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is
-                                      ignored) tolerates the taint. By default, it
-                                      is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
+                                    description: |-
+                                      TolerationSeconds represents the period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                      negative values will be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration
-                                      matches to. If the operator is Exists, the value
-                                      should be empty, otherwise just a regular string.
+                                    description: |-
+                                      Value is the taint value the toleration matches to.
+                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how
-                                a group of pods ought to spread across topology domains.
-                                Scheduler will schedule pods in a way which abides
-                                by the constraints. All topologySpreadConstraints
-                                are ANDed.
+                              description: |-
+                                TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                                domains. Scheduler will schedule pods in a way which abides by the constraints.
+                                All topologySpreadConstraints are ANDed.
                               items:
                                 description: TopologySpreadConstraint specifies how
                                   to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: LabelSelector is used to find matching
-                                      pods. Pods that match this label selector are
-                                      counted to determine the number of pods in their
-                                      corresponding topology domain.
+                                    description: |-
+                                      LabelSelector is used to find matching pods.
+                                      Pods that match this label selector are counted to determine the number of pods
+                                      in their corresponding topology domain.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
                                           label selector requirements. The requirements
                                           are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -6388,91 +5864,79 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label
-                                      keys to select the pods over which spreading
-                                      will be calculated. The keys are used to lookup
-                                      values from the incoming pod labels, those key-value
-                                      labels are ANDed with labelSelector to select
-                                      the group of existing pods over which spreading
-                                      will be calculated for the incoming pod. The
-                                      same key is forbidden to exist in both MatchLabelKeys
-                                      and LabelSelector.
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select the pods over which
+                                      spreading will be calculated. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are ANDed with labelSelector
+                                      to select the group of existing pods over which spreading will be calculated
+                                      for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   maxSkew:
-                                    description: MaxSkew describes the degree to which
-                                      pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                                      it is the maximum permitted difference between
-                                      the number of matching pods in the target topology
-                                      and the global minimum. The global minimum is
-                                      the minimum number of matching pods in an eligible
-                                      domain or zero if the number of eligible domains
-                                      is less than MinDomains.
+                                    description: |-
+                                      MaxSkew describes the degree to which pods may be unevenly distributed.
+                                      When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                      between the number of matching pods in the target topology and the global minimum.
+                                      The global minimum is the minimum number of matching pods in an eligible domain
+                                      or zero if the number of eligible domains is less than MinDomains.
                                     format: int32
                                     type: integer
                                   minDomains:
-                                    description: MinDomains indicates a minimum number
-                                      of eligible domains. When the number of eligible
-                                      domains with matching topology keys is less
-                                      than minDomains, Pod Topology Spread treats
-                                      "global minimum" as 0, and then the calculation
-                                      of Skew is performed. And when the number of
-                                      eligible domains with matching topology keys
-                                      equals or greater than minDomains, this value
-                                      has no effect on scheduling.
+                                    description: |-
+                                      MinDomains indicates a minimum number of eligible domains.
+                                      When the number of eligible domains with matching topology keys is less than minDomains,
+                                      Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                      And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                      this value has no effect on scheduling.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: "NodeAffinityPolicy indicates how
-                                      we will treat Pod's nodeAffinity/nodeSelector
-                                      when calculating pod topology spread skew. Options
-                                      are: - Honor: only nodes matching nodeAffinity/nodeSelector
-                                      are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored. All nodes
-                                      are included in the calculations. \n If this
-                                      value is nil, the behavior is equivalent to
-                                      the Honor policy."
+                                    description: |-
+                                      NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                      when calculating pod topology spread skew. Options are:
+                                      - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                      - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                                      If this value is nil, the behavior is equivalent to the Honor policy.
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: "NodeTaintsPolicy indicates how we
-                                      will treat node taints when calculating pod
-                                      topology spread skew. Options are: - Honor:
-                                      nodes without taints, along with tainted nodes
-                                      for which the incoming pod has a toleration,
-                                      are included. - Ignore: node taints are ignored.
-                                      All nodes are included. \n If this value is
-                                      nil, the behavior is equivalent to the Ignore
-                                      policy."
+                                    description: |-
+                                      NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                      pod topology spread skew. Options are:
+                                      - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                      has a toleration, are included.
+                                      - Ignore: node taints are ignored. All nodes are included.
+
+
+                                      If this value is nil, the behavior is equivalent to the Ignore policy.
                                     type: string
                                   topologyKey:
-                                    description: TopologyKey is the key of node labels.
-                                      Nodes that have a label with this key and identical
-                                      values are considered to be in the same topology.
-                                      We consider each <key, value> as a "bucket",
-                                      and try to put balanced number of pods into
-                                      each bucket. We define a domain as a particular
-                                      instance of a topology.
+                                    description: |-
+                                      TopologyKey is the key of node labels. Nodes that have a label with this key
+                                      and identical values are considered to be in the same topology.
+                                      We consider each <key, value> as a "bucket", and try to put balanced number
+                                      of pods into each bucket.
+                                      We define a domain as a particular instance of a topology.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: WhenUnsatisfiable indicates how to
-                                      deal with a pod if it doesn't satisfy the spread
-                                      constraint. - DoNotSchedule (default) tells
-                                      the scheduler not to schedule it. - ScheduleAnyway
-                                      tells the scheduler to schedule the pod in any
-                                      location, but giving higher precedence to topologies
-                                      that would help reduce the skew.
+                                    description: |-
+                                      WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                      the spread constraint.
+                                      - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                      - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                        but giving higher precedence to topologies that would help reduce the
+                                        skew.
                                     type: string
                                 required:
                                 - maxSkew
@@ -6485,49 +5949,45 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: 'List of volumes that can be mounted by
-                                containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                              description: |-
+                                List of volumes that can be mounted by containers belonging to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes
                               items:
                                 description: Volume represents a named volume in a
                                   pod that may be accessed by any container in the
                                   pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'awsElasticBlockStore represents
-                                      an AWS Disk resource that is attached to a kubelet''s
-                                      host machine and then exposed to the pod. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    description: |-
+                                      awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       partition:
-                                        description: 'partition is the partition in
-                                          the volume that you want to mount. If omitted,
-                                          the default is to mount by volume name.
-                                          Examples: For volume /dev/sda1, you specify
-                                          the partition as "1". Similarly, the volume
-                                          partition for /dev/sda is "0" (or you can
-                                          leave the property empty).'
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'readOnly value true will force
-                                          the readOnly setting in VolumeMounts. More
-                                          info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: |-
+                                          readOnly value true will force the readOnly setting in VolumeMounts.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                         type: boolean
                                       volumeID:
-                                        description: 'volumeID is unique ID of the
-                                          persistent disk resource in AWS (Amazon
-                                          EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: |-
+                                          volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                         type: string
                                     required:
                                     - volumeID
@@ -6550,11 +6010,10 @@ spec:
                                           in the blob storage
                                         type: string
                                       fsType:
-                                        description: fsType is Filesystem type to
-                                          mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is Filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       kind:
                                         description: 'kind expected values are Shared:
@@ -6564,9 +6023,9 @@ spec:
                                           availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: readOnly Defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                     required:
                                     - diskName
@@ -6578,9 +6037,9 @@ spec:
                                       the pod.
                                     properties:
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretName:
                                         description: secretName is the  name of secret
@@ -6600,9 +6059,9 @@ spec:
                                       on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'monitors is Required: Monitors
-                                          is a collection of Ceph monitors More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          monitors is Required: Monitors is a collection of Ceph monitors
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         items:
                                           type: string
                                         type: array
@@ -6612,71 +6071,72 @@ spec:
                                           tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'readOnly is Optional: Defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.
-                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: boolean
                                       secretFile:
-                                        description: 'secretFile is Optional: SecretFile
-                                          is the path to key ring for User, default
-                                          is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: string
                                       secretRef:
-                                        description: 'secretRef is Optional: SecretRef
-                                          is reference to the authentication secret
-                                          for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       user:
-                                        description: 'user is optional: User is the
-                                          rados user name, default is admin More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          user is optional: User is the rados user name, default is admin
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'cinder represents a cinder volume
-                                      attached and mounted on kubelets host machine.
-                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    description: |-
+                                      cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: string
                                       readOnly:
-                                        description: 'readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is optional: points
-                                          to a secret object containing parameters
-                                          used to connect to OpenStack.'
+                                        description: |-
+                                          secretRef is optional: points to a secret object containing parameters used to connect
+                                          to OpenStack.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       volumeID:
-                                        description: 'volumeID used to identify the
-                                          volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          volumeID used to identify the volume in cinder.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: string
                                     required:
                                     - volumeID
@@ -6686,25 +6146,21 @@ spec:
                                       that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'defaultMode is optional: mode
-                                          bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          defaultMode is optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
-                                        description: items if unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          ConfigMap will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present.
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -6713,23 +6169,19 @@ spec:
                                               description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'mode is Optional: mode
-                                                bits used to set permissions on this
-                                                file. Must be an octal value between
-                                                0000 and 0777 or a decimal value between
-                                                0 and 511. YAML accepts both octal
-                                                and decimal values, JSON requires
-                                                decimal values for mode bits. If not
-                                                specified, the volume defaultMode
-                                                will be used.'
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
-                                              description: path is the relative path
-                                                of the file to map the key to. May
-                                                not be an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -6737,10 +6189,10 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: optional specify whether the
@@ -6754,48 +6206,43 @@ spec:
                                       by certain external CSI drivers (Beta feature).
                                     properties:
                                       driver:
-                                        description: driver is the name of the CSI
-                                          driver that handles this volume. Consult
-                                          with your admin for the correct name as
-                                          registered in the cluster.
+                                        description: |-
+                                          driver is the name of the CSI driver that handles this volume.
+                                          Consult with your admin for the correct name as registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: fsType to mount. Ex. "ext4",
-                                          "xfs", "ntfs". If not provided, the empty
-                                          value is passed to the associated CSI driver
-                                          which will determine the default filesystem
-                                          to apply.
+                                        description: |-
+                                          fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                          If not provided, the empty value is passed to the associated CSI driver
+                                          which will determine the default filesystem to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: nodePublishSecretRef is a reference
-                                          to the secret object containing sensitive
-                                          information to pass to the CSI driver to
-                                          complete the CSI NodePublishVolume and NodeUnpublishVolume
-                                          calls. This field is optional, and  may
-                                          be empty if no secret is required. If the
-                                          secret object contains more than one secret,
-                                          all secret references are passed.
+                                        description: |-
+                                          nodePublishSecretRef is a reference to the secret object containing
+                                          sensitive information to pass to the CSI driver to complete the CSI
+                                          NodePublishVolume and NodeUnpublishVolume calls.
+                                          This field is optional, and  may be empty if no secret is required. If the
+                                          secret object contains more than one secret, all secret references are passed.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       readOnly:
-                                        description: readOnly specifies a read-only
-                                          configuration for the volume. Defaults to
-                                          false (read/write).
+                                        description: |-
+                                          readOnly specifies a read-only configuration for the volume.
+                                          Defaults to false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: volumeAttributes stores driver-specific
-                                          properties that are passed to the CSI driver.
-                                          Consult your driver's documentation for
-                                          supported values.
+                                        description: |-
+                                          volumeAttributes stores driver-specific properties that are passed to the CSI
+                                          driver. Consult your driver's documentation for supported values.
                                         type: object
                                     required:
                                     - driver
@@ -6805,16 +6252,13 @@ spec:
                                       about the pod that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on
-                                          created files by default. Must be a Optional:
-                                          mode bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          Optional: mode bits to use on created files by default. Must be a
+                                          Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
@@ -6844,14 +6288,11 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file, must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.'
+                                              description: |-
+                                                Optional: mode bits used to set permissions on this file, must be an octal value
+                                                between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
@@ -6863,11 +6304,9 @@ spec:
                                                 path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                requests.cpu and requests.memory)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -6897,56 +6336,51 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'emptyDir represents a temporary
-                                      directory that shares a pod''s lifetime. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    description: |-
+                                      emptyDir represents a temporary directory that shares a pod's lifetime.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     properties:
                                       medium:
-                                        description: 'medium represents what type
-                                          of storage medium should back this directory.
-                                          The default is "" which means to use the
-                                          node''s default medium. Must be an empty
-                                          string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: |-
+                                          medium represents what type of storage medium should back this directory.
+                                          The default is "" which means to use the node's default medium.
+                                          Must be an empty string (default) or Memory.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'sizeLimit is the total amount
-                                          of local storage required for this EmptyDir
-                                          volume. The size limit is also applicable
-                                          for memory medium. The maximum usage on
-                                          memory medium EmptyDir would be the minimum
-                                          value between the SizeLimit specified here
-                                          and the sum of memory limits of all containers
-                                          in a pod. The default is nil which means
-                                          that the limit is undefined. More info:
-                                          https://kubernetes.'
+                                        description: |-
+                                          sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                          The size limit is also applicable for memory medium.
+                                          The maximum usage on memory medium EmptyDir would be the minimum value between
+                                          the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                          The default is nil which means that the limit is undefined.
+                                          More info: https://kubernetes.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: ephemeral represents a volume that
-                                      is handled by a cluster storage driver. The
-                                      volume's lifecycle is tied to the pod that defines
-                                      it - it will be created before the pod starts,
+                                    description: |-
+                                      ephemeral represents a volume that is handled by a cluster storage driver.
+                                      The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                                       and deleted when the pod is removed.
                                     properties:
                                       volumeClaimTemplate:
-                                        description: Will be used to create a stand-alone
-                                          PVC to provision the volume. The pod in
-                                          which this EphemeralVolumeSource is embedded
-                                          will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.  The
-                                          name of the PVC will be `<pod name>-<volume
-                                          name>` where `<volume name>` is the name
-                                          from the `PodSpec.Volumes` array entry.
+                                        description: |-
+                                          Will be used to create a stand-alone PVC to provision the volume.
+                                          The pod in which this EphemeralVolumeSource is embedded will be the
+                                          owner of the PVC, i.e. the PVC will be deleted together with the
+                                          pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                          `<volume name>` is the name from the `PodSpec.Volumes` array
+                                          entry.
                                         properties:
                                           metadata:
-                                            description: May contain labels and annotations
-                                              that will be copied into the PVC when
-                                              creating it. No other fields are allowed
-                                              and will be rejected during validation.
+                                            description: |-
+                                              May contain labels and annotations that will be copied into the PVC
+                                              when creating it. No other fields are allowed and will be rejected during
+                                              validation.
                                             properties:
                                               annotations:
                                                 additionalProperties:
@@ -6966,39 +6400,32 @@ spec:
                                                 type: string
                                             type: object
                                           spec:
-                                            description: The specification for the
-                                              PersistentVolumeClaim. The entire content
-                                              is copied unchanged into the PVC that
-                                              gets created from this template. The
-                                              same fields as in a PersistentVolumeClaim
+                                            description: |-
+                                              The specification for the PersistentVolumeClaim. The entire content is
+                                              copied unchanged into the PVC that gets created from this
+                                              template. The same fields as in a PersistentVolumeClaim
                                               are also valid here.
                                             properties:
                                               accessModes:
-                                                description: 'accessModes contains
-                                                  the desired access modes the volume
-                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                description: |-
+                                                  accessModes contains the desired access modes the volume should have.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                                 items:
                                                   type: string
                                                 type: array
                                               dataSource:
-                                                description: 'dataSource field can
-                                                  be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                description: |-
+                                                  dataSource field can be used to specify either:
+                                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                                   * An existing PVC (PersistentVolumeClaim)
-                                                  If the provisioner or an external
-                                                  controller can support the specified
-                                                  data source, it will create a new
-                                                  volume based on the contents of
-                                                  the specified data source.'
+                                                  If the provisioner or an external controller can support the specified data source,
+                                                  it will create a new volume based on the contents of the specified data source.
                                                 properties:
                                                   apiGroup:
-                                                    description: APIGroup is the group
-                                                      for the resource being referenced.
-                                                      If APIGroup is not specified,
-                                                      the specified Kind must be in
-                                                      the core API group. For any
-                                                      other third-party types, APIGroup
-                                                      is required.
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
                                                     type: string
                                                   kind:
                                                     description: Kind is the type
@@ -7014,26 +6441,19 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               dataSourceRef:
-                                                description: dataSourceRef specifies
-                                                  the object from which to populate
-                                                  the volume with data, if a non-empty
-                                                  volume is desired. This may be any
-                                                  object from a non-empty API group
-                                                  (non core object) or a PersistentVolumeClaim
-                                                  object. When this field is specified,
-                                                  volume binding will only succeed
-                                                  if the type of the specified object
-                                                  matches some installed volume populator
-                                                  or dynamic provisioner.
+                                                description: |-
+                                                  dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                                  volume is desired. This may be any object from a non-empty API group (non
+                                                  core object) or a PersistentVolumeClaim object.
+                                                  When this field is specified, volume binding will only succeed if the type of
+                                                  the specified object matches some installed volume populator or dynamic
+                                                  provisioner.
                                                 properties:
                                                   apiGroup:
-                                                    description: APIGroup is the group
-                                                      for the resource being referenced.
-                                                      If APIGroup is not specified,
-                                                      the specified Kind must be in
-                                                      the core API group. For any
-                                                      other third-party types, APIGroup
-                                                      is required.
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
                                                     type: string
                                                   kind:
                                                     description: Kind is the type
@@ -7044,54 +6464,42 @@ spec:
                                                       of resource being referenced
                                                     type: string
                                                   namespace:
-                                                    description: Namespace is the
-                                                      namespace of resource being
-                                                      referenced Note that when a
-                                                      namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
-                                                      object is required in the referent
-                                                      namespace to allow that namespace's
-                                                      owner to accept the reference.
-                                                      See the ReferenceGrant documentation
-                                                      for details. (Alpha) This field
-                                                      requires the CrossNamespaceVolumeDataSource
-                                                      feature gate to be enabled.
+                                                    description: |-
+                                                      Namespace is the namespace of resource being referenced
+                                                      Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                      (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                                     type: string
                                                 required:
                                                 - kind
                                                 - name
                                                 type: object
                                               resources:
-                                                description: 'resources represents
-                                                  the minimum resources the volume
-                                                  should have. If RecoverVolumeExpansionFailure
-                                                  feature is enabled users are allowed
-                                                  to specify resource requirements
-                                                  that are lower than previous value
-                                                  but must still be higher than capacity
-                                                  recorded in the status field of
-                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                description: |-
+                                                  resources represents the minimum resources the volume should have.
+                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  that are lower than previous value but must still be higher than capacity recorded in the
+                                                  status field of the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                                 properties:
                                                   claims:
-                                                    description: "Claims lists the
-                                                      names of resources, defined
-                                                      in spec.resourceClaims, that
-                                                      are used by this container.
-                                                      \n This is an alpha field and
-                                                      requires enabling the DynamicResourceAllocation
-                                                      feature gate. \n This field
-                                                      is immutable. It can only be
-                                                      set for containers."
+                                                    description: |-
+                                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                                      that are used by this container.
+
+
+                                                      This is an alpha field and requires enabling the
+                                                      DynamicResourceAllocation feature gate.
+
+
+                                                      This field is immutable. It can only be set for containers.
                                                     items:
                                                       description: ResourceClaim references
                                                         one entry in PodSpec.ResourceClaims.
                                                       properties:
                                                         name:
-                                                          description: Name must match
-                                                            the name of one entry
-                                                            in pod.spec.resourceClaims
-                                                            of the Pod where this
-                                                            field is used. It makes
-                                                            that resource available
+                                                          description: |-
+                                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                                            the Pod where this field is used. It makes that resource available
                                                             inside a container.
                                                           type: string
                                                       required:
@@ -7108,10 +6516,9 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: 'Limits describes
-                                                      the maximum amount of compute
-                                                      resources allowed. More info:
-                                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    description: |-
+                                                      Limits describes the maximum amount of compute resources allowed.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -7120,15 +6527,11 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: 'Requests describes
-                                                      the minimum amount of compute
-                                                      resources required. If Requests
-                                                      is omitted for a container,
-                                                      it defaults to Limits if that
-                                                      is explicitly specified, otherwise
-                                                      to an implementation-defined
-                                                      value. Requests cannot exceed
-                                                      Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    description: |-
+                                                      Requests describes the minimum amount of compute resources required.
+                                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                 type: object
                                               selector:
@@ -7141,11 +6544,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -7153,23 +6554,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -7181,28 +6575,22 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               storageClassName:
-                                                description: 'storageClassName is
-                                                  the name of the StorageClass required
-                                                  by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                description: |-
+                                                  storageClassName is the name of the StorageClass required by the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                                 type: string
                                               volumeMode:
-                                                description: volumeMode defines what
-                                                  type of volume is required by the
-                                                  claim. Value of Filesystem is implied
-                                                  when not included in claim spec.
+                                                description: |-
+                                                  volumeMode defines what type of volume is required by the claim.
+                                                  Value of Filesystem is implied when not included in claim spec.
                                                 type: string
                                               volumeName:
                                                 description: volumeName is the binding
@@ -7220,13 +6608,11 @@ spec:
                                       and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. TODO: how do we prevent
-                                          errors in the filesystem from compromising
-                                          the machine'
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       lun:
                                         description: 'lun is Optional: FC target lun
@@ -7234,9 +6620,9 @@ spec:
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'readOnly is Optional: Defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.'
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       targetWWNs:
                                         description: 'targetWWNs is Optional: FC target
@@ -7245,29 +6631,27 @@ spec:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'wwids Optional: FC volume world
-                                          wide identifiers (wwids) Either wwids or
-                                          combination of targetWWNs and lun must be
-                                          set, but not both simultaneously.'
+                                        description: |-
+                                          wwids Optional: FC volume world wide identifiers (wwids)
+                                          Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: flexVolume represents a generic volume
-                                      resource that is provisioned/attached using
-                                      an exec based plugin.
+                                    description: |-
+                                      flexVolume represents a generic volume resource that is
+                                      provisioned/attached using an exec based plugin.
                                     properties:
                                       driver:
                                         description: driver is the name of the driver
                                           to use for this volume.
                                         type: string
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". The default filesystem depends
-                                          on FlexVolume script.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
@@ -7276,24 +6660,23 @@ spec:
                                           holds extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'readOnly is Optional: defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.'
+                                        description: |-
+                                          readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is Optional: secretRef
-                                          is reference to the secret object containing
-                                          sensitive information to pass to the plugin
-                                          scripts. This may be empty if no secret
-                                          object is specified. If the secret object
-                                          contains more than one secret, all secrets
-                                          are passed to the plugin scripts.'
+                                        description: |-
+                                          secretRef is Optional: secretRef is reference to the secret object containing
+                                          sensitive information to pass to the plugin scripts. This may be
+                                          empty if no secret object is specified. If the secret object
+                                          contains more than one secret, all secrets are passed to the plugin
+                                          scripts.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -7306,9 +6689,9 @@ spec:
                                       on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: datasetName is Name of the dataset
-                                          stored as metadata -> name on the dataset
-                                          for Flocker should be considered as deprecated
+                                        description: |-
+                                          datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                          should be considered as deprecated
                                         type: string
                                       datasetUUID:
                                         description: datasetUUID is the UUID of the
@@ -7317,60 +6700,55 @@ spec:
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'gcePersistentDisk represents a GCE
-                                      Disk resource that is attached to a kubelet''s
-                                      host machine and then exposed to the pod. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    description: |-
+                                      gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                     properties:
                                       fsType:
-                                        description: 'fsType is filesystem type of
-                                          the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       partition:
-                                        description: 'partition is the partition in
-                                          the volume that you want to mount. If omitted,
-                                          the default is to mount by volume name.
-                                          Examples: For volume /dev/sda1, you specify
-                                          the partition as "1". Similarly, the volume
-                                          partition for /dev/sda is "0" (or you can
-                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'pdName is unique name of the
-                                          PD resource in GCE. Used to identify the
-                                          disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         type: boolean
                                     required:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'gitRepo represents a git repository
-                                      at a particular revision. DEPRECATED: GitRepo
-                                      is deprecated. To provision a container with
-                                      a git repo, mount an EmptyDir into an InitContainer
-                                      that clones the repo using git, then mount the
-                                      EmptyDir into the Pod''s container.'
+                                    description: |-
+                                      gitRepo represents a git repository at a particular revision.
+                                      DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                      EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                      into the Pod's container.
                                     properties:
                                       directory:
-                                        description: directory is the target directory
-                                          name. Must not contain or start with '..'.  If
-                                          '.' is supplied, the volume directory will
-                                          be the git repository.  Otherwise, if specified,
-                                          the volume will contain the git repository
-                                          in the subdirectory with the given name.
+                                        description: |-
+                                          directory is the target directory name.
+                                          Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                          git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                          the subdirectory with the given name.
                                         type: string
                                       repository:
                                         description: repository is the URL
@@ -7383,54 +6761,58 @@ spec:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'glusterfs represents a Glusterfs
-                                      mount on the host that shares a pod''s lifetime.
-                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                    description: |-
+                                      glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                     properties:
                                       endpoints:
-                                        description: 'endpoints is the endpoint name
-                                          that details Glusterfs topology. More info:
-                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          endpoints is the endpoint name that details Glusterfs topology.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: string
                                       path:
-                                        description: 'path is the Glusterfs volume
-                                          path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          path is the Glusterfs volume path.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          Glusterfs volume to be mounted with read-only
-                                          permissions. Defaults to false. More info:
-                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: boolean
                                     required:
                                     - endpoints
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'hostPath represents a pre-existing
-                                      file or directory on the host machine that is
-                                      directly exposed to the container. This is generally
-                                      used for system agents or other privileged things
-                                      that are allowed to see the host machine. Most
-                                      containers will NOT need this. More info: https://kubernetes.'
+                                    description: |-
+                                      hostPath represents a pre-existing file or directory on the host
+                                      machine that is directly exposed to the container. This is generally
+                                      used for system agents or other privileged things that are allowed
+                                      to see the host machine. Most containers will NOT need this.
+                                      More info: https://kubernetes.
                                     properties:
                                       path:
-                                        description: 'path of the directory on the
-                                          host. If the path is a symlink, it will
-                                          follow the link to the real path. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        description: |-
+                                          path of the directory on the host.
+                                          If the path is a symlink, it will follow the link to the real path.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                         type: string
                                       type:
-                                        description: 'type for HostPath Volume Defaults
-                                          to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        description: |-
+                                          type for HostPath Volume
+                                          Defaults to ""
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'iscsi represents an ISCSI Disk resource
-                                      that is attached to a kubelet''s host machine
-                                      and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                    description: |-
+                                      iscsi represents an ISCSI Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://examples.k8s.io/volumes/iscsi/README.md
                                     properties:
                                       chapAuthDiscovery:
                                         description: chapAuthDiscovery defines whether
@@ -7441,31 +6823,27 @@ spec:
                                           support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       initiatorName:
-                                        description: initiatorName is the custom iSCSI
-                                          Initiator Name. If initiatorName is specified
-                                          with iscsiInterface simultaneously, new
-                                          iSCSI interface <target portal>:<volume
-                                          name> will be created for the connection.
+                                        description: |-
+                                          initiatorName is the custom iSCSI Initiator Name.
+                                          If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                          <target portal>:<volume name> will be created for the connection.
                                         type: string
                                       iqn:
                                         description: iqn is the target iSCSI Qualified
                                           Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iscsiInterface is the interface
-                                          Name that uses an iSCSI transport. Defaults
-                                          to 'default' (tcp).
+                                        description: |-
+                                          iscsiInterface is the interface Name that uses an iSCSI transport.
+                                          Defaults to 'default' (tcp).
                                         type: string
                                       lun:
                                         description: lun represents iSCSI Target Lun
@@ -7473,35 +6851,33 @@ spec:
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: portals is the iSCSI Target Portal
-                                          List. The portal is either an IP or ip_addr:port
-                                          if the port is other than default (typically
-                                          TCP ports 860 and 3260).
+                                        description: |-
+                                          portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false.
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
                                         type: boolean
                                       secretRef:
                                         description: secretRef is the CHAP Secret
                                           for iSCSI target and initiator authentication
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       targetPortal:
-                                        description: targetPortal is iSCSI Target
-                                          Portal. The Portal is either an IP or ip_addr:port
-                                          if the port is other than default (typically
-                                          TCP ports 860 and 3260).
+                                        description: |-
+                                          targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -7509,45 +6885,51 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'name of the volume. Must be a DNS_LABEL
-                                      and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: |-
+                                      name of the volume.
+                                      Must be a DNS_LABEL and unique within the pod.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                   nfs:
-                                    description: 'nfs represents an NFS mount on the
-                                      host that shares a pod''s lifetime More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    description: |-
+                                      nfs represents an NFS mount on the host that shares a pod's lifetime
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                     properties:
                                       path:
-                                        description: 'path that is exported by the
-                                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          path that is exported by the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          NFS export to be mounted with read-only
-                                          permissions. Defaults to false. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          readOnly here will force the NFS export to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: boolean
                                       server:
-                                        description: 'server is the hostname or IP
-                                          address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          server is the hostname or IP address of the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: string
                                     required:
                                     - path
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'persistentVolumeClaimVolumeSource
-                                      represents a reference to a PersistentVolumeClaim
-                                      in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    description: |-
+                                      persistentVolumeClaimVolumeSource represents a reference to a
+                                      PersistentVolumeClaim in the same namespace.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                     properties:
                                       claimName:
-                                        description: 'claimName is the name of a PersistentVolumeClaim
-                                          in the same namespace as the pod using this
-                                          volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        description: |-
+                                          claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                         type: string
                                       readOnly:
-                                        description: readOnly Will force the ReadOnly
-                                          setting in VolumeMounts. Default false.
+                                        description: |-
+                                          readOnly Will force the ReadOnly setting in VolumeMounts.
+                                          Default false.
                                         type: boolean
                                     required:
                                     - claimName
@@ -7558,11 +6940,10 @@ spec:
                                       mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       pdID:
                                         description: pdID is the ID that identifies
@@ -7577,16 +6958,15 @@ spec:
                                       machine
                                     properties:
                                       fsType:
-                                        description: fSType represents the filesystem
-                                          type to mount Must be a filesystem type
-                                          supported by the host operating system.
-                                          Ex. "ext4", "xfs". Implicitly inferred to
-                                          be "ext4" if unspecified.
+                                        description: |-
+                                          fSType represents the filesystem type to mount
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       volumeID:
                                         description: volumeID uniquely identifies
@@ -7600,14 +6980,11 @@ spec:
                                       secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: defaultMode are the mode bits
-                                          used to set permissions on created files
-                                          by default. Must be an octal value between
-                                          0000 and 0777 or a decimal value between
-                                          0 and 511. YAML accepts both octal and decimal
-                                          values, JSON requires decimal values for
-                                          mode bits. Directories within the path are
-                                          not affected by this setting.
+                                        description: |-
+                                          defaultMode are the mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       sources:
@@ -7622,15 +6999,12 @@ spec:
                                                 the configMap data to project
                                               properties:
                                                 items:
-                                                  description: items if unspecified,
-                                                    each key-value pair in the Data
-                                                    field of the referenced ConfigMap
-                                                    will be projected into the volume
-                                                    as a file whose name is the key
-                                                    and content is the value. If specified,
-                                                    the listed keys will be projected
-                                                    into the specified paths, and
-                                                    unlisted keys will not be present.
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    ConfigMap will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7640,27 +7014,19 @@ spec:
                                                           to project.
                                                         type: string
                                                       mode:
-                                                        description: 'mode is Optional:
-                                                          mode bits used to set permissions
-                                                          on this file. Must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: path is the relative
-                                                          path of the file to map
-                                                          the key to. May not be an
-                                                          absolute path. May not contain
-                                                          the path element '..'. May
-                                                          not start with the string
-                                                          '..'.
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -7668,10 +7034,10 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: optional specify whether
@@ -7715,17 +7081,11 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
-                                                          on this file, must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7740,12 +7100,9 @@ spec:
                                                           ''..'''
                                                         type: string
                                                       resourceFieldRef:
-                                                        description: 'Selects a resource
-                                                          of the container: only resources
-                                                          limits and requests (limits.cpu,
-                                                          limits.memory, requests.cpu
-                                                          and requests.memory) are
-                                                          currently supported.'
+                                                        description: |-
+                                                          Selects a resource of the container: only resources limits and requests
+                                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                         properties:
                                                           containerName:
                                                             description: 'Container
@@ -7780,15 +7137,12 @@ spec:
                                                 the secret data to project
                                               properties:
                                                 items:
-                                                  description: items if unspecified,
-                                                    each key-value pair in the Data
-                                                    field of the referenced Secret
-                                                    will be projected into the volume
-                                                    as a file whose name is the key
-                                                    and content is the value. If specified,
-                                                    the listed keys will be projected
-                                                    into the specified paths, and
-                                                    unlisted keys will not be present.
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    Secret will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7798,27 +7152,19 @@ spec:
                                                           to project.
                                                         type: string
                                                       mode:
-                                                        description: 'mode is Optional:
-                                                          mode bits used to set permissions
-                                                          on this file. Must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: path is the relative
-                                                          path of the file to map
-                                                          the key to. May not be an
-                                                          absolute path. May not contain
-                                                          the path element '..'. May
-                                                          not start with the string
-                                                          '..'.
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -7826,10 +7172,10 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: optional field specify
@@ -7844,35 +7190,26 @@ spec:
                                                 data to project
                                               properties:
                                                 audience:
-                                                  description: audience is the intended
-                                                    audience of the token. A recipient
-                                                    of a token must identify itself
-                                                    with an identifier specified in
-                                                    the audience of the token, and
-                                                    otherwise should reject the token.
-                                                    The audience defaults to the identifier
-                                                    of the apiserver.
+                                                  description: |-
+                                                    audience is the intended audience of the token. A recipient of a token
+                                                    must identify itself with an identifier specified in the audience of the
+                                                    token, and otherwise should reject the token. The audience defaults to the
+                                                    identifier of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: expirationSeconds is
-                                                    the requested duration of validity
-                                                    of the service account token.
-                                                    As the token approaches expiration,
-                                                    the kubelet volume plugin will
-                                                    proactively rotate the service
-                                                    account token. The kubelet will
-                                                    start trying to rotate the token
-                                                    if the token is older than 80
-                                                    percent of its time to live or
-                                                    if the token is older than 24
-                                                    hours.Defaults to 1 hour and must
-                                                    be at least 10 minutes.
+                                                  description: |-
+                                                    expirationSeconds is the requested duration of validity of the service
+                                                    account token. As the token approaches expiration, the kubelet volume
+                                                    plugin will proactively rotate the service account token. The kubelet will
+                                                    start trying to rotate the token if the token is older than 80 percent of
+                                                    its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                    and must be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: path is the path relative
-                                                    to the mount point of the file
-                                                    to project the token into.
+                                                  description: |-
+                                                    path is the path relative to the mount point of the file to project the
+                                                    token into.
                                                   type: string
                                               required:
                                               - path
@@ -7885,29 +7222,29 @@ spec:
                                       on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: group to map volume access to
+                                        description: |-
+                                          group to map volume access to
                                           Default is no group
                                         type: string
                                       readOnly:
-                                        description: readOnly here will force the
-                                          Quobyte volume to be mounted with read-only
-                                          permissions. Defaults to false.
+                                        description: |-
+                                          readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                          Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: registry represents a single
-                                          or multiple Quobyte Registry services specified
-                                          as a string as host:port pair (multiple
-                                          entries are separated with commas) which
-                                          acts as the central registry for volumes
+                                        description: |-
+                                          registry represents a single or multiple Quobyte Registry services
+                                          specified as a string as host:port pair (multiple entries are separated with commas)
+                                          which acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: tenant owning the given Quobyte
-                                          volume in the Backend Used with dynamically
-                                          provisioned Quobyte volumes, value is set
-                                          by the plugin
+                                        description: |-
+                                          tenant owning the given Quobyte volume in the Backend
+                                          Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                         type: string
                                       user:
-                                        description: user to map volume access to
+                                        description: |-
+                                          user to map volume access to
                                           Defaults to serivceaccount user
                                         type: string
                                       volume:
@@ -7919,61 +7256,68 @@ spec:
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'rbd represents a Rados Block Device
-                                      mount on the host that shares a pod''s lifetime.
-                                      More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                    description: |-
+                                      rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       image:
-                                        description: 'image is the rados image name.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       keyring:
-                                        description: 'keyring is the path to key ring
-                                          for RBDUser. Default is /etc/ceph/keyring.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          keyring is the path to key ring for RBDUser.
+                                          Default is /etc/ceph/keyring.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       monitors:
-                                        description: 'monitors is a collection of
-                                          Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          monitors is a collection of Ceph monitors.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'pool is the rados pool name.
-                                          Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          pool is the rados pool name.
+                                          Default is rbd.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is name of the authentication
-                                          secret for RBDUser. If provided overrides
-                                          keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          secretRef is name of the authentication secret for RBDUser. If provided
+                                          overrides keyring.
+                                          Default is nil.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       user:
-                                        description: 'user is the rados user name.
-                                          Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          user is the rados user name.
+                                          Default is admin.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                     required:
                                     - image
@@ -7984,10 +7328,11 @@ spec:
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Default is "xfs".
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs".
+                                          Default is "xfs".
                                         type: string
                                       gateway:
                                         description: gateway is the host address of
@@ -7999,21 +7344,20 @@ spec:
                                           configured storage.
                                         type: string
                                       readOnly:
-                                        description: readOnly Defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: secretRef references to the secret
-                                          for ScaleIO user and other sensitive information.
-                                          If this is not provided, Login operation
-                                          will fail.
+                                        description: |-
+                                          secretRef references to the secret for ScaleIO user and other
+                                          sensitive information. If this is not provided, Login operation will fail.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -8023,9 +7367,9 @@ spec:
                                           false
                                         type: boolean
                                       storageMode:
-                                        description: storageMode indicates whether
-                                          the storage for a volume should be ThickProvisioned
-                                          or ThinProvisioned. Default is ThinProvisioned.
+                                        description: |-
+                                          storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                          Default is ThinProvisioned.
                                         type: string
                                       storagePool:
                                         description: storagePool is the ScaleIO Storage
@@ -8036,9 +7380,9 @@ spec:
                                           system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: volumeName is the name of a volume
-                                          already created in the ScaleIO system that
-                                          is associated with this volume source.
+                                        description: |-
+                                          volumeName is the name of a volume already created in the ScaleIO system
+                                          that is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -8046,29 +7390,26 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'secret represents a secret that
-                                      should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    description: |-
+                                      secret represents a secret that should populate this volume.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                     properties:
                                       defaultMode:
-                                        description: 'defaultMode is Optional: mode
-                                          bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values
+                                          for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
-                                        description: items If unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          Secret will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present.
+                                        description: |-
+                                          items If unspecified, each key-value pair in the Data field of the referenced
+                                          Secret will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -8077,23 +7418,19 @@ spec:
                                               description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'mode is Optional: mode
-                                                bits used to set permissions on this
-                                                file. Must be an octal value between
-                                                0000 and 0777 or a decimal value between
-                                                0 and 511. YAML accepts both octal
-                                                and decimal values, JSON requires
-                                                decimal values for mode bits. If not
-                                                specified, the volume defaultMode
-                                                will be used.'
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
-                                              description: path is the relative path
-                                                of the file to map the key to. May
-                                                not be an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -8105,9 +7442,9 @@ spec:
                                           the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'secretName is the name of the
-                                          secret in the pod''s namespace to use. More
-                                          info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        description: |-
+                                          secretName is the name of the secret in the pod's namespace to use.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                         type: string
                                     type: object
                                   storageos:
@@ -8115,45 +7452,41 @@ spec:
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: secretRef specifies the secret
-                                          to use for obtaining the StorageOS API credentials.  If
-                                          not specified, default values will be attempted.
+                                        description: |-
+                                          secretRef specifies the secret to use for obtaining the StorageOS API
+                                          credentials.  If not specified, default values will be attempted.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       volumeName:
-                                        description: volumeName is the human-readable
-                                          name of the StorageOS volume.  Volume names
-                                          are only unique within a namespace.
+                                        description: |-
+                                          volumeName is the human-readable name of the StorageOS volume.  Volume
+                                          names are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: volumeNamespace specifies the
-                                          scope of the volume within StorageOS.  If
-                                          no namespace is specified then the Pod's
-                                          namespace will be used.  This allows the
-                                          Kubernetes name scoping to be mirrored within
-                                          StorageOS for tighter integration. Set VolumeName
-                                          to any name to override the default behaviour.
-                                          Set to "default" if you are not using namespaces
-                                          within StorageOS.
+                                        description: |-
+                                          volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                          namespace is specified then the Pod's namespace will be used.  This allows the
+                                          Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                          Set VolumeName to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces within StorageOS.
                                         type: string
                                     type: object
                                   vsphereVolume:
@@ -8162,11 +7495,10 @@ spec:
                                       machine
                                     properties:
                                       fsType:
-                                        description: fsType is filesystem type to
-                                          mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
                                         description: storagePolicyID is the storage
@@ -8193,19 +7525,24 @@ spec:
                           type: object
                       type: object
                   type: object
-                description: 'A map of PaddleReplicaType (type) to ReplicaSpec (value).
-                  Specifies the Paddle cluster configuration. For example, { "Master":
-                  PaddleReplicaSpec, "Worker": PaddleReplicaSpec, }'
+                description: |-
+                  A map of PaddleReplicaType (type) to ReplicaSpec (value). Specifies the Paddle cluster configuration.
+                  For example,
+                    {
+                      "Master": PaddleReplicaSpec,
+                      "Worker": PaddleReplicaSpec,
+                    }
                 type: object
               runPolicy:
-                description: RunPolicy encapsulates various runtime policies of the
-                  distributed training job, for example how to clean up resources
-                  and how long the job can stay active.
+                description: |-
+                  RunPolicy encapsulates various runtime policies of the distributed training
+                  job, for example how to clean up resources and how long the job can stay
+                  active.
                 properties:
                   activeDeadlineSeconds:
-                    description: Specifies the duration in seconds relative to the
-                      startTime that the job may be active before the system tries
-                      to terminate it; value must be positive integer.
+                    description: |-
+                      Specifies the duration in seconds relative to the startTime that the job may be active
+                      before the system tries to terminate it; value must be positive integer.
                     format: int64
                     type: integer
                   backoffLimit:
@@ -8214,8 +7551,9 @@ spec:
                     format: int32
                     type: integer
                   cleanPodPolicy:
-                    description: CleanPodPolicy defines the policy to kill pods after
-                      the job completes. Default to None.
+                    description: |-
+                      CleanPodPolicy defines the policy to kill pods after the job completes.
+                      Default to None.
                     type: string
                   schedulingPolicy:
                     description: SchedulingPolicy defines the policy related to scheduling,
@@ -8242,18 +7580,20 @@ spec:
                     type: object
                   suspend:
                     default: false
-                    description: suspend specifies whether the Job controller should
-                      create Pods or not. If a Job is created with suspend set to
-                      true, no Pods are created by the Job controller. If a Job is
-                      suspended after creation (i.e. the flag goes from false to true),
-                      the Job controller will delete all active Pods and PodGroups
-                      associated with this Job. Users must design their workload to
-                      gracefully handle this.
+                    description: |-
+                      suspend specifies whether the Job controller should create Pods or not.
+                      If a Job is created with suspend set to true, no Pods are created by
+                      the Job controller. If a Job is suspended after creation (i.e. the
+                      flag goes from false to true), the Job controller will delete all
+                      active Pods and PodGroups associated with this Job.
+                      Users must design their workload to gracefully handle this.
                     type: boolean
                   ttlSecondsAfterFinished:
-                    description: TTLSecondsAfterFinished is the TTL to clean up jobs.
+                    description: |-
+                      TTLSecondsAfterFinished is the TTL to clean up jobs.
                       It may take extra ReconcilePeriod seconds for the cleanup, since
-                      reconcile gets called periodically. Default to infinite.
+                      reconcile gets called periodically.
+                      Default to infinite.
                     format: int32
                     type: integer
                 type: object
@@ -8261,12 +7601,14 @@ spec:
             - paddleReplicaSpecs
             type: object
           status:
-            description: Most recently observed status of the PaddleJob. Read-only
-              (modified by the system).
+            description: |-
+              Most recently observed status of the PaddleJob.
+              Read-only (modified by the system).
             properties:
               completionTime:
-                description: Represents time when the job was completed. It is not
-                  guaranteed to be set in happens-before order across separate operations.
+                description: |-
+                  Represents time when the job was completed. It is not guaranteed to
+                  be set in happens-before order across separate operations.
                   It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
@@ -8304,9 +7646,10 @@ spec:
                   type: object
                 type: array
               lastReconcileTime:
-                description: Represents last time when the job was reconciled. It
-                  is not guaranteed to be set in happens-before order across separate
-                  operations. It is represented in RFC3339 form and is in UTC.
+                description: |-
+                  Represents last time when the job was reconciled. It is not guaranteed to
+                  be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               replicaStatuses:
@@ -8329,25 +7672,25 @@ spec:
                           description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -8359,33 +7702,33 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     selector:
-                      description: A Selector is a label query over a set of resources.
-                        The result of matchLabels and matchExpressions are ANDed.
-                        An empty Selector matches all objects. A null Selector matches
-                        no objects.
+                      description: |-
+                        A Selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty Selector matches all objects. A null
+                        Selector matches no objects.
                       type: string
                     succeeded:
                       description: The number of pods which reached phase Succeeded.
                       format: int32
                       type: integer
                   type: object
-                description: ReplicaStatuses is map of ReplicaType and ReplicaStatus,
+                description: |-
+                  ReplicaStatuses is map of ReplicaType and ReplicaStatus,
                   specifies the status of each replica.
                 type: object
               startTime:
-                description: Represents time when the job was acknowledged by the
-                  job controller. It is not guaranteed to be set in happens-before
-                  order across separate operations. It is represented in RFC3339 form
-                  and is in UTC.
+                description: |-
+                  Represents time when the job was acknowledged by the job controller.
+                  It is not guaranteed to be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
             type: object

--- a/manifests/base/crds/kubeflow.org_pytorchjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_pytorchjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: pytorchjobs.kubeflow.org
 spec:
   group: kubeflow.org
@@ -27,14 +27,19 @@ spec:
         description: PyTorchJob Represents a PyTorchJob resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -53,26 +58,25 @@ spec:
                     format: int32
                     type: integer
                   metrics:
-                    description: Metrics contains the specifications which are used
-                      to calculate the desired replica count (the maximum replica
-                      count across all metrics will be used).  The desired replica
-                      count is calculated with multiplying the ratio between the target
-                      value and the current value by the current number of pods. Ergo,
-                      metrics used must decrease as the pod count is increased, and
-                      vice-versa.
+                    description: |-
+                      Metrics contains the specifications which are used to calculate the
+                      desired replica count (the maximum replica count across all metrics will
+                      be used).  The desired replica count is calculated with multiplying the
+                      ratio between the target value and the current value by the current
+                      number of pods. Ergo, metrics used must decrease as the pod count is
+                      increased, and vice-versa.
                     items:
-                      description: MetricSpec specifies how to scale based on a single
-                        metric (only `type` and one other matching field should be
-                        set at once).
+                      description: |-
+                        MetricSpec specifies how to scale based on a single metric
+                        (only `type` and one other matching field should be set at once).
                       properties:
                         containerResource:
-                          description: containerResource refers to a resource metric
-                            (such as those specified in requests and limits) known
-                            to Kubernetes describing a single container in each pod
-                            of the current scale target (e.g. CPU or memory). Such
-                            metrics are built in to Kubernetes, and have special scaling
-                            options on top of those available to normal per-pod metrics
-                            using the "pods" source.
+                          description: |-
+                            containerResource refers to a resource metric (such as those specified in
+                            requests and limits) known to Kubernetes describing a single container in
+                            each pod of the current scale target (e.g. CPU or memory). Such metrics are
+                            built in to Kubernetes, and have special scaling options on top of those
+                            available to normal per-pod metrics using the "pods" source.
                           properties:
                             container:
                               description: container is the name of the container
@@ -86,21 +90,20 @@ spec:
                                 given metric
                               properties:
                                 averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a percentage of
                                     the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
+                                    Currently only valid for Resource metric source type
                                   format: int32
                                   type: integer
                                 averageValue:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 type:
@@ -124,11 +127,12 @@ spec:
                           - target
                           type: object
                         external:
-                          description: external refers to a global metric that is
-                            not associated with any Kubernetes object. It allows autoscaling
-                            based on information coming from components running outside
-                            of cluster (for example length of queue in cloud messaging
-                            service, or QPS from loadbalancer running outside of cluster).
+                          description: |-
+                            external refers to a global metric that is not associated
+                            with any Kubernetes object. It allows autoscaling based on information
+                            coming from components running outside of cluster
+                            (for example length of queue in cloud messaging service, or
+                            QPS from loadbalancer running outside of cluster).
                           properties:
                             metric:
                               description: metric identifies the target metric by
@@ -138,40 +142,34 @@ spec:
                                   description: name is the name of the given metric
                                   type: string
                                 selector:
-                                  description: selector is the string-encoded form
-                                    of a standard kubernetes label selector for the
-                                    given metric When set, it is passed as an additional
-                                    parameter to the metrics server for more specific
-                                    metrics scoping. When unset, just the metricName
-                                    will be used to gather metrics.
+                                  description: |-
+                                    selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                    When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                    When unset, just the metricName will be used to gather metrics.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
                                         selector requirements. The requirements are
                                         ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
                                             description: key is the label key that
                                               the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
                                               merge patch.
                                             items:
                                               type: string
@@ -184,12 +182,10 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -201,21 +197,20 @@ spec:
                                 given metric
                               properties:
                                 averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a percentage of
                                     the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
+                                    Currently only valid for Resource metric source type
                                   format: int32
                                   type: integer
                                 averageValue:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 type:
@@ -238,9 +233,9 @@ spec:
                           - target
                           type: object
                         object:
-                          description: object refers to a metric describing a single
-                            kubernetes object (for example, hits-per-second on an
-                            Ingress object).
+                          description: |-
+                            object refers to a metric describing a single kubernetes object
+                            (for example, hits-per-second on an Ingress object).
                           properties:
                             describedObject:
                               description: describedObject specifies the descriptions
@@ -270,40 +265,34 @@ spec:
                                   description: name is the name of the given metric
                                   type: string
                                 selector:
-                                  description: selector is the string-encoded form
-                                    of a standard kubernetes label selector for the
-                                    given metric When set, it is passed as an additional
-                                    parameter to the metrics server for more specific
-                                    metrics scoping. When unset, just the metricName
-                                    will be used to gather metrics.
+                                  description: |-
+                                    selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                    When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                    When unset, just the metricName will be used to gather metrics.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
                                         selector requirements. The requirements are
                                         ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
                                             description: key is the label key that
                                               the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
                                               merge patch.
                                             items:
                                               type: string
@@ -316,12 +305,10 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -333,21 +320,20 @@ spec:
                                 given metric
                               properties:
                                 averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a percentage of
                                     the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
+                                    Currently only valid for Resource metric source type
                                   format: int32
                                   type: integer
                                 averageValue:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 type:
@@ -371,10 +357,10 @@ spec:
                           - target
                           type: object
                         pods:
-                          description: pods refers to a metric describing each pod
-                            in the current scale target (for example, transactions-processed-per-second).  The
-                            values will be averaged together before being compared
-                            to the target value.
+                          description: |-
+                            pods refers to a metric describing each pod in the current scale target
+                            (for example, transactions-processed-per-second).  The values will be
+                            averaged together before being compared to the target value.
                           properties:
                             metric:
                               description: metric identifies the target metric by
@@ -384,40 +370,34 @@ spec:
                                   description: name is the name of the given metric
                                   type: string
                                 selector:
-                                  description: selector is the string-encoded form
-                                    of a standard kubernetes label selector for the
-                                    given metric When set, it is passed as an additional
-                                    parameter to the metrics server for more specific
-                                    metrics scoping. When unset, just the metricName
-                                    will be used to gather metrics.
+                                  description: |-
+                                    selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                    When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                    When unset, just the metricName will be used to gather metrics.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
                                         selector requirements. The requirements are
                                         ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
                                             description: key is the label key that
                                               the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
                                               merge patch.
                                             items:
                                               type: string
@@ -430,12 +410,10 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -447,21 +425,20 @@ spec:
                                 given metric
                               properties:
                                 averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a percentage of
                                     the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
+                                    Currently only valid for Resource metric source type
                                   format: int32
                                   type: integer
                                 averageValue:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 type:
@@ -484,11 +461,11 @@ spec:
                           - target
                           type: object
                         resource:
-                          description: resource refers to a resource metric (such
-                            as those specified in requests and limits) known to Kubernetes
-                            describing each pod in the current scale target (e.g.
-                            CPU or memory). Such metrics are built in to Kubernetes,
-                            and have special scaling options on top of those available
+                          description: |-
+                            resource refers to a resource metric (such as those specified in
+                            requests and limits) known to Kubernetes describing each pod in the
+                            current scale target (e.g. CPU or memory). Such metrics are built in to
+                            Kubernetes, and have special scaling options on top of those available
                             to normal per-pod metrics using the "pods" source.
                           properties:
                             name:
@@ -499,21 +476,20 @@ spec:
                                 given metric
                               properties:
                                 averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a percentage of
                                     the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
+                                    Currently only valid for Resource metric source type
                                   format: int32
                                   type: integer
                                 averageValue:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 type:
@@ -536,26 +512,27 @@ spec:
                           - target
                           type: object
                         type:
-                          description: 'type is the type of metric source.  It should
-                            be one of "ContainerResource", "External", "Object", "Pods"
-                            or "Resource", each mapping to a matching field in the
-                            object. Note: "ContainerResource" type is available on
-                            when the feature-gate HPAContainerMetrics is enabled'
+                          description: |-
+                            type is the type of metric source.  It should be one of "ContainerResource", "External",
+                            "Object", "Pods" or "Resource", each mapping to a matching field in the object.
+                            Note: "ContainerResource" type is available on when the feature-gate
+                            HPAContainerMetrics is enabled
                           type: string
                       required:
                       - type
                       type: object
                     type: array
                   minReplicas:
-                    description: minReplicas is the lower limit for the number of
-                      replicas to which the training job can scale down.  It defaults
-                      to null.
+                    description: |-
+                      minReplicas is the lower limit for the number of replicas to which the training job
+                      can scale down.  It defaults to null.
                     format: int32
                     type: integer
                   nProcPerNode:
-                    description: 'Number of workers per node; supported values: [auto,
-                      cpu, gpu, int]. Deprecated: This API is deprecated in v1.7+
-                      Use .spec.nprocPerNode instead.'
+                    description: |-
+                      Number of workers per node; supported values: [auto, cpu, gpu, int].
+                      Deprecated: This API is deprecated in v1.7+
+                      Use .spec.nprocPerNode instead.
                     format: int32
                     type: integer
                   rdzvBackend:
@@ -579,38 +556,45 @@ spec:
                     format: int32
                     type: integer
                   standalone:
-                    description: Start a local standalone rendezvous backend that
-                      is represented by a C10d TCP store on port 29400. Useful when
-                      launching single-node, multi-worker job. If specified --rdzv_backend,
-                      --rdzv_endpoint, --rdzv_id are auto-assigned; any explicitly
-                      set values are ignored.
+                    description: |-
+                      Start a local standalone rendezvous backend that is represented by a C10d TCP store
+                      on port 29400. Useful when launching single-node, multi-worker job. If specified
+                      --rdzv_backend, --rdzv_endpoint, --rdzv_id are auto-assigned; any explicitly set values
+                      are ignored.
                     type: boolean
                 type: object
               nprocPerNode:
-                description: 'Number of workers per node; supported values: [auto,
-                  cpu, gpu, int]. For more, https://github.com/pytorch/pytorch/blob/26f7f470df64d90e092081e39507e4ac751f55d6/torch/distributed/run.py#L629-L658.
-                  Defaults to auto.'
+                description: |-
+                  Number of workers per node; supported values: [auto, cpu, gpu, int].
+                  For more, https://github.com/pytorch/pytorch/blob/26f7f470df64d90e092081e39507e4ac751f55d6/torch/distributed/run.py#L629-L658.
+                  Defaults to auto.
                 type: string
               pytorchReplicaSpecs:
                 additionalProperties:
                   description: ReplicaSpec is a description of the replica
                   properties:
                     replicas:
-                      description: Replicas is the desired number of replicas of the
-                        given template. If unspecified, defaults to 1.
+                      description: |-
+                        Replicas is the desired number of replicas of the given template.
+                        If unspecified, defaults to 1.
                       format: int32
                       type: integer
                     restartPolicy:
-                      description: Restart policy for all replicas within the job.
-                        One of Always, OnFailure, Never and ExitCode. Default to Never.
+                      description: |-
+                        Restart policy for all replicas within the job.
+                        One of Always, OnFailure, Never and ExitCode.
+                        Default to Never.
                       type: string
                     template:
-                      description: Template is the object that describes the pod that
+                      description: |-
+                        Template is the object that describes the pod that
                         will be created for this replica. RestartPolicy in PodTemplateSpec
                         will be overide by RestartPolicy in ReplicaSpec
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          description: |-
+                            Standard object's metadata.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                           properties:
                             annotations:
                               additionalProperties:
@@ -630,15 +614,15 @@ spec:
                               type: string
                           type: object
                         spec:
-                          description: 'Specification of the desired behavior of the
-                            pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                          description: |-
+                            Specification of the desired behavior of the pod.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                           properties:
                             activeDeadlineSeconds:
-                              description: Optional duration in seconds the pod may
-                                be active on the node relative to StartTime before
-                                the system will actively try to mark it failed and
-                                kill associated containers. Value must be a positive
-                                integer.
+                              description: |-
+                                Optional duration in seconds the pod may be active on the node relative to
+                                StartTime before the system will actively try to mark it failed and kill associated containers.
+                                Value must be a positive integer.
                               format: int64
                               type: integer
                             affinity:
@@ -649,21 +633,17 @@ spec:
                                     rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.
                                       items:
-                                        description: An empty preferred scheduling
-                                          term matches all objects with implicit weight
-                                          0 (i.e. it's a no-op). A null preferred
-                                          scheduling term matches no objects (i.e.
-                                          is also a no-op).
+                                        description: |-
+                                          An empty preferred scheduling term matches all objects with implicit weight 0
+                                          (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                         properties:
                                           preference:
                                             description: A node selector term, associated
@@ -673,35 +653,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -714,35 +685,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -765,57 +727,46 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified
-                                        by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to an update), the
-                                        system may or may not try to eventually evict
-                                        the pod from its node.
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to an update), the system
+                                        may or may not try to eventually evict the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
                                             terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector
-                                              term matches no objects. The requirements
-                                              of them are ANDed. The TopologySelectorTerm
-                                              type implements a subset of the NodeSelectorTerm.
+                                            description: |-
+                                              A null or empty node selector term matches no objects. The requirements of
+                                              them are ANDed.
+                                              The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
                                                 description: A list of node selector
                                                   requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -828,35 +779,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -879,15 +821,13 @@ spec:
                                     etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -908,11 +848,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -920,23 +858,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -948,29 +879,20 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaceSelector:
-                                                description: A label query over the
-                                                  set of namespaces that the term
-                                                  applies to. The term is applied
-                                                  to the union of the namespaces selected
-                                                  by this field and the ones listed
-                                                  in the namespaces field. null selector
-                                                  and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -978,11 +900,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -990,23 +910,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -1018,50 +931,37 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaces:
-                                                description: namespaces specifies
-                                                  a static list of namespace names
-                                                  that the term applies to. The term
-                                                  is applied to the union of the namespaces
-                                                  listed in this field and the ones
-                                                  selected by namespaceSelector. null
-                                                  or empty namespaces list and null
-                                                  namespaceSelector means "this pod's
-                                                  namespace".
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching
-                                              the corresponding podAffinityTerm, in
-                                              the range 1-100.
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -1070,24 +970,20 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified
-                                        by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to a pod label update),
-                                        the system may or may not try to eventually
-                                        evict the pod from its node.
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
                                       items:
-                                        description: Defines a set of pods (namely
-                                          those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -1098,10 +994,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -1109,21 +1004,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -1136,25 +1025,19 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
@@ -1162,10 +1045,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -1173,21 +1055,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -1200,39 +1076,29 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace".
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1245,13 +1111,11 @@ spec:
                                     node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the anti-affinity
-                                        expressions specified by this field, but it
-                                        may choose a node that violates one or more
-                                        of the expressions. The node that is most
-                                        preferred is the one with the greatest sum
-                                        of weights, i.e.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the anti-affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -1272,11 +1136,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -1284,23 +1146,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -1312,29 +1167,20 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaceSelector:
-                                                description: A label query over the
-                                                  set of namespaces that the term
-                                                  applies to. The term is applied
-                                                  to the union of the namespaces selected
-                                                  by this field and the ones listed
-                                                  in the namespaces field. null selector
-                                                  and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -1342,11 +1188,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -1354,23 +1198,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -1382,50 +1219,37 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaces:
-                                                description: namespaces specifies
-                                                  a static list of namespace names
-                                                  that the term applies to. The term
-                                                  is applied to the union of the namespaces
-                                                  listed in this field and the ones
-                                                  selected by namespaceSelector. null
-                                                  or empty namespaces list and null
-                                                  namespaceSelector means "this pod's
-                                                  namespace".
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching
-                                              the corresponding podAffinityTerm, in
-                                              the range 1-100.
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -1434,24 +1258,20 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements
-                                        specified by this field are not met at scheduling
-                                        time, the pod will not be scheduled onto the
-                                        node. If the anti-affinity requirements specified
-                                        by this field cease to be met at some point
-                                        during pod execution (e.g. due to a pod label
-                                        update), the system may or may not try to
-                                        eventually evict the pod from its node.
+                                      description: |-
+                                        If the anti-affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the anti-affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
                                       items:
-                                        description: Defines a set of pods (namely
-                                          those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -1462,10 +1282,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -1473,21 +1292,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -1500,25 +1313,19 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
@@ -1526,10 +1333,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -1537,21 +1343,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -1564,39 +1364,29 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace".
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1610,41 +1400,39 @@ spec:
                                 mounted.
                               type: boolean
                             containers:
-                              description: List of containers belonging to the pod.
-                                Containers cannot currently be added or removed. There
-                                must be at least one container in a Pod. Cannot be
-                                updated.
+                              description: |-
+                                List of containers belonging to the pod.
+                                Containers cannot currently be added or removed.
+                                There must be at least one container in a Pod.
+                                Cannot be updated.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
-                                      provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The container image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
-                                      used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The container image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -1654,16 +1442,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1677,10 +1462,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1691,11 +1476,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -1711,12 +1494,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -1750,10 +1530,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1769,15 +1549,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1786,10 +1564,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -1806,10 +1584,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -1820,48 +1598,43 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images
-                                      This field is optional to allow higher level
-                                      config management to default or override container
-                                      images in workload controllers like Deployments
-                                      and StatefulSets.'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system
-                                      should take in response to container lifecycle
-                                      events. Cannot be updated.
+                                    description: |-
+                                      Actions that the management system should take in response to container lifecycle events.
+                                      Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1871,10 +1644,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -1886,11 +1658,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -1909,25 +1679,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1938,41 +1707,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1982,10 +1744,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -1997,11 +1758,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -2020,25 +1779,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2049,10 +1807,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -2060,35 +1818,31 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness.
+                                    description: |-
+                                      Periodic probe of container liveness.
                                       Container will be restarted if the probe fails.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -2101,11 +1855,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -2115,9 +1870,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -2127,11 +1882,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -2149,36 +1902,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -2193,55 +1945,52 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as
-                                      a DNS_LABEL. Each container in a pod must have
-                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    description: |-
+                                      Name of the container specified as a DNS_LABEL.
+                                      Each container in a pod must have a unique name (DNS_LABEL).
+                                      Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the
-                                      container. Not specifying a port here DOES NOT
-                                      prevent that port from being exposed. Any port
-                                      which is listening on the default "0.0.0.0"
-                                      address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
+                                    description: |-
+                                      List of ports to expose from the container. Not specifying a port here
+                                      DOES NOT prevent that port from being exposed. Any port which is
+                                      listening on the default "0.0.0.0" address inside a container will be
+                                      accessible from the network.
+                                      Modifying this array with strategic merge patch may corrupt the data.
                                       For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -2249,24 +1998,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -2277,36 +2026,31 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service
-                                      readiness. Container will be removed from service
-                                      endpoints if the probe fails. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Periodic probe of container service readiness.
+                                      Container will be removed from service endpoints if the probe fails.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -2319,11 +2063,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -2333,9 +2078,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -2345,11 +2090,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -2367,36 +2110,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -2411,30 +2153,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -2445,14 +2184,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -2461,26 +2200,31 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Compute Resources required by this container.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -2496,9 +2240,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2507,48 +2251,41 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: RestartPolicy defines the restart
-                                      behavior of individual containers in a pod.
-                                      This field may only be set for init containers,
-                                      and the only allowed value is "Always". For
-                                      non-init containers or when this field is not
-                                      specified, the restart behavior is defined by
-                                      the Pod's restart policy and the container type.
+                                    description: |-
+                                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                                      This field may only be set for init containers, and the only allowed value is "Always".
+                                      For non-init containers or when this field is not specified,
+                                      the restart behavior is defined by the Pod's restart policy and the container type.
                                     type: string
                                   securityContext:
-                                    description: 'SecurityContext defines the security
-                                      options the container should be run with. If
-                                      set, the fields of SecurityContext override
-                                      the equivalent fields of PodSecurityContext.
-                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    description: |-
+                                      SecurityContext defines the security options the container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -2566,68 +2303,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2647,52 +2375,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -2700,60 +2420,46 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: StartupProbe indicates that the Pod
-                                      has successfully initialized. If specified,
-                                      no other probes are executed until this completes
-                                      successfully. If this probe fails, the Pod will
-                                      be restarted, just as if the livenessProbe failed.
+                                    description: |-
+                                      StartupProbe indicates that the Pod has successfully initialized.
+                                      If specified, no other probes are executed until this completes successfully.
+                                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -2766,11 +2472,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -2780,9 +2487,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -2792,11 +2499,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -2814,36 +2519,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -2858,72 +2562,62 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -2947,46 +2641,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -2994,34 +2687,36 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             dnsConfig:
-                              description: Specifies the DNS parameters of a pod.
-                                Parameters specified here will be merged to the generated
-                                DNS configuration based on DNSPolicy.
+                              description: |-
+                                Specifies the DNS parameters of a pod.
+                                Parameters specified here will be merged to the generated DNS
+                                configuration based on DNSPolicy.
                               properties:
                                 nameservers:
-                                  description: A list of DNS name server IP addresses.
-                                    This will be appended to the base nameservers
-                                    generated from DNSPolicy. Duplicated nameservers
-                                    will be removed.
+                                  description: |-
+                                    A list of DNS name server IP addresses.
+                                    This will be appended to the base nameservers generated from DNSPolicy.
+                                    Duplicated nameservers will be removed.
                                   items:
                                     type: string
                                   type: array
                                 options:
-                                  description: A list of DNS resolver options. This
-                                    will be merged with the base options generated
-                                    from DNSPolicy. Duplicated entries will be removed.
-                                    Resolution options given in Options will override
-                                    those that appear in the base DNSPolicy.
+                                  description: |-
+                                    A list of DNS resolver options.
+                                    This will be merged with the base options generated from DNSPolicy.
+                                    Duplicated entries will be removed. Resolution options given in Options
+                                    will override those that appear in the base DNSPolicy.
                                   items:
                                     description: PodDNSConfigOption defines DNS resolver
                                       options of a pod.
@@ -3034,75 +2729,68 @@ spec:
                                     type: object
                                   type: array
                                 searches:
-                                  description: A list of DNS search domains for host-name
-                                    lookup. This will be appended to the base search
-                                    paths generated from DNSPolicy. Duplicated search
-                                    paths will be removed.
+                                  description: |-
+                                    A list of DNS search domains for host-name lookup.
+                                    This will be appended to the base search paths generated from DNSPolicy.
+                                    Duplicated search paths will be removed.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
-                              description: Set DNS policy for the pod. Defaults to
-                                "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
-                                'ClusterFirst', 'Default' or 'None'. DNS parameters
-                                given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy. To have DNS options set along
-                                with hostNetwork, you have to specify DNS policy explicitly
-                                to 'ClusterFirstWithHostNet'.
+                              description: |-
+                                Set DNS policy for the pod.
+                                Defaults to "ClusterFirst".
+                                Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                                DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                                To have DNS options set along with hostNetwork, you have to specify DNS policy
+                                explicitly to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
-                              description: 'EnableServiceLinks indicates whether information
-                                about services should be injected into pod''s environment
-                                variables, matching the syntax of Docker links. Optional:
-                                Defaults to true.'
+                              description: |-
+                                EnableServiceLinks indicates whether information about services should be injected into pod's
+                                environment variables, matching the syntax of Docker links.
+                                Optional: Defaults to true.
                               type: boolean
                             ephemeralContainers:
-                              description: List of ephemeral containers run in this
-                                pod. Ephemeral containers may be run in an existing
-                                pod to perform user-initiated actions such as debugging.
-                                This list cannot be specified when creating a pod,
-                                and it cannot be modified by updating the pod spec.
-                                In order to add an ephemeral container to an existing
-                                pod, use the pod's ephemeralcontainers subresource.
+                              description: |-
+                                List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                                pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                                creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                                ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
                               items:
-                                description: An EphemeralContainer is a temporary
-                                  container that you may add to an existing Pod for
-                                  user-initiated activities such as debugging. Ephemeral
-                                  containers have no resource or scheduling guarantees,
-                                  and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted. The kubelet
-                                  may evict a Pod if an ephemeral container causes
-                                  the Pod to exceed its resource allocation.
+                                description: |-
+                                  An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                                  user-initiated activities such as debugging. Ephemeral containers have no resource or
+                                  scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                                  removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                                  Pod to exceed its resource allocation.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the
-                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                      produce the string literal "$(VAR_NAME)".'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)".
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The image''s ENTRYPOINT is used if
-                                      this is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -3112,16 +2800,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -3135,10 +2820,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -3149,11 +2834,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -3169,12 +2852,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -3208,10 +2888,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -3227,15 +2907,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -3244,10 +2922,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -3264,10 +2942,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -3278,43 +2956,40 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
                                     description: Lifecycle is not allowed for ephemeral
                                       containers.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3324,10 +2999,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -3339,11 +3013,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -3362,25 +3034,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -3391,41 +3062,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3435,10 +3099,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -3450,11 +3113,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -3473,25 +3134,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -3502,10 +3162,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -3521,26 +3181,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -3553,11 +3207,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -3567,9 +3222,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -3579,11 +3234,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3601,36 +3254,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -3645,38 +3297,34 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the ephemeral container specified
-                                      as a DNS_LABEL. This name must be unique among
-                                      all containers, init containers and ephemeral
-                                      containers.
+                                    description: |-
+                                      Name of the ephemeral container specified as a DNS_LABEL.
+                                      This name must be unique among all containers, init containers and ephemeral containers.
                                     type: string
                                   ports:
                                     description: Ports are not allowed for ephemeral
@@ -3686,9 +3334,9 @@ spec:
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -3696,24 +3344,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -3732,26 +3380,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -3764,11 +3406,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -3778,9 +3421,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -3790,11 +3433,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3812,36 +3453,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -3856,30 +3496,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -3890,14 +3527,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -3906,27 +3543,30 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: Resources are not allowed for ephemeral
-                                      containers. Ephemeral containers use spare resources
+                                    description: |-
+                                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
                                       already allocated to the pod.
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -3942,9 +3582,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -3953,45 +3593,40 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: Restart policy for the container
-                                      to manage the restart behavior of each container
-                                      within a pod. This may only be set for init
-                                      containers. You cannot set this field on ephemeral
-                                      containers.
+                                    description: |-
+                                      Restart policy for the container to manage the restart behavior of each
+                                      container within a pod.
+                                      This may only be set for init containers. You cannot set this field on
+                                      ephemeral containers.
                                     type: string
                                   securityContext:
-                                    description: 'Optional: SecurityContext defines
-                                      the security options the ephemeral container
-                                      should be run with. If set, the fields of SecurityContext
-                                      override the equivalent fields of PodSecurityContext.'
+                                    description: |-
+                                      Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -4009,68 +3644,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -4090,52 +3716,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -4143,25 +3761,18 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
@@ -4174,26 +3785,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -4206,11 +3811,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -4220,9 +3826,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -4232,11 +3838,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -4254,36 +3858,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -4298,81 +3901,71 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: "If set, the name of the container
-                                      from PodSpec that this ephemeral container targets.
-                                      The ephemeral container will be run in the namespaces
-                                      (IPC, PID, etc) of this container. If not set
-                                      then the ephemeral container uses the namespaces
-                                      configured in the Pod spec. \n The container
-                                      runtime must implement support for this feature."
+                                    description: |-
+                                      If set, the name of the container from PodSpec that this ephemeral container targets.
+                                      The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                      If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+
+                                      The container runtime must implement support for this feature.
                                     type: string
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -4396,47 +3989,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Subpath mounts are not allowed for
-                                      ephemeral containers. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -4444,24 +4035,24 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             hostAliases:
-                              description: HostAliases is an optional list of hosts
-                                and IPs that will be injected into the pod's hosts
-                                file if specified. This is only valid for non-hostNetwork
-                                pods.
+                              description: |-
+                                HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                file if specified. This is only valid for non-hostNetwork pods.
                               items:
-                                description: HostAlias holds the mapping between IP
-                                  and hostnames that will be injected as an entry
-                                  in the pod's hosts file.
+                                description: |-
+                                  HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                  pod's hosts file.
                                 properties:
                                   hostnames:
                                     description: Hostnames for the above IP address.
@@ -4474,93 +4065,89 @@ spec:
                                 type: object
                               type: array
                             hostIPC:
-                              description: 'Use the host''s ipc namespace. Optional:
-                                Default to false.'
+                              description: |-
+                                Use the host's ipc namespace.
+                                Optional: Default to false.
                               type: boolean
                             hostNetwork:
-                              description: Host networking requested for this pod.
-                                Use the host's network namespace. If this option is
-                                set, the ports that will be used must be specified.
+                              description: |-
+                                Host networking requested for this pod. Use the host's network namespace.
+                                If this option is set, the ports that will be used must be specified.
                                 Default to false.
                               type: boolean
                             hostPID:
-                              description: 'Use the host''s pid namespace. Optional:
-                                Default to false.'
+                              description: |-
+                                Use the host's pid namespace.
+                                Optional: Default to false.
                               type: boolean
                             hostUsers:
-                              description: 'Use the host''s user namespace. Optional:
-                                Default to true. If set to true or not present, the
-                                pod will be run in the host user namespace, useful
-                                for when the pod needs a feature only available to
-                                the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE. When set to false, a new
-                                userns is created for the pod.'
+                              description: |-
+                                Use the host's user namespace.
+                                Optional: Default to true.
+                                If set to true or not present, the pod will be run in the host user namespace, useful
+                                for when the pod needs a feature only available to the host user namespace, such as
+                                loading a kernel module with CAP_SYS_MODULE.
+                                When set to false, a new userns is created for the pod.
                               type: boolean
                             hostname:
-                              description: Specifies the hostname of the Pod If not
-                                specified, the pod's hostname will be set to a system-defined
-                                value.
+                              description: |-
+                                Specifies the hostname of the Pod
+                                If not specified, the pod's hostname will be set to a system-defined value.
                               type: string
                             imagePullSecrets:
-                              description: 'ImagePullSecrets is an optional list of
-                                references to secrets in the same namespace to use
-                                for pulling any of the images used by this PodSpec.
-                                If specified, these secrets will be passed to individual
-                                puller implementations for them to use. More info:
-                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                              description: |-
+                                ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                If specified, these secrets will be passed to individual puller implementations for them to use.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                               items:
-                                description: LocalObjectReference contains enough
-                                  information to let you locate the referenced object
-                                  inside the same namespace.
+                                description: |-
+                                  LocalObjectReference contains enough information to let you locate the
+                                  referenced object inside the same namespace.
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               type: array
                             initContainers:
-                              description: List of initialization containers belonging
-                                to the pod. Init containers are executed in order
-                                prior to containers being started. If any init container
-                                fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy. The name for
-                                an init container or normal container must be unique
-                                among all containers.
+                              description: |-
+                                List of initialization containers belonging to the pod.
+                                Init containers are executed in order prior to containers being started. If any
+                                init container fails, the pod is considered to have failed and is handled according
+                                to its restartPolicy. The name for an init container or normal container must be
+                                unique among all containers.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
-                                      provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The container image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
-                                      used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The container image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -4570,16 +4157,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -4593,10 +4177,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -4607,11 +4191,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -4627,12 +4209,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -4666,10 +4245,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -4685,15 +4264,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -4702,10 +4279,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -4722,10 +4299,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -4736,48 +4313,43 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images
-                                      This field is optional to allow higher level
-                                      config management to default or override container
-                                      images in workload controllers like Deployments
-                                      and StatefulSets.'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system
-                                      should take in response to container lifecycle
-                                      events. Cannot be updated.
+                                    description: |-
+                                      Actions that the management system should take in response to container lifecycle events.
+                                      Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4787,10 +4359,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -4802,11 +4373,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -4825,25 +4394,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -4854,41 +4422,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4898,10 +4459,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -4913,11 +4473,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -4936,25 +4494,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -4965,10 +4522,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -4976,35 +4533,31 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness.
+                                    description: |-
+                                      Periodic probe of container liveness.
                                       Container will be restarted if the probe fails.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -5017,11 +4570,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -5031,9 +4585,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -5043,11 +4597,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -5065,36 +4617,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -5109,55 +4660,52 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as
-                                      a DNS_LABEL. Each container in a pod must have
-                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    description: |-
+                                      Name of the container specified as a DNS_LABEL.
+                                      Each container in a pod must have a unique name (DNS_LABEL).
+                                      Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the
-                                      container. Not specifying a port here DOES NOT
-                                      prevent that port from being exposed. Any port
-                                      which is listening on the default "0.0.0.0"
-                                      address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
+                                    description: |-
+                                      List of ports to expose from the container. Not specifying a port here
+                                      DOES NOT prevent that port from being exposed. Any port which is
+                                      listening on the default "0.0.0.0" address inside a container will be
+                                      accessible from the network.
+                                      Modifying this array with strategic merge patch may corrupt the data.
                                       For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -5165,24 +4713,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -5193,36 +4741,31 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service
-                                      readiness. Container will be removed from service
-                                      endpoints if the probe fails. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Periodic probe of container service readiness.
+                                      Container will be removed from service endpoints if the probe fails.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -5235,11 +4778,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -5249,9 +4793,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -5261,11 +4805,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -5283,36 +4825,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -5327,30 +4868,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -5361,14 +4899,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -5377,26 +4915,31 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Compute Resources required by this container.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -5412,9 +4955,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -5423,48 +4966,41 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: RestartPolicy defines the restart
-                                      behavior of individual containers in a pod.
-                                      This field may only be set for init containers,
-                                      and the only allowed value is "Always". For
-                                      non-init containers or when this field is not
-                                      specified, the restart behavior is defined by
-                                      the Pod's restart policy and the container type.
+                                    description: |-
+                                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                                      This field may only be set for init containers, and the only allowed value is "Always".
+                                      For non-init containers or when this field is not specified,
+                                      the restart behavior is defined by the Pod's restart policy and the container type.
                                     type: string
                                   securityContext:
-                                    description: 'SecurityContext defines the security
-                                      options the container should be run with. If
-                                      set, the fields of SecurityContext override
-                                      the equivalent fields of PodSecurityContext.
-                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    description: |-
+                                      SecurityContext defines the security options the container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -5482,68 +5018,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -5563,52 +5090,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -5616,60 +5135,46 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: StartupProbe indicates that the Pod
-                                      has successfully initialized. If specified,
-                                      no other probes are executed until this completes
-                                      successfully. If this probe fails, the Pod will
-                                      be restarted, just as if the livenessProbe failed.
+                                    description: |-
+                                      StartupProbe indicates that the Pod has successfully initialized.
+                                      If specified, no other probes are executed until this completes successfully.
+                                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -5682,11 +5187,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -5696,9 +5202,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -5708,11 +5214,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -5730,36 +5234,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -5774,72 +5277,62 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -5863,46 +5356,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -5910,47 +5402,54 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             nodeName:
-                              description: NodeName is a request to schedule this
-                                pod onto a specific node. If it is non-empty, the
-                                scheduler simply schedules this pod onto that node,
-                                assuming that it fits resource requirements.
+                              description: |-
+                                NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
+                                the scheduler simply schedules this pod onto that node, assuming that it fits resource
+                                requirements.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: 'NodeSelector is a selector which must
-                                be true for the pod to fit on a node. Selector which
-                                must match a node''s labels for the pod to be scheduled
-                                on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                              description: |-
+                                NodeSelector is a selector which must be true for the pod to fit on a node.
+                                Selector which must match a node's labels for the pod to be scheduled on that node.
+                                More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                               type: object
                               x-kubernetes-map-type: atomic
                             os:
-                              description: "Specifies the OS of the containers in
-                                the pod. Some pod and container fields are restricted
-                                if this is set. \n If the OS field is set to linux,
-                                the following fields must be unset: -securityContext.windowsOptions
-                                \n If the OS field is set to windows, following fields
-                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
-                                - spec.securityContext.seLinuxOptions - spec.securityContext."
+                              description: |-
+                                Specifies the OS of the containers in the pod.
+                                Some pod and container fields are restricted if this is set.
+
+
+                                If the OS field is set to linux, the following fields must be unset:
+                                -securityContext.windowsOptions
+
+
+                                If the OS field is set to windows, following fields must be unset:
+                                - spec.hostPID
+                                - spec.hostIPC
+                                - spec.hostUsers
+                                - spec.securityContext.seLinuxOptions
+                                - spec.securityContext.
                               properties:
                                 name:
-                                  description: 'Name is the name of the operating
-                                    system. The currently supported values are linux
-                                    and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                    Clients should expect to handle additional values
-                                    and treat unrecognized values in this field as
-                                    os: null'
+                                  description: |-
+                                    Name is the name of the operating system. The currently supported values are linux and windows.
+                                    Additional value may be defined in future and can be one of:
+                                    https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values and treat unrecognized values in this field as os: null
                                   type: string
                               required:
                               - name
@@ -5962,44 +5461,43 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: Overhead represents the resource overhead
-                                associated with running a pod for a given RuntimeClass.
-                                This field will be autopopulated at admission time
-                                by the RuntimeClass admission controller. If the RuntimeClass
-                                admission controller is enabled, overhead must not
-                                be set in Pod create requests. The RuntimeClass admission
-                                controller will reject Pod create requests which have
-                                the overhead already set.
+                              description: |-
+                                Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                                This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                                the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                                The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                                set.
                               type: object
                             preemptionPolicy:
-                              description: PreemptionPolicy is the Policy for preempting
-                                pods with lower priority. One of Never, PreemptLowerPriority.
+                              description: |-
+                                PreemptionPolicy is the Policy for preempting pods with lower priority.
+                                One of Never, PreemptLowerPriority.
                                 Defaults to PreemptLowerPriority if unset.
                               type: string
                             priority:
-                              description: The priority value. Various system components
-                                use this field to find the priority of the pod. When
-                                Priority Admission Controller is enabled, it prevents
-                                users from setting this field. The admission controller
-                                populates this field from PriorityClassName. The higher
-                                the value, the higher the priority.
+                              description: |-
+                                The priority value. Various system components use this field to find the
+                                priority of the pod. When Priority Admission Controller is enabled, it
+                                prevents users from setting this field. The admission controller populates
+                                this field from PriorityClassName.
+                                The higher the value, the higher the priority.
                               format: int32
                               type: integer
                             priorityClassName:
-                              description: If specified, indicates the pod's priority.
-                                "system-node-critical" and "system-cluster-critical"
-                                are two special keywords which indicate the highest
-                                priorities with the former being the highest priority.
-                                Any other name must be defined by creating a PriorityClass
-                                object with that name. If not specified, the pod priority
-                                will be default or zero if there is no default.
+                              description: |-
+                                If specified, indicates the pod's priority. "system-node-critical" and
+                                "system-cluster-critical" are two special keywords which indicate the
+                                highest priorities with the former being the highest priority. Any other
+                                name must be defined by creating a PriorityClass object with that name.
+                                If not specified, the pod priority will be default or zero if there is no
+                                default.
                               type: string
                             readinessGates:
-                              description: 'If specified, all readiness gates will
-                                be evaluated for pod readiness. A pod is ready when
-                                all its containers are ready AND all conditions specified
-                                in the readiness gates have status equal to "True"
-                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                              description: |-
+                                If specified, all readiness gates will be evaluated for pod readiness.
+                                A pod is ready when all its containers are ready AND
+                                all conditions specified in the readiness gates have status equal to "True"
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
                               items:
                                 description: PodReadinessGate contains the reference
                                   to a pod condition
@@ -6013,40 +5511,47 @@ spec:
                                 type: object
                               type: array
                             resourceClaims:
-                              description: "ResourceClaims defines which ResourceClaims
-                                must be allocated and reserved before the Pod is allowed
-                                to start. The resources will be made available to
-                                those containers which consume them by name. \n This
-                                is an alpha field and requires enabling the DynamicResourceAllocation
-                                feature gate. \n This field is immutable."
+                              description: |-
+                                ResourceClaims defines which ResourceClaims must be allocated
+                                and reserved before the Pod is allowed to start. The resources
+                                will be made available to those containers which consume them
+                                by name.
+
+
+                                This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate.
+
+
+                                This field is immutable.
                               items:
-                                description: PodResourceClaim references exactly one
-                                  ResourceClaim through a ClaimSource. It adds a name
-                                  to it that uniquely identifies the ResourceClaim
-                                  inside the Pod. Containers that need access to the
-                                  ResourceClaim reference it with this name.
+                                description: |-
+                                  PodResourceClaim references exactly one ResourceClaim through a ClaimSource.
+                                  It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                                  Containers that need access to the ResourceClaim reference it with this name.
                                 properties:
                                   name:
-                                    description: Name uniquely identifies this resource
-                                      claim inside the pod. This must be a DNS_LABEL.
+                                    description: |-
+                                      Name uniquely identifies this resource claim inside the pod.
+                                      This must be a DNS_LABEL.
                                     type: string
                                   source:
                                     description: Source describes where to find the
                                       ResourceClaim.
                                     properties:
                                       resourceClaimName:
-                                        description: ResourceClaimName is the name
-                                          of a ResourceClaim object in the same namespace
-                                          as this pod.
+                                        description: |-
+                                          ResourceClaimName is the name of a ResourceClaim object in the same
+                                          namespace as this pod.
                                         type: string
                                       resourceClaimTemplateName:
-                                        description: "ResourceClaimTemplateName is
-                                          the name of a ResourceClaimTemplate object
-                                          in the same namespace as this pod. \n The
-                                          template will be used to create a new ResourceClaim,
-                                          which will be bound to this pod. When this
-                                          pod is deleted, the ResourceClaim will also
-                                          be deleted."
+                                        description: |-
+                                          ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                          object in the same namespace as this pod.
+
+
+                                          The template will be used to create a new ResourceClaim, which will
+                                          be bound to this pod. When this pod is deleted, the ResourceClaim
+                                          will also be deleted.
                                         type: string
                                     type: object
                                 required:
@@ -6057,42 +5562,44 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             restartPolicy:
-                              description: 'Restart policy for all containers within
-                                the pod. One of Always, OnFailure, Never. In some
-                                contexts, only a subset of those values may be permitted.
-                                Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                              description: |-
+                                Restart policy for all containers within the pod.
+                                One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                                Default to Always.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass
-                                object in the node.k8s.io group, which should be used
-                                to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run. If unset
-                                or empty, the "legacy" RuntimeClass will be used,
-                                which is an implicit class with an empty definition
-                                that uses the default runtime handler. More info:
-                                https://git.k8s.'
+                              description: |-
+                                RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                                to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                                If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                                empty definition that uses the default runtime handler.
+                                More info: https://git.k8s.
                               type: string
                             schedulerName:
-                              description: If specified, the pod will be dispatched
-                                by specified scheduler. If not specified, the pod
-                                will be dispatched by default scheduler.
+                              description: |-
+                                If specified, the pod will be dispatched by specified scheduler.
+                                If not specified, the pod will be dispatched by default scheduler.
                               type: string
                             schedulingGates:
-                              description: "SchedulingGates is an opaque list of values
-                                that if specified will block scheduling the pod. If
-                                schedulingGates is not empty, the pod will stay in
-                                the SchedulingGated state and the scheduler will not
-                                attempt to schedule the pod. \n SchedulingGates can
-                                only be set at pod creation time, and be removed only
-                                afterwards. \n This is a beta feature enabled by the
-                                PodSchedulingReadiness feature gate."
+                              description: |-
+                                SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                                If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                                scheduler will not attempt to schedule the pod.
+
+
+                                SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+
+
+                                This is a beta feature enabled by the PodSchedulingReadiness feature gate.
                               items:
                                 description: PodSchedulingGate is associated to a
                                   Pod to guard its scheduling.
                                 properties:
                                   name:
-                                    description: Name of the scheduling gate. Each
-                                      scheduling gate must have a unique name field.
+                                    description: |-
+                                      Name of the scheduling gate.
+                                      Each scheduling gate must have a unique name field.
                                     type: string
                                 required:
                                 - name
@@ -6102,70 +5609,67 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             securityContext:
-                              description: 'SecurityContext holds pod-level security
-                                attributes and common container settings. Optional:
-                                Defaults to empty.  See type description for default
-                                values of each field.'
+                              description: |-
+                                SecurityContext holds pod-level security attributes and common container settings.
+                                Optional: Defaults to empty.  See type description for default values of each field.
                               properties:
                                 fsGroup:
-                                  description: "A special supplemental group that
-                                    applies to all containers in a pod. Some volume
-                                    types allow the Kubelet to change the ownership
-                                    of that volume to be owned by the pod: \n 1. The
-                                    owning GID will be the FSGroup 2. The setgid bit
-                                    is set (new files created in the volume will be
-                                    owned by FSGroup) 3."
+                                  description: |-
+                                    A special supplemental group that applies to all containers in a pod.
+                                    Some volume types allow the Kubelet to change the ownership of that volume
+                                    to be owned by the pod:
+
+
+                                    1. The owning GID will be the FSGroup
+                                    2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                    3.
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior
-                                    of changing ownership and permission of the volume
-                                    before being exposed inside Pod. This field will
-                                    only apply to volume types which support fsGroup
-                                    based ownership(and permissions). It will have
-                                    no effect on ephemeral volume types such as: secret,
-                                    configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified, "Always" is used.'
+                                  description: |-
+                                    fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                    before being exposed inside Pod. This field will only apply to
+                                    volume types which support fsGroup based ownership(and permissions).
+                                    It will have no effect on ephemeral volume types such as: secret, configmaps
+                                    and emptydir.
+                                    Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
                                   type: string
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in SecurityContext.  If set in
-                                    both SecurityContext and PodSecurityContext, the
-                                    value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in SecurityContext.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in SecurityContext.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence for that container.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    all containers. If unspecified, the container
-                                    runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                  description: |-
+                                    The SELinux context to be applied to all containers.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in SecurityContext.  If set in
+                                    both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                    takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -6185,49 +5689,45 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by the containers
-                                    in this pod. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by the containers in this pod.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must be set if type is "Localhost".
-                                        Must NOT be set for any other type.
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first
-                                    process run in each container, in addition to
-                                    the container's primary GID, the fsGroup (if specified),
-                                    and group memberships defined in the container
-                                    image for the uid of the container process. If
-                                    unspecified, no additional groups are added to
-                                    any container.
+                                  description: |-
+                                    A list of groups applied to the first process run in each container, in addition
+                                    to the container's primary GID, the fsGroup (if specified), and group memberships
+                                    defined in the container image for the uid of the container process. If unspecified,
+                                    no additional groups are added to any container.
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls
-                                    used for the pod. Pods with unsupported sysctls
-                                    (by the container runtime) might fail to launch.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                    sysctls (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   items:
                                     description: Sysctl defines a kernel parameter
                                       to be set
@@ -6244,173 +5744,151 @@ spec:
                                     type: object
                                   type: array
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    within a container's SecurityContext will be used.
-                                    If set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options within a container's SecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        All of a Pod's containers must have the same
-                                        effective HostProcess value (it is not allowed
-                                        to have a mix of HostProcess containers and
-                                        non-HostProcess containers). In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: 'DeprecatedServiceAccount is a depreciated
-                                alias for ServiceAccountName. Deprecated: Use serviceAccountName
-                                instead.'
+                              description: |-
+                                DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+                                Deprecated: Use serviceAccountName instead.
                               type: string
                             serviceAccountName:
-                              description: 'ServiceAccountName is the name of the
-                                ServiceAccount to use to run this pod. More info:
-                                https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                              description: |-
+                                ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                               type: string
                             setHostnameAsFQDN:
-                              description: If true the pod's hostname will be configured
-                                as the pod's FQDN, rather than the leaf name (the
-                                default). In Linux containers, this means setting
-                                the FQDN in the hostname field of the kernel (the
-                                nodename field of struct utsname).
+                              description: |-
+                                If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                                In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between
-                                all of the containers in a pod. When this is set containers
-                                will be able to view and signal processes from other
-                                containers in the same pod, and the first process
-                                in each container will not be assigned PID 1. HostPID
-                                and ShareProcessNamespace cannot both be set. Optional:
-                                Default to false.'
+                              description: |-
+                                Share a single process namespace between all of the containers in a pod.
+                                When this is set containers will be able to view and signal processes from other containers
+                                in the same pod, and the first process in each container will not be assigned PID 1.
+                                HostPID and ShareProcessNamespace cannot both be set.
+                                Optional: Default to false.
                               type: boolean
                             subdomain:
-                              description: If specified, the fully qualified Pod hostname
-                                will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                                domain>". If not specified, the pod will not have
-                                a domainname at all.
+                              description: |-
+                                If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                                If not specified, the pod will not have a domainname at all.
                               type: string
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs
-                                to terminate gracefully. May be decreased in delete
-                                request. Value must be non-negative integer. The value
-                                zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down). If this value is nil,
-                                the default grace period will be used instead.
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                If this value is nil, the default grace period will be used instead.
                               format: int64
                               type: integer
                             tolerations:
                               description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to
-                                  tolerates any taint that matches the triple <key,value,effect>
-                                  using the matching operator <operator>.
+                                description: |-
+                                  The pod this Toleration is attached to tolerates any taint that matches
+                                  the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect
-                                      to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule,
-                                      PreferNoSchedule and NoExecute.
+                                    description: |-
+                                      Effect indicates the taint effect to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration
-                                      applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists;
-                                      this combination means to match all values and
-                                      all keys.
+                                    description: |-
+                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship
-                                      to the value. Valid operators are Exists and
-                                      Equal. Defaults to Equal. Exists is equivalent
-                                      to wildcard for value, so that a pod can tolerate
-                                      all taints of a particular category.
+                                    description: |-
+                                      Operator represents a key's relationship to the value.
+                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Exists is equivalent to wildcard for value, so that a pod can
+                                      tolerate all taints of a particular category.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the
-                                      period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is
-                                      ignored) tolerates the taint. By default, it
-                                      is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
+                                    description: |-
+                                      TolerationSeconds represents the period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                      negative values will be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration
-                                      matches to. If the operator is Exists, the value
-                                      should be empty, otherwise just a regular string.
+                                    description: |-
+                                      Value is the taint value the toleration matches to.
+                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how
-                                a group of pods ought to spread across topology domains.
-                                Scheduler will schedule pods in a way which abides
-                                by the constraints. All topologySpreadConstraints
-                                are ANDed.
+                              description: |-
+                                TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                                domains. Scheduler will schedule pods in a way which abides by the constraints.
+                                All topologySpreadConstraints are ANDed.
                               items:
                                 description: TopologySpreadConstraint specifies how
                                   to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: LabelSelector is used to find matching
-                                      pods. Pods that match this label selector are
-                                      counted to determine the number of pods in their
-                                      corresponding topology domain.
+                                    description: |-
+                                      LabelSelector is used to find matching pods.
+                                      Pods that match this label selector are counted to determine the number of pods
+                                      in their corresponding topology domain.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
                                           label selector requirements. The requirements
                                           are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -6423,91 +5901,79 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label
-                                      keys to select the pods over which spreading
-                                      will be calculated. The keys are used to lookup
-                                      values from the incoming pod labels, those key-value
-                                      labels are ANDed with labelSelector to select
-                                      the group of existing pods over which spreading
-                                      will be calculated for the incoming pod. The
-                                      same key is forbidden to exist in both MatchLabelKeys
-                                      and LabelSelector.
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select the pods over which
+                                      spreading will be calculated. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are ANDed with labelSelector
+                                      to select the group of existing pods over which spreading will be calculated
+                                      for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   maxSkew:
-                                    description: MaxSkew describes the degree to which
-                                      pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                                      it is the maximum permitted difference between
-                                      the number of matching pods in the target topology
-                                      and the global minimum. The global minimum is
-                                      the minimum number of matching pods in an eligible
-                                      domain or zero if the number of eligible domains
-                                      is less than MinDomains.
+                                    description: |-
+                                      MaxSkew describes the degree to which pods may be unevenly distributed.
+                                      When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                      between the number of matching pods in the target topology and the global minimum.
+                                      The global minimum is the minimum number of matching pods in an eligible domain
+                                      or zero if the number of eligible domains is less than MinDomains.
                                     format: int32
                                     type: integer
                                   minDomains:
-                                    description: MinDomains indicates a minimum number
-                                      of eligible domains. When the number of eligible
-                                      domains with matching topology keys is less
-                                      than minDomains, Pod Topology Spread treats
-                                      "global minimum" as 0, and then the calculation
-                                      of Skew is performed. And when the number of
-                                      eligible domains with matching topology keys
-                                      equals or greater than minDomains, this value
-                                      has no effect on scheduling.
+                                    description: |-
+                                      MinDomains indicates a minimum number of eligible domains.
+                                      When the number of eligible domains with matching topology keys is less than minDomains,
+                                      Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                      And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                      this value has no effect on scheduling.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: "NodeAffinityPolicy indicates how
-                                      we will treat Pod's nodeAffinity/nodeSelector
-                                      when calculating pod topology spread skew. Options
-                                      are: - Honor: only nodes matching nodeAffinity/nodeSelector
-                                      are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored. All nodes
-                                      are included in the calculations. \n If this
-                                      value is nil, the behavior is equivalent to
-                                      the Honor policy."
+                                    description: |-
+                                      NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                      when calculating pod topology spread skew. Options are:
+                                      - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                      - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                                      If this value is nil, the behavior is equivalent to the Honor policy.
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: "NodeTaintsPolicy indicates how we
-                                      will treat node taints when calculating pod
-                                      topology spread skew. Options are: - Honor:
-                                      nodes without taints, along with tainted nodes
-                                      for which the incoming pod has a toleration,
-                                      are included. - Ignore: node taints are ignored.
-                                      All nodes are included. \n If this value is
-                                      nil, the behavior is equivalent to the Ignore
-                                      policy."
+                                    description: |-
+                                      NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                      pod topology spread skew. Options are:
+                                      - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                      has a toleration, are included.
+                                      - Ignore: node taints are ignored. All nodes are included.
+
+
+                                      If this value is nil, the behavior is equivalent to the Ignore policy.
                                     type: string
                                   topologyKey:
-                                    description: TopologyKey is the key of node labels.
-                                      Nodes that have a label with this key and identical
-                                      values are considered to be in the same topology.
-                                      We consider each <key, value> as a "bucket",
-                                      and try to put balanced number of pods into
-                                      each bucket. We define a domain as a particular
-                                      instance of a topology.
+                                    description: |-
+                                      TopologyKey is the key of node labels. Nodes that have a label with this key
+                                      and identical values are considered to be in the same topology.
+                                      We consider each <key, value> as a "bucket", and try to put balanced number
+                                      of pods into each bucket.
+                                      We define a domain as a particular instance of a topology.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: WhenUnsatisfiable indicates how to
-                                      deal with a pod if it doesn't satisfy the spread
-                                      constraint. - DoNotSchedule (default) tells
-                                      the scheduler not to schedule it. - ScheduleAnyway
-                                      tells the scheduler to schedule the pod in any
-                                      location, but giving higher precedence to topologies
-                                      that would help reduce the skew.
+                                    description: |-
+                                      WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                      the spread constraint.
+                                      - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                      - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                        but giving higher precedence to topologies that would help reduce the
+                                        skew.
                                     type: string
                                 required:
                                 - maxSkew
@@ -6520,49 +5986,45 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: 'List of volumes that can be mounted by
-                                containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                              description: |-
+                                List of volumes that can be mounted by containers belonging to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes
                               items:
                                 description: Volume represents a named volume in a
                                   pod that may be accessed by any container in the
                                   pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'awsElasticBlockStore represents
-                                      an AWS Disk resource that is attached to a kubelet''s
-                                      host machine and then exposed to the pod. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    description: |-
+                                      awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       partition:
-                                        description: 'partition is the partition in
-                                          the volume that you want to mount. If omitted,
-                                          the default is to mount by volume name.
-                                          Examples: For volume /dev/sda1, you specify
-                                          the partition as "1". Similarly, the volume
-                                          partition for /dev/sda is "0" (or you can
-                                          leave the property empty).'
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'readOnly value true will force
-                                          the readOnly setting in VolumeMounts. More
-                                          info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: |-
+                                          readOnly value true will force the readOnly setting in VolumeMounts.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                         type: boolean
                                       volumeID:
-                                        description: 'volumeID is unique ID of the
-                                          persistent disk resource in AWS (Amazon
-                                          EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: |-
+                                          volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                         type: string
                                     required:
                                     - volumeID
@@ -6585,11 +6047,10 @@ spec:
                                           in the blob storage
                                         type: string
                                       fsType:
-                                        description: fsType is Filesystem type to
-                                          mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is Filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       kind:
                                         description: 'kind expected values are Shared:
@@ -6599,9 +6060,9 @@ spec:
                                           availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: readOnly Defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                     required:
                                     - diskName
@@ -6613,9 +6074,9 @@ spec:
                                       the pod.
                                     properties:
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretName:
                                         description: secretName is the  name of secret
@@ -6635,9 +6096,9 @@ spec:
                                       on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'monitors is Required: Monitors
-                                          is a collection of Ceph monitors More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          monitors is Required: Monitors is a collection of Ceph monitors
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         items:
                                           type: string
                                         type: array
@@ -6647,71 +6108,72 @@ spec:
                                           tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'readOnly is Optional: Defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.
-                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: boolean
                                       secretFile:
-                                        description: 'secretFile is Optional: SecretFile
-                                          is the path to key ring for User, default
-                                          is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: string
                                       secretRef:
-                                        description: 'secretRef is Optional: SecretRef
-                                          is reference to the authentication secret
-                                          for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       user:
-                                        description: 'user is optional: User is the
-                                          rados user name, default is admin More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          user is optional: User is the rados user name, default is admin
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'cinder represents a cinder volume
-                                      attached and mounted on kubelets host machine.
-                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    description: |-
+                                      cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: string
                                       readOnly:
-                                        description: 'readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is optional: points
-                                          to a secret object containing parameters
-                                          used to connect to OpenStack.'
+                                        description: |-
+                                          secretRef is optional: points to a secret object containing parameters used to connect
+                                          to OpenStack.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       volumeID:
-                                        description: 'volumeID used to identify the
-                                          volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          volumeID used to identify the volume in cinder.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: string
                                     required:
                                     - volumeID
@@ -6721,25 +6183,21 @@ spec:
                                       that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'defaultMode is optional: mode
-                                          bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          defaultMode is optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
-                                        description: items if unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          ConfigMap will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present.
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -6748,23 +6206,19 @@ spec:
                                               description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'mode is Optional: mode
-                                                bits used to set permissions on this
-                                                file. Must be an octal value between
-                                                0000 and 0777 or a decimal value between
-                                                0 and 511. YAML accepts both octal
-                                                and decimal values, JSON requires
-                                                decimal values for mode bits. If not
-                                                specified, the volume defaultMode
-                                                will be used.'
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
-                                              description: path is the relative path
-                                                of the file to map the key to. May
-                                                not be an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -6772,10 +6226,10 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: optional specify whether the
@@ -6789,48 +6243,43 @@ spec:
                                       by certain external CSI drivers (Beta feature).
                                     properties:
                                       driver:
-                                        description: driver is the name of the CSI
-                                          driver that handles this volume. Consult
-                                          with your admin for the correct name as
-                                          registered in the cluster.
+                                        description: |-
+                                          driver is the name of the CSI driver that handles this volume.
+                                          Consult with your admin for the correct name as registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: fsType to mount. Ex. "ext4",
-                                          "xfs", "ntfs". If not provided, the empty
-                                          value is passed to the associated CSI driver
-                                          which will determine the default filesystem
-                                          to apply.
+                                        description: |-
+                                          fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                          If not provided, the empty value is passed to the associated CSI driver
+                                          which will determine the default filesystem to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: nodePublishSecretRef is a reference
-                                          to the secret object containing sensitive
-                                          information to pass to the CSI driver to
-                                          complete the CSI NodePublishVolume and NodeUnpublishVolume
-                                          calls. This field is optional, and  may
-                                          be empty if no secret is required. If the
-                                          secret object contains more than one secret,
-                                          all secret references are passed.
+                                        description: |-
+                                          nodePublishSecretRef is a reference to the secret object containing
+                                          sensitive information to pass to the CSI driver to complete the CSI
+                                          NodePublishVolume and NodeUnpublishVolume calls.
+                                          This field is optional, and  may be empty if no secret is required. If the
+                                          secret object contains more than one secret, all secret references are passed.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       readOnly:
-                                        description: readOnly specifies a read-only
-                                          configuration for the volume. Defaults to
-                                          false (read/write).
+                                        description: |-
+                                          readOnly specifies a read-only configuration for the volume.
+                                          Defaults to false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: volumeAttributes stores driver-specific
-                                          properties that are passed to the CSI driver.
-                                          Consult your driver's documentation for
-                                          supported values.
+                                        description: |-
+                                          volumeAttributes stores driver-specific properties that are passed to the CSI
+                                          driver. Consult your driver's documentation for supported values.
                                         type: object
                                     required:
                                     - driver
@@ -6840,16 +6289,13 @@ spec:
                                       about the pod that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on
-                                          created files by default. Must be a Optional:
-                                          mode bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          Optional: mode bits to use on created files by default. Must be a
+                                          Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
@@ -6879,14 +6325,11 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file, must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.'
+                                              description: |-
+                                                Optional: mode bits used to set permissions on this file, must be an octal value
+                                                between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
@@ -6898,11 +6341,9 @@ spec:
                                                 path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                requests.cpu and requests.memory)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -6932,56 +6373,51 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'emptyDir represents a temporary
-                                      directory that shares a pod''s lifetime. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    description: |-
+                                      emptyDir represents a temporary directory that shares a pod's lifetime.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     properties:
                                       medium:
-                                        description: 'medium represents what type
-                                          of storage medium should back this directory.
-                                          The default is "" which means to use the
-                                          node''s default medium. Must be an empty
-                                          string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: |-
+                                          medium represents what type of storage medium should back this directory.
+                                          The default is "" which means to use the node's default medium.
+                                          Must be an empty string (default) or Memory.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'sizeLimit is the total amount
-                                          of local storage required for this EmptyDir
-                                          volume. The size limit is also applicable
-                                          for memory medium. The maximum usage on
-                                          memory medium EmptyDir would be the minimum
-                                          value between the SizeLimit specified here
-                                          and the sum of memory limits of all containers
-                                          in a pod. The default is nil which means
-                                          that the limit is undefined. More info:
-                                          https://kubernetes.'
+                                        description: |-
+                                          sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                          The size limit is also applicable for memory medium.
+                                          The maximum usage on memory medium EmptyDir would be the minimum value between
+                                          the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                          The default is nil which means that the limit is undefined.
+                                          More info: https://kubernetes.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: ephemeral represents a volume that
-                                      is handled by a cluster storage driver. The
-                                      volume's lifecycle is tied to the pod that defines
-                                      it - it will be created before the pod starts,
+                                    description: |-
+                                      ephemeral represents a volume that is handled by a cluster storage driver.
+                                      The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                                       and deleted when the pod is removed.
                                     properties:
                                       volumeClaimTemplate:
-                                        description: Will be used to create a stand-alone
-                                          PVC to provision the volume. The pod in
-                                          which this EphemeralVolumeSource is embedded
-                                          will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.  The
-                                          name of the PVC will be `<pod name>-<volume
-                                          name>` where `<volume name>` is the name
-                                          from the `PodSpec.Volumes` array entry.
+                                        description: |-
+                                          Will be used to create a stand-alone PVC to provision the volume.
+                                          The pod in which this EphemeralVolumeSource is embedded will be the
+                                          owner of the PVC, i.e. the PVC will be deleted together with the
+                                          pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                          `<volume name>` is the name from the `PodSpec.Volumes` array
+                                          entry.
                                         properties:
                                           metadata:
-                                            description: May contain labels and annotations
-                                              that will be copied into the PVC when
-                                              creating it. No other fields are allowed
-                                              and will be rejected during validation.
+                                            description: |-
+                                              May contain labels and annotations that will be copied into the PVC
+                                              when creating it. No other fields are allowed and will be rejected during
+                                              validation.
                                             properties:
                                               annotations:
                                                 additionalProperties:
@@ -7001,39 +6437,32 @@ spec:
                                                 type: string
                                             type: object
                                           spec:
-                                            description: The specification for the
-                                              PersistentVolumeClaim. The entire content
-                                              is copied unchanged into the PVC that
-                                              gets created from this template. The
-                                              same fields as in a PersistentVolumeClaim
+                                            description: |-
+                                              The specification for the PersistentVolumeClaim. The entire content is
+                                              copied unchanged into the PVC that gets created from this
+                                              template. The same fields as in a PersistentVolumeClaim
                                               are also valid here.
                                             properties:
                                               accessModes:
-                                                description: 'accessModes contains
-                                                  the desired access modes the volume
-                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                description: |-
+                                                  accessModes contains the desired access modes the volume should have.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                                 items:
                                                   type: string
                                                 type: array
                                               dataSource:
-                                                description: 'dataSource field can
-                                                  be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                description: |-
+                                                  dataSource field can be used to specify either:
+                                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                                   * An existing PVC (PersistentVolumeClaim)
-                                                  If the provisioner or an external
-                                                  controller can support the specified
-                                                  data source, it will create a new
-                                                  volume based on the contents of
-                                                  the specified data source.'
+                                                  If the provisioner or an external controller can support the specified data source,
+                                                  it will create a new volume based on the contents of the specified data source.
                                                 properties:
                                                   apiGroup:
-                                                    description: APIGroup is the group
-                                                      for the resource being referenced.
-                                                      If APIGroup is not specified,
-                                                      the specified Kind must be in
-                                                      the core API group. For any
-                                                      other third-party types, APIGroup
-                                                      is required.
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
                                                     type: string
                                                   kind:
                                                     description: Kind is the type
@@ -7049,26 +6478,19 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               dataSourceRef:
-                                                description: dataSourceRef specifies
-                                                  the object from which to populate
-                                                  the volume with data, if a non-empty
-                                                  volume is desired. This may be any
-                                                  object from a non-empty API group
-                                                  (non core object) or a PersistentVolumeClaim
-                                                  object. When this field is specified,
-                                                  volume binding will only succeed
-                                                  if the type of the specified object
-                                                  matches some installed volume populator
-                                                  or dynamic provisioner.
+                                                description: |-
+                                                  dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                                  volume is desired. This may be any object from a non-empty API group (non
+                                                  core object) or a PersistentVolumeClaim object.
+                                                  When this field is specified, volume binding will only succeed if the type of
+                                                  the specified object matches some installed volume populator or dynamic
+                                                  provisioner.
                                                 properties:
                                                   apiGroup:
-                                                    description: APIGroup is the group
-                                                      for the resource being referenced.
-                                                      If APIGroup is not specified,
-                                                      the specified Kind must be in
-                                                      the core API group. For any
-                                                      other third-party types, APIGroup
-                                                      is required.
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
                                                     type: string
                                                   kind:
                                                     description: Kind is the type
@@ -7079,54 +6501,42 @@ spec:
                                                       of resource being referenced
                                                     type: string
                                                   namespace:
-                                                    description: Namespace is the
-                                                      namespace of resource being
-                                                      referenced Note that when a
-                                                      namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
-                                                      object is required in the referent
-                                                      namespace to allow that namespace's
-                                                      owner to accept the reference.
-                                                      See the ReferenceGrant documentation
-                                                      for details. (Alpha) This field
-                                                      requires the CrossNamespaceVolumeDataSource
-                                                      feature gate to be enabled.
+                                                    description: |-
+                                                      Namespace is the namespace of resource being referenced
+                                                      Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                      (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                                     type: string
                                                 required:
                                                 - kind
                                                 - name
                                                 type: object
                                               resources:
-                                                description: 'resources represents
-                                                  the minimum resources the volume
-                                                  should have. If RecoverVolumeExpansionFailure
-                                                  feature is enabled users are allowed
-                                                  to specify resource requirements
-                                                  that are lower than previous value
-                                                  but must still be higher than capacity
-                                                  recorded in the status field of
-                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                description: |-
+                                                  resources represents the minimum resources the volume should have.
+                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  that are lower than previous value but must still be higher than capacity recorded in the
+                                                  status field of the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                                 properties:
                                                   claims:
-                                                    description: "Claims lists the
-                                                      names of resources, defined
-                                                      in spec.resourceClaims, that
-                                                      are used by this container.
-                                                      \n This is an alpha field and
-                                                      requires enabling the DynamicResourceAllocation
-                                                      feature gate. \n This field
-                                                      is immutable. It can only be
-                                                      set for containers."
+                                                    description: |-
+                                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                                      that are used by this container.
+
+
+                                                      This is an alpha field and requires enabling the
+                                                      DynamicResourceAllocation feature gate.
+
+
+                                                      This field is immutable. It can only be set for containers.
                                                     items:
                                                       description: ResourceClaim references
                                                         one entry in PodSpec.ResourceClaims.
                                                       properties:
                                                         name:
-                                                          description: Name must match
-                                                            the name of one entry
-                                                            in pod.spec.resourceClaims
-                                                            of the Pod where this
-                                                            field is used. It makes
-                                                            that resource available
+                                                          description: |-
+                                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                                            the Pod where this field is used. It makes that resource available
                                                             inside a container.
                                                           type: string
                                                       required:
@@ -7143,10 +6553,9 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: 'Limits describes
-                                                      the maximum amount of compute
-                                                      resources allowed. More info:
-                                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    description: |-
+                                                      Limits describes the maximum amount of compute resources allowed.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -7155,15 +6564,11 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: 'Requests describes
-                                                      the minimum amount of compute
-                                                      resources required. If Requests
-                                                      is omitted for a container,
-                                                      it defaults to Limits if that
-                                                      is explicitly specified, otherwise
-                                                      to an implementation-defined
-                                                      value. Requests cannot exceed
-                                                      Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    description: |-
+                                                      Requests describes the minimum amount of compute resources required.
+                                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                 type: object
                                               selector:
@@ -7176,11 +6581,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -7188,23 +6591,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -7216,28 +6612,22 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               storageClassName:
-                                                description: 'storageClassName is
-                                                  the name of the StorageClass required
-                                                  by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                description: |-
+                                                  storageClassName is the name of the StorageClass required by the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                                 type: string
                                               volumeMode:
-                                                description: volumeMode defines what
-                                                  type of volume is required by the
-                                                  claim. Value of Filesystem is implied
-                                                  when not included in claim spec.
+                                                description: |-
+                                                  volumeMode defines what type of volume is required by the claim.
+                                                  Value of Filesystem is implied when not included in claim spec.
                                                 type: string
                                               volumeName:
                                                 description: volumeName is the binding
@@ -7255,13 +6645,11 @@ spec:
                                       and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. TODO: how do we prevent
-                                          errors in the filesystem from compromising
-                                          the machine'
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       lun:
                                         description: 'lun is Optional: FC target lun
@@ -7269,9 +6657,9 @@ spec:
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'readOnly is Optional: Defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.'
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       targetWWNs:
                                         description: 'targetWWNs is Optional: FC target
@@ -7280,29 +6668,27 @@ spec:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'wwids Optional: FC volume world
-                                          wide identifiers (wwids) Either wwids or
-                                          combination of targetWWNs and lun must be
-                                          set, but not both simultaneously.'
+                                        description: |-
+                                          wwids Optional: FC volume world wide identifiers (wwids)
+                                          Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: flexVolume represents a generic volume
-                                      resource that is provisioned/attached using
-                                      an exec based plugin.
+                                    description: |-
+                                      flexVolume represents a generic volume resource that is
+                                      provisioned/attached using an exec based plugin.
                                     properties:
                                       driver:
                                         description: driver is the name of the driver
                                           to use for this volume.
                                         type: string
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". The default filesystem depends
-                                          on FlexVolume script.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
@@ -7311,24 +6697,23 @@ spec:
                                           holds extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'readOnly is Optional: defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.'
+                                        description: |-
+                                          readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is Optional: secretRef
-                                          is reference to the secret object containing
-                                          sensitive information to pass to the plugin
-                                          scripts. This may be empty if no secret
-                                          object is specified. If the secret object
-                                          contains more than one secret, all secrets
-                                          are passed to the plugin scripts.'
+                                        description: |-
+                                          secretRef is Optional: secretRef is reference to the secret object containing
+                                          sensitive information to pass to the plugin scripts. This may be
+                                          empty if no secret object is specified. If the secret object
+                                          contains more than one secret, all secrets are passed to the plugin
+                                          scripts.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -7341,9 +6726,9 @@ spec:
                                       on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: datasetName is Name of the dataset
-                                          stored as metadata -> name on the dataset
-                                          for Flocker should be considered as deprecated
+                                        description: |-
+                                          datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                          should be considered as deprecated
                                         type: string
                                       datasetUUID:
                                         description: datasetUUID is the UUID of the
@@ -7352,60 +6737,55 @@ spec:
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'gcePersistentDisk represents a GCE
-                                      Disk resource that is attached to a kubelet''s
-                                      host machine and then exposed to the pod. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    description: |-
+                                      gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                     properties:
                                       fsType:
-                                        description: 'fsType is filesystem type of
-                                          the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       partition:
-                                        description: 'partition is the partition in
-                                          the volume that you want to mount. If omitted,
-                                          the default is to mount by volume name.
-                                          Examples: For volume /dev/sda1, you specify
-                                          the partition as "1". Similarly, the volume
-                                          partition for /dev/sda is "0" (or you can
-                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'pdName is unique name of the
-                                          PD resource in GCE. Used to identify the
-                                          disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         type: boolean
                                     required:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'gitRepo represents a git repository
-                                      at a particular revision. DEPRECATED: GitRepo
-                                      is deprecated. To provision a container with
-                                      a git repo, mount an EmptyDir into an InitContainer
-                                      that clones the repo using git, then mount the
-                                      EmptyDir into the Pod''s container.'
+                                    description: |-
+                                      gitRepo represents a git repository at a particular revision.
+                                      DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                      EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                      into the Pod's container.
                                     properties:
                                       directory:
-                                        description: directory is the target directory
-                                          name. Must not contain or start with '..'.  If
-                                          '.' is supplied, the volume directory will
-                                          be the git repository.  Otherwise, if specified,
-                                          the volume will contain the git repository
-                                          in the subdirectory with the given name.
+                                        description: |-
+                                          directory is the target directory name.
+                                          Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                          git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                          the subdirectory with the given name.
                                         type: string
                                       repository:
                                         description: repository is the URL
@@ -7418,54 +6798,58 @@ spec:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'glusterfs represents a Glusterfs
-                                      mount on the host that shares a pod''s lifetime.
-                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                    description: |-
+                                      glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                     properties:
                                       endpoints:
-                                        description: 'endpoints is the endpoint name
-                                          that details Glusterfs topology. More info:
-                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          endpoints is the endpoint name that details Glusterfs topology.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: string
                                       path:
-                                        description: 'path is the Glusterfs volume
-                                          path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          path is the Glusterfs volume path.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          Glusterfs volume to be mounted with read-only
-                                          permissions. Defaults to false. More info:
-                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: boolean
                                     required:
                                     - endpoints
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'hostPath represents a pre-existing
-                                      file or directory on the host machine that is
-                                      directly exposed to the container. This is generally
-                                      used for system agents or other privileged things
-                                      that are allowed to see the host machine. Most
-                                      containers will NOT need this. More info: https://kubernetes.'
+                                    description: |-
+                                      hostPath represents a pre-existing file or directory on the host
+                                      machine that is directly exposed to the container. This is generally
+                                      used for system agents or other privileged things that are allowed
+                                      to see the host machine. Most containers will NOT need this.
+                                      More info: https://kubernetes.
                                     properties:
                                       path:
-                                        description: 'path of the directory on the
-                                          host. If the path is a symlink, it will
-                                          follow the link to the real path. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        description: |-
+                                          path of the directory on the host.
+                                          If the path is a symlink, it will follow the link to the real path.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                         type: string
                                       type:
-                                        description: 'type for HostPath Volume Defaults
-                                          to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        description: |-
+                                          type for HostPath Volume
+                                          Defaults to ""
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'iscsi represents an ISCSI Disk resource
-                                      that is attached to a kubelet''s host machine
-                                      and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                    description: |-
+                                      iscsi represents an ISCSI Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://examples.k8s.io/volumes/iscsi/README.md
                                     properties:
                                       chapAuthDiscovery:
                                         description: chapAuthDiscovery defines whether
@@ -7476,31 +6860,27 @@ spec:
                                           support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       initiatorName:
-                                        description: initiatorName is the custom iSCSI
-                                          Initiator Name. If initiatorName is specified
-                                          with iscsiInterface simultaneously, new
-                                          iSCSI interface <target portal>:<volume
-                                          name> will be created for the connection.
+                                        description: |-
+                                          initiatorName is the custom iSCSI Initiator Name.
+                                          If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                          <target portal>:<volume name> will be created for the connection.
                                         type: string
                                       iqn:
                                         description: iqn is the target iSCSI Qualified
                                           Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iscsiInterface is the interface
-                                          Name that uses an iSCSI transport. Defaults
-                                          to 'default' (tcp).
+                                        description: |-
+                                          iscsiInterface is the interface Name that uses an iSCSI transport.
+                                          Defaults to 'default' (tcp).
                                         type: string
                                       lun:
                                         description: lun represents iSCSI Target Lun
@@ -7508,35 +6888,33 @@ spec:
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: portals is the iSCSI Target Portal
-                                          List. The portal is either an IP or ip_addr:port
-                                          if the port is other than default (typically
-                                          TCP ports 860 and 3260).
+                                        description: |-
+                                          portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false.
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
                                         type: boolean
                                       secretRef:
                                         description: secretRef is the CHAP Secret
                                           for iSCSI target and initiator authentication
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       targetPortal:
-                                        description: targetPortal is iSCSI Target
-                                          Portal. The Portal is either an IP or ip_addr:port
-                                          if the port is other than default (typically
-                                          TCP ports 860 and 3260).
+                                        description: |-
+                                          targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -7544,45 +6922,51 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'name of the volume. Must be a DNS_LABEL
-                                      and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: |-
+                                      name of the volume.
+                                      Must be a DNS_LABEL and unique within the pod.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                   nfs:
-                                    description: 'nfs represents an NFS mount on the
-                                      host that shares a pod''s lifetime More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    description: |-
+                                      nfs represents an NFS mount on the host that shares a pod's lifetime
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                     properties:
                                       path:
-                                        description: 'path that is exported by the
-                                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          path that is exported by the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          NFS export to be mounted with read-only
-                                          permissions. Defaults to false. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          readOnly here will force the NFS export to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: boolean
                                       server:
-                                        description: 'server is the hostname or IP
-                                          address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          server is the hostname or IP address of the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: string
                                     required:
                                     - path
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'persistentVolumeClaimVolumeSource
-                                      represents a reference to a PersistentVolumeClaim
-                                      in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    description: |-
+                                      persistentVolumeClaimVolumeSource represents a reference to a
+                                      PersistentVolumeClaim in the same namespace.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                     properties:
                                       claimName:
-                                        description: 'claimName is the name of a PersistentVolumeClaim
-                                          in the same namespace as the pod using this
-                                          volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        description: |-
+                                          claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                         type: string
                                       readOnly:
-                                        description: readOnly Will force the ReadOnly
-                                          setting in VolumeMounts. Default false.
+                                        description: |-
+                                          readOnly Will force the ReadOnly setting in VolumeMounts.
+                                          Default false.
                                         type: boolean
                                     required:
                                     - claimName
@@ -7593,11 +6977,10 @@ spec:
                                       mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       pdID:
                                         description: pdID is the ID that identifies
@@ -7612,16 +6995,15 @@ spec:
                                       machine
                                     properties:
                                       fsType:
-                                        description: fSType represents the filesystem
-                                          type to mount Must be a filesystem type
-                                          supported by the host operating system.
-                                          Ex. "ext4", "xfs". Implicitly inferred to
-                                          be "ext4" if unspecified.
+                                        description: |-
+                                          fSType represents the filesystem type to mount
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       volumeID:
                                         description: volumeID uniquely identifies
@@ -7635,14 +7017,11 @@ spec:
                                       secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: defaultMode are the mode bits
-                                          used to set permissions on created files
-                                          by default. Must be an octal value between
-                                          0000 and 0777 or a decimal value between
-                                          0 and 511. YAML accepts both octal and decimal
-                                          values, JSON requires decimal values for
-                                          mode bits. Directories within the path are
-                                          not affected by this setting.
+                                        description: |-
+                                          defaultMode are the mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       sources:
@@ -7657,15 +7036,12 @@ spec:
                                                 the configMap data to project
                                               properties:
                                                 items:
-                                                  description: items if unspecified,
-                                                    each key-value pair in the Data
-                                                    field of the referenced ConfigMap
-                                                    will be projected into the volume
-                                                    as a file whose name is the key
-                                                    and content is the value. If specified,
-                                                    the listed keys will be projected
-                                                    into the specified paths, and
-                                                    unlisted keys will not be present.
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    ConfigMap will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7675,27 +7051,19 @@ spec:
                                                           to project.
                                                         type: string
                                                       mode:
-                                                        description: 'mode is Optional:
-                                                          mode bits used to set permissions
-                                                          on this file. Must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: path is the relative
-                                                          path of the file to map
-                                                          the key to. May not be an
-                                                          absolute path. May not contain
-                                                          the path element '..'. May
-                                                          not start with the string
-                                                          '..'.
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -7703,10 +7071,10 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: optional specify whether
@@ -7750,17 +7118,11 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
-                                                          on this file, must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7775,12 +7137,9 @@ spec:
                                                           ''..'''
                                                         type: string
                                                       resourceFieldRef:
-                                                        description: 'Selects a resource
-                                                          of the container: only resources
-                                                          limits and requests (limits.cpu,
-                                                          limits.memory, requests.cpu
-                                                          and requests.memory) are
-                                                          currently supported.'
+                                                        description: |-
+                                                          Selects a resource of the container: only resources limits and requests
+                                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                         properties:
                                                           containerName:
                                                             description: 'Container
@@ -7815,15 +7174,12 @@ spec:
                                                 the secret data to project
                                               properties:
                                                 items:
-                                                  description: items if unspecified,
-                                                    each key-value pair in the Data
-                                                    field of the referenced Secret
-                                                    will be projected into the volume
-                                                    as a file whose name is the key
-                                                    and content is the value. If specified,
-                                                    the listed keys will be projected
-                                                    into the specified paths, and
-                                                    unlisted keys will not be present.
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    Secret will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7833,27 +7189,19 @@ spec:
                                                           to project.
                                                         type: string
                                                       mode:
-                                                        description: 'mode is Optional:
-                                                          mode bits used to set permissions
-                                                          on this file. Must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: path is the relative
-                                                          path of the file to map
-                                                          the key to. May not be an
-                                                          absolute path. May not contain
-                                                          the path element '..'. May
-                                                          not start with the string
-                                                          '..'.
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -7861,10 +7209,10 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: optional field specify
@@ -7879,35 +7227,26 @@ spec:
                                                 data to project
                                               properties:
                                                 audience:
-                                                  description: audience is the intended
-                                                    audience of the token. A recipient
-                                                    of a token must identify itself
-                                                    with an identifier specified in
-                                                    the audience of the token, and
-                                                    otherwise should reject the token.
-                                                    The audience defaults to the identifier
-                                                    of the apiserver.
+                                                  description: |-
+                                                    audience is the intended audience of the token. A recipient of a token
+                                                    must identify itself with an identifier specified in the audience of the
+                                                    token, and otherwise should reject the token. The audience defaults to the
+                                                    identifier of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: expirationSeconds is
-                                                    the requested duration of validity
-                                                    of the service account token.
-                                                    As the token approaches expiration,
-                                                    the kubelet volume plugin will
-                                                    proactively rotate the service
-                                                    account token. The kubelet will
-                                                    start trying to rotate the token
-                                                    if the token is older than 80
-                                                    percent of its time to live or
-                                                    if the token is older than 24
-                                                    hours.Defaults to 1 hour and must
-                                                    be at least 10 minutes.
+                                                  description: |-
+                                                    expirationSeconds is the requested duration of validity of the service
+                                                    account token. As the token approaches expiration, the kubelet volume
+                                                    plugin will proactively rotate the service account token. The kubelet will
+                                                    start trying to rotate the token if the token is older than 80 percent of
+                                                    its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                    and must be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: path is the path relative
-                                                    to the mount point of the file
-                                                    to project the token into.
+                                                  description: |-
+                                                    path is the path relative to the mount point of the file to project the
+                                                    token into.
                                                   type: string
                                               required:
                                               - path
@@ -7920,29 +7259,29 @@ spec:
                                       on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: group to map volume access to
+                                        description: |-
+                                          group to map volume access to
                                           Default is no group
                                         type: string
                                       readOnly:
-                                        description: readOnly here will force the
-                                          Quobyte volume to be mounted with read-only
-                                          permissions. Defaults to false.
+                                        description: |-
+                                          readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                          Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: registry represents a single
-                                          or multiple Quobyte Registry services specified
-                                          as a string as host:port pair (multiple
-                                          entries are separated with commas) which
-                                          acts as the central registry for volumes
+                                        description: |-
+                                          registry represents a single or multiple Quobyte Registry services
+                                          specified as a string as host:port pair (multiple entries are separated with commas)
+                                          which acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: tenant owning the given Quobyte
-                                          volume in the Backend Used with dynamically
-                                          provisioned Quobyte volumes, value is set
-                                          by the plugin
+                                        description: |-
+                                          tenant owning the given Quobyte volume in the Backend
+                                          Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                         type: string
                                       user:
-                                        description: user to map volume access to
+                                        description: |-
+                                          user to map volume access to
                                           Defaults to serivceaccount user
                                         type: string
                                       volume:
@@ -7954,61 +7293,68 @@ spec:
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'rbd represents a Rados Block Device
-                                      mount on the host that shares a pod''s lifetime.
-                                      More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                    description: |-
+                                      rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       image:
-                                        description: 'image is the rados image name.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       keyring:
-                                        description: 'keyring is the path to key ring
-                                          for RBDUser. Default is /etc/ceph/keyring.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          keyring is the path to key ring for RBDUser.
+                                          Default is /etc/ceph/keyring.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       monitors:
-                                        description: 'monitors is a collection of
-                                          Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          monitors is a collection of Ceph monitors.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'pool is the rados pool name.
-                                          Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          pool is the rados pool name.
+                                          Default is rbd.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is name of the authentication
-                                          secret for RBDUser. If provided overrides
-                                          keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          secretRef is name of the authentication secret for RBDUser. If provided
+                                          overrides keyring.
+                                          Default is nil.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       user:
-                                        description: 'user is the rados user name.
-                                          Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          user is the rados user name.
+                                          Default is admin.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                     required:
                                     - image
@@ -8019,10 +7365,11 @@ spec:
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Default is "xfs".
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs".
+                                          Default is "xfs".
                                         type: string
                                       gateway:
                                         description: gateway is the host address of
@@ -8034,21 +7381,20 @@ spec:
                                           configured storage.
                                         type: string
                                       readOnly:
-                                        description: readOnly Defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: secretRef references to the secret
-                                          for ScaleIO user and other sensitive information.
-                                          If this is not provided, Login operation
-                                          will fail.
+                                        description: |-
+                                          secretRef references to the secret for ScaleIO user and other
+                                          sensitive information. If this is not provided, Login operation will fail.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -8058,9 +7404,9 @@ spec:
                                           false
                                         type: boolean
                                       storageMode:
-                                        description: storageMode indicates whether
-                                          the storage for a volume should be ThickProvisioned
-                                          or ThinProvisioned. Default is ThinProvisioned.
+                                        description: |-
+                                          storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                          Default is ThinProvisioned.
                                         type: string
                                       storagePool:
                                         description: storagePool is the ScaleIO Storage
@@ -8071,9 +7417,9 @@ spec:
                                           system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: volumeName is the name of a volume
-                                          already created in the ScaleIO system that
-                                          is associated with this volume source.
+                                        description: |-
+                                          volumeName is the name of a volume already created in the ScaleIO system
+                                          that is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -8081,29 +7427,26 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'secret represents a secret that
-                                      should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    description: |-
+                                      secret represents a secret that should populate this volume.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                     properties:
                                       defaultMode:
-                                        description: 'defaultMode is Optional: mode
-                                          bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values
+                                          for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
-                                        description: items If unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          Secret will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present.
+                                        description: |-
+                                          items If unspecified, each key-value pair in the Data field of the referenced
+                                          Secret will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -8112,23 +7455,19 @@ spec:
                                               description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'mode is Optional: mode
-                                                bits used to set permissions on this
-                                                file. Must be an octal value between
-                                                0000 and 0777 or a decimal value between
-                                                0 and 511. YAML accepts both octal
-                                                and decimal values, JSON requires
-                                                decimal values for mode bits. If not
-                                                specified, the volume defaultMode
-                                                will be used.'
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
-                                              description: path is the relative path
-                                                of the file to map the key to. May
-                                                not be an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -8140,9 +7479,9 @@ spec:
                                           the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'secretName is the name of the
-                                          secret in the pod''s namespace to use. More
-                                          info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        description: |-
+                                          secretName is the name of the secret in the pod's namespace to use.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                         type: string
                                     type: object
                                   storageos:
@@ -8150,45 +7489,41 @@ spec:
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: secretRef specifies the secret
-                                          to use for obtaining the StorageOS API credentials.  If
-                                          not specified, default values will be attempted.
+                                        description: |-
+                                          secretRef specifies the secret to use for obtaining the StorageOS API
+                                          credentials.  If not specified, default values will be attempted.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       volumeName:
-                                        description: volumeName is the human-readable
-                                          name of the StorageOS volume.  Volume names
-                                          are only unique within a namespace.
+                                        description: |-
+                                          volumeName is the human-readable name of the StorageOS volume.  Volume
+                                          names are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: volumeNamespace specifies the
-                                          scope of the volume within StorageOS.  If
-                                          no namespace is specified then the Pod's
-                                          namespace will be used.  This allows the
-                                          Kubernetes name scoping to be mirrored within
-                                          StorageOS for tighter integration. Set VolumeName
-                                          to any name to override the default behaviour.
-                                          Set to "default" if you are not using namespaces
-                                          within StorageOS.
+                                        description: |-
+                                          volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                          namespace is specified then the Pod's namespace will be used.  This allows the
+                                          Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                          Set VolumeName to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces within StorageOS.
                                         type: string
                                     type: object
                                   vsphereVolume:
@@ -8197,11 +7532,10 @@ spec:
                                       machine
                                     properties:
                                       fsType:
-                                        description: fsType is filesystem type to
-                                          mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
                                         description: storagePolicyID is the storage
@@ -8228,19 +7562,24 @@ spec:
                           type: object
                       type: object
                   type: object
-                description: 'A map of PyTorchReplicaType (type) to ReplicaSpec (value).
-                  Specifies the PyTorch cluster configuration. For example, { "Master":
-                  PyTorchReplicaSpec, "Worker": PyTorchReplicaSpec, }'
+                description: |-
+                  A map of PyTorchReplicaType (type) to ReplicaSpec (value). Specifies the PyTorch cluster configuration.
+                  For example,
+                    {
+                      "Master": PyTorchReplicaSpec,
+                      "Worker": PyTorchReplicaSpec,
+                    }
                 type: object
               runPolicy:
-                description: RunPolicy encapsulates various runtime policies of the
-                  distributed training job, for example how to clean up resources
-                  and how long the job can stay active.
+                description: |-
+                  RunPolicy encapsulates various runtime policies of the distributed training
+                  job, for example how to clean up resources and how long the job can stay
+                  active.
                 properties:
                   activeDeadlineSeconds:
-                    description: Specifies the duration in seconds relative to the
-                      startTime that the job may be active before the system tries
-                      to terminate it; value must be positive integer.
+                    description: |-
+                      Specifies the duration in seconds relative to the startTime that the job may be active
+                      before the system tries to terminate it; value must be positive integer.
                     format: int64
                     type: integer
                   backoffLimit:
@@ -8249,8 +7588,9 @@ spec:
                     format: int32
                     type: integer
                   cleanPodPolicy:
-                    description: CleanPodPolicy defines the policy to kill pods after
-                      the job completes. Default to None.
+                    description: |-
+                      CleanPodPolicy defines the policy to kill pods after the job completes.
+                      Default to None.
                     type: string
                   schedulingPolicy:
                     description: SchedulingPolicy defines the policy related to scheduling,
@@ -8277,18 +7617,20 @@ spec:
                     type: object
                   suspend:
                     default: false
-                    description: suspend specifies whether the Job controller should
-                      create Pods or not. If a Job is created with suspend set to
-                      true, no Pods are created by the Job controller. If a Job is
-                      suspended after creation (i.e. the flag goes from false to true),
-                      the Job controller will delete all active Pods and PodGroups
-                      associated with this Job. Users must design their workload to
-                      gracefully handle this.
+                    description: |-
+                      suspend specifies whether the Job controller should create Pods or not.
+                      If a Job is created with suspend set to true, no Pods are created by
+                      the Job controller. If a Job is suspended after creation (i.e. the
+                      flag goes from false to true), the Job controller will delete all
+                      active Pods and PodGroups associated with this Job.
+                      Users must design their workload to gracefully handle this.
                     type: boolean
                   ttlSecondsAfterFinished:
-                    description: TTLSecondsAfterFinished is the TTL to clean up jobs.
+                    description: |-
+                      TTLSecondsAfterFinished is the TTL to clean up jobs.
                       It may take extra ReconcilePeriod seconds for the cleanup, since
-                      reconcile gets called periodically. Default to infinite.
+                      reconcile gets called periodically.
+                      Default to infinite.
                     format: int32
                     type: integer
                 type: object
@@ -8296,12 +7638,14 @@ spec:
             - pytorchReplicaSpecs
             type: object
           status:
-            description: Most recently observed status of the PyTorchJob. Read-only
-              (modified by the system).
+            description: |-
+              Most recently observed status of the PyTorchJob.
+              Read-only (modified by the system).
             properties:
               completionTime:
-                description: Represents time when the job was completed. It is not
-                  guaranteed to be set in happens-before order across separate operations.
+                description: |-
+                  Represents time when the job was completed. It is not guaranteed to
+                  be set in happens-before order across separate operations.
                   It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
@@ -8339,9 +7683,10 @@ spec:
                   type: object
                 type: array
               lastReconcileTime:
-                description: Represents last time when the job was reconciled. It
-                  is not guaranteed to be set in happens-before order across separate
-                  operations. It is represented in RFC3339 form and is in UTC.
+                description: |-
+                  Represents last time when the job was reconciled. It is not guaranteed to
+                  be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               replicaStatuses:
@@ -8364,25 +7709,25 @@ spec:
                           description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -8394,33 +7739,33 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     selector:
-                      description: A Selector is a label query over a set of resources.
-                        The result of matchLabels and matchExpressions are ANDed.
-                        An empty Selector matches all objects. A null Selector matches
-                        no objects.
+                      description: |-
+                        A Selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty Selector matches all objects. A null
+                        Selector matches no objects.
                       type: string
                     succeeded:
                       description: The number of pods which reached phase Succeeded.
                       format: int32
                       type: integer
                   type: object
-                description: ReplicaStatuses is map of ReplicaType and ReplicaStatus,
+                description: |-
+                  ReplicaStatuses is map of ReplicaType and ReplicaStatus,
                   specifies the status of each replica.
                 type: object
               startTime:
-                description: Represents time when the job was acknowledged by the
-                  job controller. It is not guaranteed to be set in happens-before
-                  order across separate operations. It is represented in RFC3339 form
-                  and is in UTC.
+                description: |-
+                  Represents time when the job was acknowledged by the job controller.
+                  It is not guaranteed to be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
             type: object

--- a/manifests/base/crds/kubeflow.org_tfjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_tfjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: tfjobs.kubeflow.org
 spec:
   group: kubeflow.org
@@ -27,14 +27,19 @@ spec:
         description: TFJob represents a TFJob resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -45,14 +50,15 @@ spec:
                 description: A switch to enable dynamic worker
                 type: boolean
               runPolicy:
-                description: RunPolicy encapsulates various runtime policies of the
-                  distributed training job, for example how to clean up resources
-                  and how long the job can stay active.
+                description: |-
+                  RunPolicy encapsulates various runtime policies of the distributed training
+                  job, for example how to clean up resources and how long the job can stay
+                  active.
                 properties:
                   activeDeadlineSeconds:
-                    description: Specifies the duration in seconds relative to the
-                      startTime that the job may be active before the system tries
-                      to terminate it; value must be positive integer.
+                    description: |-
+                      Specifies the duration in seconds relative to the startTime that the job may be active
+                      before the system tries to terminate it; value must be positive integer.
                     format: int64
                     type: integer
                   backoffLimit:
@@ -61,8 +67,9 @@ spec:
                     format: int32
                     type: integer
                   cleanPodPolicy:
-                    description: CleanPodPolicy defines the policy to kill pods after
-                      the job completes. Default to None.
+                    description: |-
+                      CleanPodPolicy defines the policy to kill pods after the job completes.
+                      Default to None.
                     type: string
                   schedulingPolicy:
                     description: SchedulingPolicy defines the policy related to scheduling,
@@ -89,45 +96,54 @@ spec:
                     type: object
                   suspend:
                     default: false
-                    description: suspend specifies whether the Job controller should
-                      create Pods or not. If a Job is created with suspend set to
-                      true, no Pods are created by the Job controller. If a Job is
-                      suspended after creation (i.e. the flag goes from false to true),
-                      the Job controller will delete all active Pods and PodGroups
-                      associated with this Job. Users must design their workload to
-                      gracefully handle this.
+                    description: |-
+                      suspend specifies whether the Job controller should create Pods or not.
+                      If a Job is created with suspend set to true, no Pods are created by
+                      the Job controller. If a Job is suspended after creation (i.e. the
+                      flag goes from false to true), the Job controller will delete all
+                      active Pods and PodGroups associated with this Job.
+                      Users must design their workload to gracefully handle this.
                     type: boolean
                   ttlSecondsAfterFinished:
-                    description: TTLSecondsAfterFinished is the TTL to clean up jobs.
+                    description: |-
+                      TTLSecondsAfterFinished is the TTL to clean up jobs.
                       It may take extra ReconcilePeriod seconds for the cleanup, since
-                      reconcile gets called periodically. Default to infinite.
+                      reconcile gets called periodically.
+                      Default to infinite.
                     format: int32
                     type: integer
                 type: object
               successPolicy:
-                description: SuccessPolicy defines the policy to mark the TFJob as
-                  succeeded. Default to "", using the default rules.
+                description: |-
+                  SuccessPolicy defines the policy to mark the TFJob as succeeded.
+                  Default to "", using the default rules.
                 type: string
               tfReplicaSpecs:
                 additionalProperties:
                   description: ReplicaSpec is a description of the replica
                   properties:
                     replicas:
-                      description: Replicas is the desired number of replicas of the
-                        given template. If unspecified, defaults to 1.
+                      description: |-
+                        Replicas is the desired number of replicas of the given template.
+                        If unspecified, defaults to 1.
                       format: int32
                       type: integer
                     restartPolicy:
-                      description: Restart policy for all replicas within the job.
-                        One of Always, OnFailure, Never and ExitCode. Default to Never.
+                      description: |-
+                        Restart policy for all replicas within the job.
+                        One of Always, OnFailure, Never and ExitCode.
+                        Default to Never.
                       type: string
                     template:
-                      description: Template is the object that describes the pod that
+                      description: |-
+                        Template is the object that describes the pod that
                         will be created for this replica. RestartPolicy in PodTemplateSpec
                         will be overide by RestartPolicy in ReplicaSpec
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          description: |-
+                            Standard object's metadata.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                           properties:
                             annotations:
                               additionalProperties:
@@ -147,15 +163,15 @@ spec:
                               type: string
                           type: object
                         spec:
-                          description: 'Specification of the desired behavior of the
-                            pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                          description: |-
+                            Specification of the desired behavior of the pod.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                           properties:
                             activeDeadlineSeconds:
-                              description: Optional duration in seconds the pod may
-                                be active on the node relative to StartTime before
-                                the system will actively try to mark it failed and
-                                kill associated containers. Value must be a positive
-                                integer.
+                              description: |-
+                                Optional duration in seconds the pod may be active on the node relative to
+                                StartTime before the system will actively try to mark it failed and kill associated containers.
+                                Value must be a positive integer.
                               format: int64
                               type: integer
                             affinity:
@@ -166,21 +182,17 @@ spec:
                                     rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.
                                       items:
-                                        description: An empty preferred scheduling
-                                          term matches all objects with implicit weight
-                                          0 (i.e. it's a no-op). A null preferred
-                                          scheduling term matches no objects (i.e.
-                                          is also a no-op).
+                                        description: |-
+                                          An empty preferred scheduling term matches all objects with implicit weight 0
+                                          (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                         properties:
                                           preference:
                                             description: A node selector term, associated
@@ -190,35 +202,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -231,35 +234,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -282,57 +276,46 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified
-                                        by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to an update), the
-                                        system may or may not try to eventually evict
-                                        the pod from its node.
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to an update), the system
+                                        may or may not try to eventually evict the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
                                             terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector
-                                              term matches no objects. The requirements
-                                              of them are ANDed. The TopologySelectorTerm
-                                              type implements a subset of the NodeSelectorTerm.
+                                            description: |-
+                                              A null or empty node selector term matches no objects. The requirements of
+                                              them are ANDed.
+                                              The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
                                                 description: A list of node selector
                                                   requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -345,35 +328,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -396,15 +370,13 @@ spec:
                                     etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -425,11 +397,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -437,23 +407,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -465,29 +428,20 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaceSelector:
-                                                description: A label query over the
-                                                  set of namespaces that the term
-                                                  applies to. The term is applied
-                                                  to the union of the namespaces selected
-                                                  by this field and the ones listed
-                                                  in the namespaces field. null selector
-                                                  and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -495,11 +449,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -507,23 +459,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -535,50 +480,37 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaces:
-                                                description: namespaces specifies
-                                                  a static list of namespace names
-                                                  that the term applies to. The term
-                                                  is applied to the union of the namespaces
-                                                  listed in this field and the ones
-                                                  selected by namespaceSelector. null
-                                                  or empty namespaces list and null
-                                                  namespaceSelector means "this pod's
-                                                  namespace".
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching
-                                              the corresponding podAffinityTerm, in
-                                              the range 1-100.
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -587,24 +519,20 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified
-                                        by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to a pod label update),
-                                        the system may or may not try to eventually
-                                        evict the pod from its node.
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
                                       items:
-                                        description: Defines a set of pods (namely
-                                          those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -615,10 +543,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -626,21 +553,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -653,25 +574,19 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
@@ -679,10 +594,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -690,21 +604,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -717,39 +625,29 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace".
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -762,13 +660,11 @@ spec:
                                     node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the anti-affinity
-                                        expressions specified by this field, but it
-                                        may choose a node that violates one or more
-                                        of the expressions. The node that is most
-                                        preferred is the one with the greatest sum
-                                        of weights, i.e.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the anti-affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -789,11 +685,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -801,23 +695,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -829,29 +716,20 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaceSelector:
-                                                description: A label query over the
-                                                  set of namespaces that the term
-                                                  applies to. The term is applied
-                                                  to the union of the namespaces selected
-                                                  by this field and the ones listed
-                                                  in the namespaces field. null selector
-                                                  and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -859,11 +737,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -871,23 +747,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -899,50 +768,37 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaces:
-                                                description: namespaces specifies
-                                                  a static list of namespace names
-                                                  that the term applies to. The term
-                                                  is applied to the union of the namespaces
-                                                  listed in this field and the ones
-                                                  selected by namespaceSelector. null
-                                                  or empty namespaces list and null
-                                                  namespaceSelector means "this pod's
-                                                  namespace".
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching
-                                              the corresponding podAffinityTerm, in
-                                              the range 1-100.
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -951,24 +807,20 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements
-                                        specified by this field are not met at scheduling
-                                        time, the pod will not be scheduled onto the
-                                        node. If the anti-affinity requirements specified
-                                        by this field cease to be met at some point
-                                        during pod execution (e.g. due to a pod label
-                                        update), the system may or may not try to
-                                        eventually evict the pod from its node.
+                                      description: |-
+                                        If the anti-affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the anti-affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
                                       items:
-                                        description: Defines a set of pods (namely
-                                          those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -979,10 +831,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -990,21 +841,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -1017,25 +862,19 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
@@ -1043,10 +882,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -1054,21 +892,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -1081,39 +913,29 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace".
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1127,41 +949,39 @@ spec:
                                 mounted.
                               type: boolean
                             containers:
-                              description: List of containers belonging to the pod.
-                                Containers cannot currently be added or removed. There
-                                must be at least one container in a Pod. Cannot be
-                                updated.
+                              description: |-
+                                List of containers belonging to the pod.
+                                Containers cannot currently be added or removed.
+                                There must be at least one container in a Pod.
+                                Cannot be updated.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
-                                      provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The container image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
-                                      used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The container image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -1171,16 +991,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1194,10 +1011,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1208,11 +1025,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -1228,12 +1043,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -1267,10 +1079,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1286,15 +1098,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1303,10 +1113,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -1323,10 +1133,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -1337,48 +1147,43 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images
-                                      This field is optional to allow higher level
-                                      config management to default or override container
-                                      images in workload controllers like Deployments
-                                      and StatefulSets.'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system
-                                      should take in response to container lifecycle
-                                      events. Cannot be updated.
+                                    description: |-
+                                      Actions that the management system should take in response to container lifecycle events.
+                                      Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1388,10 +1193,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -1403,11 +1207,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -1426,25 +1228,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1455,41 +1256,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1499,10 +1293,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -1514,11 +1307,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -1537,25 +1328,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1566,10 +1356,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -1577,35 +1367,31 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness.
+                                    description: |-
+                                      Periodic probe of container liveness.
                                       Container will be restarted if the probe fails.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -1618,11 +1404,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -1632,9 +1419,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -1644,11 +1431,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -1666,36 +1451,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -1710,55 +1494,52 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as
-                                      a DNS_LABEL. Each container in a pod must have
-                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    description: |-
+                                      Name of the container specified as a DNS_LABEL.
+                                      Each container in a pod must have a unique name (DNS_LABEL).
+                                      Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the
-                                      container. Not specifying a port here DOES NOT
-                                      prevent that port from being exposed. Any port
-                                      which is listening on the default "0.0.0.0"
-                                      address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
+                                    description: |-
+                                      List of ports to expose from the container. Not specifying a port here
+                                      DOES NOT prevent that port from being exposed. Any port which is
+                                      listening on the default "0.0.0.0" address inside a container will be
+                                      accessible from the network.
+                                      Modifying this array with strategic merge patch may corrupt the data.
                                       For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -1766,24 +1547,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -1794,36 +1575,31 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service
-                                      readiness. Container will be removed from service
-                                      endpoints if the probe fails. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Periodic probe of container service readiness.
+                                      Container will be removed from service endpoints if the probe fails.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -1836,11 +1612,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -1850,9 +1627,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -1862,11 +1639,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -1884,36 +1659,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -1928,30 +1702,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -1962,14 +1733,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -1978,26 +1749,31 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Compute Resources required by this container.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -2013,9 +1789,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2024,48 +1800,41 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: RestartPolicy defines the restart
-                                      behavior of individual containers in a pod.
-                                      This field may only be set for init containers,
-                                      and the only allowed value is "Always". For
-                                      non-init containers or when this field is not
-                                      specified, the restart behavior is defined by
-                                      the Pod's restart policy and the container type.
+                                    description: |-
+                                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                                      This field may only be set for init containers, and the only allowed value is "Always".
+                                      For non-init containers or when this field is not specified,
+                                      the restart behavior is defined by the Pod's restart policy and the container type.
                                     type: string
                                   securityContext:
-                                    description: 'SecurityContext defines the security
-                                      options the container should be run with. If
-                                      set, the fields of SecurityContext override
-                                      the equivalent fields of PodSecurityContext.
-                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    description: |-
+                                      SecurityContext defines the security options the container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -2083,68 +1852,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2164,52 +1924,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -2217,60 +1969,46 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: StartupProbe indicates that the Pod
-                                      has successfully initialized. If specified,
-                                      no other probes are executed until this completes
-                                      successfully. If this probe fails, the Pod will
-                                      be restarted, just as if the livenessProbe failed.
+                                    description: |-
+                                      StartupProbe indicates that the Pod has successfully initialized.
+                                      If specified, no other probes are executed until this completes successfully.
+                                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -2283,11 +2021,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -2297,9 +2036,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -2309,11 +2048,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -2331,36 +2068,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -2375,72 +2111,62 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -2464,46 +2190,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -2511,34 +2236,36 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             dnsConfig:
-                              description: Specifies the DNS parameters of a pod.
-                                Parameters specified here will be merged to the generated
-                                DNS configuration based on DNSPolicy.
+                              description: |-
+                                Specifies the DNS parameters of a pod.
+                                Parameters specified here will be merged to the generated DNS
+                                configuration based on DNSPolicy.
                               properties:
                                 nameservers:
-                                  description: A list of DNS name server IP addresses.
-                                    This will be appended to the base nameservers
-                                    generated from DNSPolicy. Duplicated nameservers
-                                    will be removed.
+                                  description: |-
+                                    A list of DNS name server IP addresses.
+                                    This will be appended to the base nameservers generated from DNSPolicy.
+                                    Duplicated nameservers will be removed.
                                   items:
                                     type: string
                                   type: array
                                 options:
-                                  description: A list of DNS resolver options. This
-                                    will be merged with the base options generated
-                                    from DNSPolicy. Duplicated entries will be removed.
-                                    Resolution options given in Options will override
-                                    those that appear in the base DNSPolicy.
+                                  description: |-
+                                    A list of DNS resolver options.
+                                    This will be merged with the base options generated from DNSPolicy.
+                                    Duplicated entries will be removed. Resolution options given in Options
+                                    will override those that appear in the base DNSPolicy.
                                   items:
                                     description: PodDNSConfigOption defines DNS resolver
                                       options of a pod.
@@ -2551,75 +2278,68 @@ spec:
                                     type: object
                                   type: array
                                 searches:
-                                  description: A list of DNS search domains for host-name
-                                    lookup. This will be appended to the base search
-                                    paths generated from DNSPolicy. Duplicated search
-                                    paths will be removed.
+                                  description: |-
+                                    A list of DNS search domains for host-name lookup.
+                                    This will be appended to the base search paths generated from DNSPolicy.
+                                    Duplicated search paths will be removed.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
-                              description: Set DNS policy for the pod. Defaults to
-                                "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
-                                'ClusterFirst', 'Default' or 'None'. DNS parameters
-                                given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy. To have DNS options set along
-                                with hostNetwork, you have to specify DNS policy explicitly
-                                to 'ClusterFirstWithHostNet'.
+                              description: |-
+                                Set DNS policy for the pod.
+                                Defaults to "ClusterFirst".
+                                Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                                DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                                To have DNS options set along with hostNetwork, you have to specify DNS policy
+                                explicitly to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
-                              description: 'EnableServiceLinks indicates whether information
-                                about services should be injected into pod''s environment
-                                variables, matching the syntax of Docker links. Optional:
-                                Defaults to true.'
+                              description: |-
+                                EnableServiceLinks indicates whether information about services should be injected into pod's
+                                environment variables, matching the syntax of Docker links.
+                                Optional: Defaults to true.
                               type: boolean
                             ephemeralContainers:
-                              description: List of ephemeral containers run in this
-                                pod. Ephemeral containers may be run in an existing
-                                pod to perform user-initiated actions such as debugging.
-                                This list cannot be specified when creating a pod,
-                                and it cannot be modified by updating the pod spec.
-                                In order to add an ephemeral container to an existing
-                                pod, use the pod's ephemeralcontainers subresource.
+                              description: |-
+                                List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                                pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                                creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                                ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
                               items:
-                                description: An EphemeralContainer is a temporary
-                                  container that you may add to an existing Pod for
-                                  user-initiated activities such as debugging. Ephemeral
-                                  containers have no resource or scheduling guarantees,
-                                  and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted. The kubelet
-                                  may evict a Pod if an ephemeral container causes
-                                  the Pod to exceed its resource allocation.
+                                description: |-
+                                  An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                                  user-initiated activities such as debugging. Ephemeral containers have no resource or
+                                  scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                                  removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                                  Pod to exceed its resource allocation.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the
-                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                      produce the string literal "$(VAR_NAME)".'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)".
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The image''s ENTRYPOINT is used if
-                                      this is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -2629,16 +2349,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -2652,10 +2369,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -2666,11 +2383,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -2686,12 +2401,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -2725,10 +2437,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -2744,15 +2456,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -2761,10 +2471,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -2781,10 +2491,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -2795,43 +2505,40 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
                                     description: Lifecycle is not allowed for ephemeral
                                       containers.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2841,10 +2548,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -2856,11 +2562,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -2879,25 +2583,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2908,41 +2611,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2952,10 +2648,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -2967,11 +2662,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -2990,25 +2683,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -3019,10 +2711,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -3038,26 +2730,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -3070,11 +2756,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -3084,9 +2771,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -3096,11 +2783,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3118,36 +2803,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -3162,38 +2846,34 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the ephemeral container specified
-                                      as a DNS_LABEL. This name must be unique among
-                                      all containers, init containers and ephemeral
-                                      containers.
+                                    description: |-
+                                      Name of the ephemeral container specified as a DNS_LABEL.
+                                      This name must be unique among all containers, init containers and ephemeral containers.
                                     type: string
                                   ports:
                                     description: Ports are not allowed for ephemeral
@@ -3203,9 +2883,9 @@ spec:
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -3213,24 +2893,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -3249,26 +2929,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -3281,11 +2955,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -3295,9 +2970,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -3307,11 +2982,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3329,36 +3002,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -3373,30 +3045,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -3407,14 +3076,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -3423,27 +3092,30 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: Resources are not allowed for ephemeral
-                                      containers. Ephemeral containers use spare resources
+                                    description: |-
+                                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
                                       already allocated to the pod.
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -3459,9 +3131,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -3470,45 +3142,40 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: Restart policy for the container
-                                      to manage the restart behavior of each container
-                                      within a pod. This may only be set for init
-                                      containers. You cannot set this field on ephemeral
-                                      containers.
+                                    description: |-
+                                      Restart policy for the container to manage the restart behavior of each
+                                      container within a pod.
+                                      This may only be set for init containers. You cannot set this field on
+                                      ephemeral containers.
                                     type: string
                                   securityContext:
-                                    description: 'Optional: SecurityContext defines
-                                      the security options the ephemeral container
-                                      should be run with. If set, the fields of SecurityContext
-                                      override the equivalent fields of PodSecurityContext.'
+                                    description: |-
+                                      Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -3526,68 +3193,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3607,52 +3265,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -3660,25 +3310,18 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
@@ -3691,26 +3334,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -3723,11 +3360,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -3737,9 +3375,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -3749,11 +3387,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3771,36 +3407,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -3815,81 +3450,71 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: "If set, the name of the container
-                                      from PodSpec that this ephemeral container targets.
-                                      The ephemeral container will be run in the namespaces
-                                      (IPC, PID, etc) of this container. If not set
-                                      then the ephemeral container uses the namespaces
-                                      configured in the Pod spec. \n The container
-                                      runtime must implement support for this feature."
+                                    description: |-
+                                      If set, the name of the container from PodSpec that this ephemeral container targets.
+                                      The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                      If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+
+                                      The container runtime must implement support for this feature.
                                     type: string
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -3913,47 +3538,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Subpath mounts are not allowed for
-                                      ephemeral containers. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -3961,24 +3584,24 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             hostAliases:
-                              description: HostAliases is an optional list of hosts
-                                and IPs that will be injected into the pod's hosts
-                                file if specified. This is only valid for non-hostNetwork
-                                pods.
+                              description: |-
+                                HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                file if specified. This is only valid for non-hostNetwork pods.
                               items:
-                                description: HostAlias holds the mapping between IP
-                                  and hostnames that will be injected as an entry
-                                  in the pod's hosts file.
+                                description: |-
+                                  HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                  pod's hosts file.
                                 properties:
                                   hostnames:
                                     description: Hostnames for the above IP address.
@@ -3991,93 +3614,89 @@ spec:
                                 type: object
                               type: array
                             hostIPC:
-                              description: 'Use the host''s ipc namespace. Optional:
-                                Default to false.'
+                              description: |-
+                                Use the host's ipc namespace.
+                                Optional: Default to false.
                               type: boolean
                             hostNetwork:
-                              description: Host networking requested for this pod.
-                                Use the host's network namespace. If this option is
-                                set, the ports that will be used must be specified.
+                              description: |-
+                                Host networking requested for this pod. Use the host's network namespace.
+                                If this option is set, the ports that will be used must be specified.
                                 Default to false.
                               type: boolean
                             hostPID:
-                              description: 'Use the host''s pid namespace. Optional:
-                                Default to false.'
+                              description: |-
+                                Use the host's pid namespace.
+                                Optional: Default to false.
                               type: boolean
                             hostUsers:
-                              description: 'Use the host''s user namespace. Optional:
-                                Default to true. If set to true or not present, the
-                                pod will be run in the host user namespace, useful
-                                for when the pod needs a feature only available to
-                                the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE. When set to false, a new
-                                userns is created for the pod.'
+                              description: |-
+                                Use the host's user namespace.
+                                Optional: Default to true.
+                                If set to true or not present, the pod will be run in the host user namespace, useful
+                                for when the pod needs a feature only available to the host user namespace, such as
+                                loading a kernel module with CAP_SYS_MODULE.
+                                When set to false, a new userns is created for the pod.
                               type: boolean
                             hostname:
-                              description: Specifies the hostname of the Pod If not
-                                specified, the pod's hostname will be set to a system-defined
-                                value.
+                              description: |-
+                                Specifies the hostname of the Pod
+                                If not specified, the pod's hostname will be set to a system-defined value.
                               type: string
                             imagePullSecrets:
-                              description: 'ImagePullSecrets is an optional list of
-                                references to secrets in the same namespace to use
-                                for pulling any of the images used by this PodSpec.
-                                If specified, these secrets will be passed to individual
-                                puller implementations for them to use. More info:
-                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                              description: |-
+                                ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                If specified, these secrets will be passed to individual puller implementations for them to use.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                               items:
-                                description: LocalObjectReference contains enough
-                                  information to let you locate the referenced object
-                                  inside the same namespace.
+                                description: |-
+                                  LocalObjectReference contains enough information to let you locate the
+                                  referenced object inside the same namespace.
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               type: array
                             initContainers:
-                              description: List of initialization containers belonging
-                                to the pod. Init containers are executed in order
-                                prior to containers being started. If any init container
-                                fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy. The name for
-                                an init container or normal container must be unique
-                                among all containers.
+                              description: |-
+                                List of initialization containers belonging to the pod.
+                                Init containers are executed in order prior to containers being started. If any
+                                init container fails, the pod is considered to have failed and is handled according
+                                to its restartPolicy. The name for an init container or normal container must be
+                                unique among all containers.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
-                                      provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The container image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
-                                      used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The container image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -4087,16 +3706,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -4110,10 +3726,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -4124,11 +3740,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -4144,12 +3758,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -4183,10 +3794,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -4202,15 +3813,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -4219,10 +3828,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -4239,10 +3848,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -4253,48 +3862,43 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images
-                                      This field is optional to allow higher level
-                                      config management to default or override container
-                                      images in workload controllers like Deployments
-                                      and StatefulSets.'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system
-                                      should take in response to container lifecycle
-                                      events. Cannot be updated.
+                                    description: |-
+                                      Actions that the management system should take in response to container lifecycle events.
+                                      Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4304,10 +3908,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -4319,11 +3922,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -4342,25 +3943,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -4371,41 +3971,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4415,10 +4008,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -4430,11 +4022,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -4453,25 +4043,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -4482,10 +4071,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -4493,35 +4082,31 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness.
+                                    description: |-
+                                      Periodic probe of container liveness.
                                       Container will be restarted if the probe fails.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -4534,11 +4119,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -4548,9 +4134,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -4560,11 +4146,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -4582,36 +4166,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -4626,55 +4209,52 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as
-                                      a DNS_LABEL. Each container in a pod must have
-                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    description: |-
+                                      Name of the container specified as a DNS_LABEL.
+                                      Each container in a pod must have a unique name (DNS_LABEL).
+                                      Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the
-                                      container. Not specifying a port here DOES NOT
-                                      prevent that port from being exposed. Any port
-                                      which is listening on the default "0.0.0.0"
-                                      address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
+                                    description: |-
+                                      List of ports to expose from the container. Not specifying a port here
+                                      DOES NOT prevent that port from being exposed. Any port which is
+                                      listening on the default "0.0.0.0" address inside a container will be
+                                      accessible from the network.
+                                      Modifying this array with strategic merge patch may corrupt the data.
                                       For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -4682,24 +4262,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -4710,36 +4290,31 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service
-                                      readiness. Container will be removed from service
-                                      endpoints if the probe fails. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Periodic probe of container service readiness.
+                                      Container will be removed from service endpoints if the probe fails.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -4752,11 +4327,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -4766,9 +4342,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -4778,11 +4354,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -4800,36 +4374,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -4844,30 +4417,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -4878,14 +4448,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -4894,26 +4464,31 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Compute Resources required by this container.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -4929,9 +4504,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -4940,48 +4515,41 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: RestartPolicy defines the restart
-                                      behavior of individual containers in a pod.
-                                      This field may only be set for init containers,
-                                      and the only allowed value is "Always". For
-                                      non-init containers or when this field is not
-                                      specified, the restart behavior is defined by
-                                      the Pod's restart policy and the container type.
+                                    description: |-
+                                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                                      This field may only be set for init containers, and the only allowed value is "Always".
+                                      For non-init containers or when this field is not specified,
+                                      the restart behavior is defined by the Pod's restart policy and the container type.
                                     type: string
                                   securityContext:
-                                    description: 'SecurityContext defines the security
-                                      options the container should be run with. If
-                                      set, the fields of SecurityContext override
-                                      the equivalent fields of PodSecurityContext.
-                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    description: |-
+                                      SecurityContext defines the security options the container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -4999,68 +4567,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -5080,52 +4639,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -5133,60 +4684,46 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: StartupProbe indicates that the Pod
-                                      has successfully initialized. If specified,
-                                      no other probes are executed until this completes
-                                      successfully. If this probe fails, the Pod will
-                                      be restarted, just as if the livenessProbe failed.
+                                    description: |-
+                                      StartupProbe indicates that the Pod has successfully initialized.
+                                      If specified, no other probes are executed until this completes successfully.
+                                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -5199,11 +4736,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -5213,9 +4751,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -5225,11 +4763,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -5247,36 +4783,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -5291,72 +4826,62 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -5380,46 +4905,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -5427,47 +4951,54 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             nodeName:
-                              description: NodeName is a request to schedule this
-                                pod onto a specific node. If it is non-empty, the
-                                scheduler simply schedules this pod onto that node,
-                                assuming that it fits resource requirements.
+                              description: |-
+                                NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
+                                the scheduler simply schedules this pod onto that node, assuming that it fits resource
+                                requirements.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: 'NodeSelector is a selector which must
-                                be true for the pod to fit on a node. Selector which
-                                must match a node''s labels for the pod to be scheduled
-                                on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                              description: |-
+                                NodeSelector is a selector which must be true for the pod to fit on a node.
+                                Selector which must match a node's labels for the pod to be scheduled on that node.
+                                More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                               type: object
                               x-kubernetes-map-type: atomic
                             os:
-                              description: "Specifies the OS of the containers in
-                                the pod. Some pod and container fields are restricted
-                                if this is set. \n If the OS field is set to linux,
-                                the following fields must be unset: -securityContext.windowsOptions
-                                \n If the OS field is set to windows, following fields
-                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
-                                - spec.securityContext.seLinuxOptions - spec.securityContext."
+                              description: |-
+                                Specifies the OS of the containers in the pod.
+                                Some pod and container fields are restricted if this is set.
+
+
+                                If the OS field is set to linux, the following fields must be unset:
+                                -securityContext.windowsOptions
+
+
+                                If the OS field is set to windows, following fields must be unset:
+                                - spec.hostPID
+                                - spec.hostIPC
+                                - spec.hostUsers
+                                - spec.securityContext.seLinuxOptions
+                                - spec.securityContext.
                               properties:
                                 name:
-                                  description: 'Name is the name of the operating
-                                    system. The currently supported values are linux
-                                    and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                    Clients should expect to handle additional values
-                                    and treat unrecognized values in this field as
-                                    os: null'
+                                  description: |-
+                                    Name is the name of the operating system. The currently supported values are linux and windows.
+                                    Additional value may be defined in future and can be one of:
+                                    https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values and treat unrecognized values in this field as os: null
                                   type: string
                               required:
                               - name
@@ -5479,44 +5010,43 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: Overhead represents the resource overhead
-                                associated with running a pod for a given RuntimeClass.
-                                This field will be autopopulated at admission time
-                                by the RuntimeClass admission controller. If the RuntimeClass
-                                admission controller is enabled, overhead must not
-                                be set in Pod create requests. The RuntimeClass admission
-                                controller will reject Pod create requests which have
-                                the overhead already set.
+                              description: |-
+                                Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                                This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                                the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                                The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                                set.
                               type: object
                             preemptionPolicy:
-                              description: PreemptionPolicy is the Policy for preempting
-                                pods with lower priority. One of Never, PreemptLowerPriority.
+                              description: |-
+                                PreemptionPolicy is the Policy for preempting pods with lower priority.
+                                One of Never, PreemptLowerPriority.
                                 Defaults to PreemptLowerPriority if unset.
                               type: string
                             priority:
-                              description: The priority value. Various system components
-                                use this field to find the priority of the pod. When
-                                Priority Admission Controller is enabled, it prevents
-                                users from setting this field. The admission controller
-                                populates this field from PriorityClassName. The higher
-                                the value, the higher the priority.
+                              description: |-
+                                The priority value. Various system components use this field to find the
+                                priority of the pod. When Priority Admission Controller is enabled, it
+                                prevents users from setting this field. The admission controller populates
+                                this field from PriorityClassName.
+                                The higher the value, the higher the priority.
                               format: int32
                               type: integer
                             priorityClassName:
-                              description: If specified, indicates the pod's priority.
-                                "system-node-critical" and "system-cluster-critical"
-                                are two special keywords which indicate the highest
-                                priorities with the former being the highest priority.
-                                Any other name must be defined by creating a PriorityClass
-                                object with that name. If not specified, the pod priority
-                                will be default or zero if there is no default.
+                              description: |-
+                                If specified, indicates the pod's priority. "system-node-critical" and
+                                "system-cluster-critical" are two special keywords which indicate the
+                                highest priorities with the former being the highest priority. Any other
+                                name must be defined by creating a PriorityClass object with that name.
+                                If not specified, the pod priority will be default or zero if there is no
+                                default.
                               type: string
                             readinessGates:
-                              description: 'If specified, all readiness gates will
-                                be evaluated for pod readiness. A pod is ready when
-                                all its containers are ready AND all conditions specified
-                                in the readiness gates have status equal to "True"
-                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                              description: |-
+                                If specified, all readiness gates will be evaluated for pod readiness.
+                                A pod is ready when all its containers are ready AND
+                                all conditions specified in the readiness gates have status equal to "True"
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
                               items:
                                 description: PodReadinessGate contains the reference
                                   to a pod condition
@@ -5530,40 +5060,47 @@ spec:
                                 type: object
                               type: array
                             resourceClaims:
-                              description: "ResourceClaims defines which ResourceClaims
-                                must be allocated and reserved before the Pod is allowed
-                                to start. The resources will be made available to
-                                those containers which consume them by name. \n This
-                                is an alpha field and requires enabling the DynamicResourceAllocation
-                                feature gate. \n This field is immutable."
+                              description: |-
+                                ResourceClaims defines which ResourceClaims must be allocated
+                                and reserved before the Pod is allowed to start. The resources
+                                will be made available to those containers which consume them
+                                by name.
+
+
+                                This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate.
+
+
+                                This field is immutable.
                               items:
-                                description: PodResourceClaim references exactly one
-                                  ResourceClaim through a ClaimSource. It adds a name
-                                  to it that uniquely identifies the ResourceClaim
-                                  inside the Pod. Containers that need access to the
-                                  ResourceClaim reference it with this name.
+                                description: |-
+                                  PodResourceClaim references exactly one ResourceClaim through a ClaimSource.
+                                  It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                                  Containers that need access to the ResourceClaim reference it with this name.
                                 properties:
                                   name:
-                                    description: Name uniquely identifies this resource
-                                      claim inside the pod. This must be a DNS_LABEL.
+                                    description: |-
+                                      Name uniquely identifies this resource claim inside the pod.
+                                      This must be a DNS_LABEL.
                                     type: string
                                   source:
                                     description: Source describes where to find the
                                       ResourceClaim.
                                     properties:
                                       resourceClaimName:
-                                        description: ResourceClaimName is the name
-                                          of a ResourceClaim object in the same namespace
-                                          as this pod.
+                                        description: |-
+                                          ResourceClaimName is the name of a ResourceClaim object in the same
+                                          namespace as this pod.
                                         type: string
                                       resourceClaimTemplateName:
-                                        description: "ResourceClaimTemplateName is
-                                          the name of a ResourceClaimTemplate object
-                                          in the same namespace as this pod. \n The
-                                          template will be used to create a new ResourceClaim,
-                                          which will be bound to this pod. When this
-                                          pod is deleted, the ResourceClaim will also
-                                          be deleted."
+                                        description: |-
+                                          ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                          object in the same namespace as this pod.
+
+
+                                          The template will be used to create a new ResourceClaim, which will
+                                          be bound to this pod. When this pod is deleted, the ResourceClaim
+                                          will also be deleted.
                                         type: string
                                     type: object
                                 required:
@@ -5574,42 +5111,44 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             restartPolicy:
-                              description: 'Restart policy for all containers within
-                                the pod. One of Always, OnFailure, Never. In some
-                                contexts, only a subset of those values may be permitted.
-                                Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                              description: |-
+                                Restart policy for all containers within the pod.
+                                One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                                Default to Always.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass
-                                object in the node.k8s.io group, which should be used
-                                to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run. If unset
-                                or empty, the "legacy" RuntimeClass will be used,
-                                which is an implicit class with an empty definition
-                                that uses the default runtime handler. More info:
-                                https://git.k8s.'
+                              description: |-
+                                RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                                to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                                If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                                empty definition that uses the default runtime handler.
+                                More info: https://git.k8s.
                               type: string
                             schedulerName:
-                              description: If specified, the pod will be dispatched
-                                by specified scheduler. If not specified, the pod
-                                will be dispatched by default scheduler.
+                              description: |-
+                                If specified, the pod will be dispatched by specified scheduler.
+                                If not specified, the pod will be dispatched by default scheduler.
                               type: string
                             schedulingGates:
-                              description: "SchedulingGates is an opaque list of values
-                                that if specified will block scheduling the pod. If
-                                schedulingGates is not empty, the pod will stay in
-                                the SchedulingGated state and the scheduler will not
-                                attempt to schedule the pod. \n SchedulingGates can
-                                only be set at pod creation time, and be removed only
-                                afterwards. \n This is a beta feature enabled by the
-                                PodSchedulingReadiness feature gate."
+                              description: |-
+                                SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                                If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                                scheduler will not attempt to schedule the pod.
+
+
+                                SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+
+
+                                This is a beta feature enabled by the PodSchedulingReadiness feature gate.
                               items:
                                 description: PodSchedulingGate is associated to a
                                   Pod to guard its scheduling.
                                 properties:
                                   name:
-                                    description: Name of the scheduling gate. Each
-                                      scheduling gate must have a unique name field.
+                                    description: |-
+                                      Name of the scheduling gate.
+                                      Each scheduling gate must have a unique name field.
                                     type: string
                                 required:
                                 - name
@@ -5619,70 +5158,67 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             securityContext:
-                              description: 'SecurityContext holds pod-level security
-                                attributes and common container settings. Optional:
-                                Defaults to empty.  See type description for default
-                                values of each field.'
+                              description: |-
+                                SecurityContext holds pod-level security attributes and common container settings.
+                                Optional: Defaults to empty.  See type description for default values of each field.
                               properties:
                                 fsGroup:
-                                  description: "A special supplemental group that
-                                    applies to all containers in a pod. Some volume
-                                    types allow the Kubelet to change the ownership
-                                    of that volume to be owned by the pod: \n 1. The
-                                    owning GID will be the FSGroup 2. The setgid bit
-                                    is set (new files created in the volume will be
-                                    owned by FSGroup) 3."
+                                  description: |-
+                                    A special supplemental group that applies to all containers in a pod.
+                                    Some volume types allow the Kubelet to change the ownership of that volume
+                                    to be owned by the pod:
+
+
+                                    1. The owning GID will be the FSGroup
+                                    2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                    3.
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior
-                                    of changing ownership and permission of the volume
-                                    before being exposed inside Pod. This field will
-                                    only apply to volume types which support fsGroup
-                                    based ownership(and permissions). It will have
-                                    no effect on ephemeral volume types such as: secret,
-                                    configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified, "Always" is used.'
+                                  description: |-
+                                    fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                    before being exposed inside Pod. This field will only apply to
+                                    volume types which support fsGroup based ownership(and permissions).
+                                    It will have no effect on ephemeral volume types such as: secret, configmaps
+                                    and emptydir.
+                                    Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
                                   type: string
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in SecurityContext.  If set in
-                                    both SecurityContext and PodSecurityContext, the
-                                    value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in SecurityContext.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in SecurityContext.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence for that container.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    all containers. If unspecified, the container
-                                    runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                  description: |-
+                                    The SELinux context to be applied to all containers.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in SecurityContext.  If set in
+                                    both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                    takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5702,49 +5238,45 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by the containers
-                                    in this pod. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by the containers in this pod.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must be set if type is "Localhost".
-                                        Must NOT be set for any other type.
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first
-                                    process run in each container, in addition to
-                                    the container's primary GID, the fsGroup (if specified),
-                                    and group memberships defined in the container
-                                    image for the uid of the container process. If
-                                    unspecified, no additional groups are added to
-                                    any container.
+                                  description: |-
+                                    A list of groups applied to the first process run in each container, in addition
+                                    to the container's primary GID, the fsGroup (if specified), and group memberships
+                                    defined in the container image for the uid of the container process. If unspecified,
+                                    no additional groups are added to any container.
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls
-                                    used for the pod. Pods with unsupported sysctls
-                                    (by the container runtime) might fail to launch.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                    sysctls (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   items:
                                     description: Sysctl defines a kernel parameter
                                       to be set
@@ -5761,173 +5293,151 @@ spec:
                                     type: object
                                   type: array
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    within a container's SecurityContext will be used.
-                                    If set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options within a container's SecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        All of a Pod's containers must have the same
-                                        effective HostProcess value (it is not allowed
-                                        to have a mix of HostProcess containers and
-                                        non-HostProcess containers). In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: 'DeprecatedServiceAccount is a depreciated
-                                alias for ServiceAccountName. Deprecated: Use serviceAccountName
-                                instead.'
+                              description: |-
+                                DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+                                Deprecated: Use serviceAccountName instead.
                               type: string
                             serviceAccountName:
-                              description: 'ServiceAccountName is the name of the
-                                ServiceAccount to use to run this pod. More info:
-                                https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                              description: |-
+                                ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                               type: string
                             setHostnameAsFQDN:
-                              description: If true the pod's hostname will be configured
-                                as the pod's FQDN, rather than the leaf name (the
-                                default). In Linux containers, this means setting
-                                the FQDN in the hostname field of the kernel (the
-                                nodename field of struct utsname).
+                              description: |-
+                                If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                                In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between
-                                all of the containers in a pod. When this is set containers
-                                will be able to view and signal processes from other
-                                containers in the same pod, and the first process
-                                in each container will not be assigned PID 1. HostPID
-                                and ShareProcessNamespace cannot both be set. Optional:
-                                Default to false.'
+                              description: |-
+                                Share a single process namespace between all of the containers in a pod.
+                                When this is set containers will be able to view and signal processes from other containers
+                                in the same pod, and the first process in each container will not be assigned PID 1.
+                                HostPID and ShareProcessNamespace cannot both be set.
+                                Optional: Default to false.
                               type: boolean
                             subdomain:
-                              description: If specified, the fully qualified Pod hostname
-                                will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                                domain>". If not specified, the pod will not have
-                                a domainname at all.
+                              description: |-
+                                If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                                If not specified, the pod will not have a domainname at all.
                               type: string
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs
-                                to terminate gracefully. May be decreased in delete
-                                request. Value must be non-negative integer. The value
-                                zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down). If this value is nil,
-                                the default grace period will be used instead.
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                If this value is nil, the default grace period will be used instead.
                               format: int64
                               type: integer
                             tolerations:
                               description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to
-                                  tolerates any taint that matches the triple <key,value,effect>
-                                  using the matching operator <operator>.
+                                description: |-
+                                  The pod this Toleration is attached to tolerates any taint that matches
+                                  the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect
-                                      to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule,
-                                      PreferNoSchedule and NoExecute.
+                                    description: |-
+                                      Effect indicates the taint effect to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration
-                                      applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists;
-                                      this combination means to match all values and
-                                      all keys.
+                                    description: |-
+                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship
-                                      to the value. Valid operators are Exists and
-                                      Equal. Defaults to Equal. Exists is equivalent
-                                      to wildcard for value, so that a pod can tolerate
-                                      all taints of a particular category.
+                                    description: |-
+                                      Operator represents a key's relationship to the value.
+                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Exists is equivalent to wildcard for value, so that a pod can
+                                      tolerate all taints of a particular category.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the
-                                      period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is
-                                      ignored) tolerates the taint. By default, it
-                                      is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
+                                    description: |-
+                                      TolerationSeconds represents the period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                      negative values will be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration
-                                      matches to. If the operator is Exists, the value
-                                      should be empty, otherwise just a regular string.
+                                    description: |-
+                                      Value is the taint value the toleration matches to.
+                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how
-                                a group of pods ought to spread across topology domains.
-                                Scheduler will schedule pods in a way which abides
-                                by the constraints. All topologySpreadConstraints
-                                are ANDed.
+                              description: |-
+                                TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                                domains. Scheduler will schedule pods in a way which abides by the constraints.
+                                All topologySpreadConstraints are ANDed.
                               items:
                                 description: TopologySpreadConstraint specifies how
                                   to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: LabelSelector is used to find matching
-                                      pods. Pods that match this label selector are
-                                      counted to determine the number of pods in their
-                                      corresponding topology domain.
+                                    description: |-
+                                      LabelSelector is used to find matching pods.
+                                      Pods that match this label selector are counted to determine the number of pods
+                                      in their corresponding topology domain.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
                                           label selector requirements. The requirements
                                           are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -5940,91 +5450,79 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label
-                                      keys to select the pods over which spreading
-                                      will be calculated. The keys are used to lookup
-                                      values from the incoming pod labels, those key-value
-                                      labels are ANDed with labelSelector to select
-                                      the group of existing pods over which spreading
-                                      will be calculated for the incoming pod. The
-                                      same key is forbidden to exist in both MatchLabelKeys
-                                      and LabelSelector.
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select the pods over which
+                                      spreading will be calculated. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are ANDed with labelSelector
+                                      to select the group of existing pods over which spreading will be calculated
+                                      for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   maxSkew:
-                                    description: MaxSkew describes the degree to which
-                                      pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                                      it is the maximum permitted difference between
-                                      the number of matching pods in the target topology
-                                      and the global minimum. The global minimum is
-                                      the minimum number of matching pods in an eligible
-                                      domain or zero if the number of eligible domains
-                                      is less than MinDomains.
+                                    description: |-
+                                      MaxSkew describes the degree to which pods may be unevenly distributed.
+                                      When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                      between the number of matching pods in the target topology and the global minimum.
+                                      The global minimum is the minimum number of matching pods in an eligible domain
+                                      or zero if the number of eligible domains is less than MinDomains.
                                     format: int32
                                     type: integer
                                   minDomains:
-                                    description: MinDomains indicates a minimum number
-                                      of eligible domains. When the number of eligible
-                                      domains with matching topology keys is less
-                                      than minDomains, Pod Topology Spread treats
-                                      "global minimum" as 0, and then the calculation
-                                      of Skew is performed. And when the number of
-                                      eligible domains with matching topology keys
-                                      equals or greater than minDomains, this value
-                                      has no effect on scheduling.
+                                    description: |-
+                                      MinDomains indicates a minimum number of eligible domains.
+                                      When the number of eligible domains with matching topology keys is less than minDomains,
+                                      Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                      And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                      this value has no effect on scheduling.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: "NodeAffinityPolicy indicates how
-                                      we will treat Pod's nodeAffinity/nodeSelector
-                                      when calculating pod topology spread skew. Options
-                                      are: - Honor: only nodes matching nodeAffinity/nodeSelector
-                                      are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored. All nodes
-                                      are included in the calculations. \n If this
-                                      value is nil, the behavior is equivalent to
-                                      the Honor policy."
+                                    description: |-
+                                      NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                      when calculating pod topology spread skew. Options are:
+                                      - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                      - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                                      If this value is nil, the behavior is equivalent to the Honor policy.
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: "NodeTaintsPolicy indicates how we
-                                      will treat node taints when calculating pod
-                                      topology spread skew. Options are: - Honor:
-                                      nodes without taints, along with tainted nodes
-                                      for which the incoming pod has a toleration,
-                                      are included. - Ignore: node taints are ignored.
-                                      All nodes are included. \n If this value is
-                                      nil, the behavior is equivalent to the Ignore
-                                      policy."
+                                    description: |-
+                                      NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                      pod topology spread skew. Options are:
+                                      - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                      has a toleration, are included.
+                                      - Ignore: node taints are ignored. All nodes are included.
+
+
+                                      If this value is nil, the behavior is equivalent to the Ignore policy.
                                     type: string
                                   topologyKey:
-                                    description: TopologyKey is the key of node labels.
-                                      Nodes that have a label with this key and identical
-                                      values are considered to be in the same topology.
-                                      We consider each <key, value> as a "bucket",
-                                      and try to put balanced number of pods into
-                                      each bucket. We define a domain as a particular
-                                      instance of a topology.
+                                    description: |-
+                                      TopologyKey is the key of node labels. Nodes that have a label with this key
+                                      and identical values are considered to be in the same topology.
+                                      We consider each <key, value> as a "bucket", and try to put balanced number
+                                      of pods into each bucket.
+                                      We define a domain as a particular instance of a topology.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: WhenUnsatisfiable indicates how to
-                                      deal with a pod if it doesn't satisfy the spread
-                                      constraint. - DoNotSchedule (default) tells
-                                      the scheduler not to schedule it. - ScheduleAnyway
-                                      tells the scheduler to schedule the pod in any
-                                      location, but giving higher precedence to topologies
-                                      that would help reduce the skew.
+                                    description: |-
+                                      WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                      the spread constraint.
+                                      - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                      - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                        but giving higher precedence to topologies that would help reduce the
+                                        skew.
                                     type: string
                                 required:
                                 - maxSkew
@@ -6037,49 +5535,45 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: 'List of volumes that can be mounted by
-                                containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                              description: |-
+                                List of volumes that can be mounted by containers belonging to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes
                               items:
                                 description: Volume represents a named volume in a
                                   pod that may be accessed by any container in the
                                   pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'awsElasticBlockStore represents
-                                      an AWS Disk resource that is attached to a kubelet''s
-                                      host machine and then exposed to the pod. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    description: |-
+                                      awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       partition:
-                                        description: 'partition is the partition in
-                                          the volume that you want to mount. If omitted,
-                                          the default is to mount by volume name.
-                                          Examples: For volume /dev/sda1, you specify
-                                          the partition as "1". Similarly, the volume
-                                          partition for /dev/sda is "0" (or you can
-                                          leave the property empty).'
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'readOnly value true will force
-                                          the readOnly setting in VolumeMounts. More
-                                          info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: |-
+                                          readOnly value true will force the readOnly setting in VolumeMounts.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                         type: boolean
                                       volumeID:
-                                        description: 'volumeID is unique ID of the
-                                          persistent disk resource in AWS (Amazon
-                                          EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: |-
+                                          volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                         type: string
                                     required:
                                     - volumeID
@@ -6102,11 +5596,10 @@ spec:
                                           in the blob storage
                                         type: string
                                       fsType:
-                                        description: fsType is Filesystem type to
-                                          mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is Filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       kind:
                                         description: 'kind expected values are Shared:
@@ -6116,9 +5609,9 @@ spec:
                                           availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: readOnly Defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                     required:
                                     - diskName
@@ -6130,9 +5623,9 @@ spec:
                                       the pod.
                                     properties:
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretName:
                                         description: secretName is the  name of secret
@@ -6152,9 +5645,9 @@ spec:
                                       on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'monitors is Required: Monitors
-                                          is a collection of Ceph monitors More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          monitors is Required: Monitors is a collection of Ceph monitors
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         items:
                                           type: string
                                         type: array
@@ -6164,71 +5657,72 @@ spec:
                                           tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'readOnly is Optional: Defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.
-                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: boolean
                                       secretFile:
-                                        description: 'secretFile is Optional: SecretFile
-                                          is the path to key ring for User, default
-                                          is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: string
                                       secretRef:
-                                        description: 'secretRef is Optional: SecretRef
-                                          is reference to the authentication secret
-                                          for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       user:
-                                        description: 'user is optional: User is the
-                                          rados user name, default is admin More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          user is optional: User is the rados user name, default is admin
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'cinder represents a cinder volume
-                                      attached and mounted on kubelets host machine.
-                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    description: |-
+                                      cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: string
                                       readOnly:
-                                        description: 'readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is optional: points
-                                          to a secret object containing parameters
-                                          used to connect to OpenStack.'
+                                        description: |-
+                                          secretRef is optional: points to a secret object containing parameters used to connect
+                                          to OpenStack.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       volumeID:
-                                        description: 'volumeID used to identify the
-                                          volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          volumeID used to identify the volume in cinder.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: string
                                     required:
                                     - volumeID
@@ -6238,25 +5732,21 @@ spec:
                                       that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'defaultMode is optional: mode
-                                          bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          defaultMode is optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
-                                        description: items if unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          ConfigMap will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present.
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -6265,23 +5755,19 @@ spec:
                                               description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'mode is Optional: mode
-                                                bits used to set permissions on this
-                                                file. Must be an octal value between
-                                                0000 and 0777 or a decimal value between
-                                                0 and 511. YAML accepts both octal
-                                                and decimal values, JSON requires
-                                                decimal values for mode bits. If not
-                                                specified, the volume defaultMode
-                                                will be used.'
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
-                                              description: path is the relative path
-                                                of the file to map the key to. May
-                                                not be an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -6289,10 +5775,10 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: optional specify whether the
@@ -6306,48 +5792,43 @@ spec:
                                       by certain external CSI drivers (Beta feature).
                                     properties:
                                       driver:
-                                        description: driver is the name of the CSI
-                                          driver that handles this volume. Consult
-                                          with your admin for the correct name as
-                                          registered in the cluster.
+                                        description: |-
+                                          driver is the name of the CSI driver that handles this volume.
+                                          Consult with your admin for the correct name as registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: fsType to mount. Ex. "ext4",
-                                          "xfs", "ntfs". If not provided, the empty
-                                          value is passed to the associated CSI driver
-                                          which will determine the default filesystem
-                                          to apply.
+                                        description: |-
+                                          fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                          If not provided, the empty value is passed to the associated CSI driver
+                                          which will determine the default filesystem to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: nodePublishSecretRef is a reference
-                                          to the secret object containing sensitive
-                                          information to pass to the CSI driver to
-                                          complete the CSI NodePublishVolume and NodeUnpublishVolume
-                                          calls. This field is optional, and  may
-                                          be empty if no secret is required. If the
-                                          secret object contains more than one secret,
-                                          all secret references are passed.
+                                        description: |-
+                                          nodePublishSecretRef is a reference to the secret object containing
+                                          sensitive information to pass to the CSI driver to complete the CSI
+                                          NodePublishVolume and NodeUnpublishVolume calls.
+                                          This field is optional, and  may be empty if no secret is required. If the
+                                          secret object contains more than one secret, all secret references are passed.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       readOnly:
-                                        description: readOnly specifies a read-only
-                                          configuration for the volume. Defaults to
-                                          false (read/write).
+                                        description: |-
+                                          readOnly specifies a read-only configuration for the volume.
+                                          Defaults to false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: volumeAttributes stores driver-specific
-                                          properties that are passed to the CSI driver.
-                                          Consult your driver's documentation for
-                                          supported values.
+                                        description: |-
+                                          volumeAttributes stores driver-specific properties that are passed to the CSI
+                                          driver. Consult your driver's documentation for supported values.
                                         type: object
                                     required:
                                     - driver
@@ -6357,16 +5838,13 @@ spec:
                                       about the pod that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on
-                                          created files by default. Must be a Optional:
-                                          mode bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          Optional: mode bits to use on created files by default. Must be a
+                                          Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
@@ -6396,14 +5874,11 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file, must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.'
+                                              description: |-
+                                                Optional: mode bits used to set permissions on this file, must be an octal value
+                                                between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
@@ -6415,11 +5890,9 @@ spec:
                                                 path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                requests.cpu and requests.memory)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -6449,56 +5922,51 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'emptyDir represents a temporary
-                                      directory that shares a pod''s lifetime. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    description: |-
+                                      emptyDir represents a temporary directory that shares a pod's lifetime.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     properties:
                                       medium:
-                                        description: 'medium represents what type
-                                          of storage medium should back this directory.
-                                          The default is "" which means to use the
-                                          node''s default medium. Must be an empty
-                                          string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: |-
+                                          medium represents what type of storage medium should back this directory.
+                                          The default is "" which means to use the node's default medium.
+                                          Must be an empty string (default) or Memory.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'sizeLimit is the total amount
-                                          of local storage required for this EmptyDir
-                                          volume. The size limit is also applicable
-                                          for memory medium. The maximum usage on
-                                          memory medium EmptyDir would be the minimum
-                                          value between the SizeLimit specified here
-                                          and the sum of memory limits of all containers
-                                          in a pod. The default is nil which means
-                                          that the limit is undefined. More info:
-                                          https://kubernetes.'
+                                        description: |-
+                                          sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                          The size limit is also applicable for memory medium.
+                                          The maximum usage on memory medium EmptyDir would be the minimum value between
+                                          the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                          The default is nil which means that the limit is undefined.
+                                          More info: https://kubernetes.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: ephemeral represents a volume that
-                                      is handled by a cluster storage driver. The
-                                      volume's lifecycle is tied to the pod that defines
-                                      it - it will be created before the pod starts,
+                                    description: |-
+                                      ephemeral represents a volume that is handled by a cluster storage driver.
+                                      The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                                       and deleted when the pod is removed.
                                     properties:
                                       volumeClaimTemplate:
-                                        description: Will be used to create a stand-alone
-                                          PVC to provision the volume. The pod in
-                                          which this EphemeralVolumeSource is embedded
-                                          will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.  The
-                                          name of the PVC will be `<pod name>-<volume
-                                          name>` where `<volume name>` is the name
-                                          from the `PodSpec.Volumes` array entry.
+                                        description: |-
+                                          Will be used to create a stand-alone PVC to provision the volume.
+                                          The pod in which this EphemeralVolumeSource is embedded will be the
+                                          owner of the PVC, i.e. the PVC will be deleted together with the
+                                          pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                          `<volume name>` is the name from the `PodSpec.Volumes` array
+                                          entry.
                                         properties:
                                           metadata:
-                                            description: May contain labels and annotations
-                                              that will be copied into the PVC when
-                                              creating it. No other fields are allowed
-                                              and will be rejected during validation.
+                                            description: |-
+                                              May contain labels and annotations that will be copied into the PVC
+                                              when creating it. No other fields are allowed and will be rejected during
+                                              validation.
                                             properties:
                                               annotations:
                                                 additionalProperties:
@@ -6518,39 +5986,32 @@ spec:
                                                 type: string
                                             type: object
                                           spec:
-                                            description: The specification for the
-                                              PersistentVolumeClaim. The entire content
-                                              is copied unchanged into the PVC that
-                                              gets created from this template. The
-                                              same fields as in a PersistentVolumeClaim
+                                            description: |-
+                                              The specification for the PersistentVolumeClaim. The entire content is
+                                              copied unchanged into the PVC that gets created from this
+                                              template. The same fields as in a PersistentVolumeClaim
                                               are also valid here.
                                             properties:
                                               accessModes:
-                                                description: 'accessModes contains
-                                                  the desired access modes the volume
-                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                description: |-
+                                                  accessModes contains the desired access modes the volume should have.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                                 items:
                                                   type: string
                                                 type: array
                                               dataSource:
-                                                description: 'dataSource field can
-                                                  be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                description: |-
+                                                  dataSource field can be used to specify either:
+                                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                                   * An existing PVC (PersistentVolumeClaim)
-                                                  If the provisioner or an external
-                                                  controller can support the specified
-                                                  data source, it will create a new
-                                                  volume based on the contents of
-                                                  the specified data source.'
+                                                  If the provisioner or an external controller can support the specified data source,
+                                                  it will create a new volume based on the contents of the specified data source.
                                                 properties:
                                                   apiGroup:
-                                                    description: APIGroup is the group
-                                                      for the resource being referenced.
-                                                      If APIGroup is not specified,
-                                                      the specified Kind must be in
-                                                      the core API group. For any
-                                                      other third-party types, APIGroup
-                                                      is required.
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
                                                     type: string
                                                   kind:
                                                     description: Kind is the type
@@ -6566,26 +6027,19 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               dataSourceRef:
-                                                description: dataSourceRef specifies
-                                                  the object from which to populate
-                                                  the volume with data, if a non-empty
-                                                  volume is desired. This may be any
-                                                  object from a non-empty API group
-                                                  (non core object) or a PersistentVolumeClaim
-                                                  object. When this field is specified,
-                                                  volume binding will only succeed
-                                                  if the type of the specified object
-                                                  matches some installed volume populator
-                                                  or dynamic provisioner.
+                                                description: |-
+                                                  dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                                  volume is desired. This may be any object from a non-empty API group (non
+                                                  core object) or a PersistentVolumeClaim object.
+                                                  When this field is specified, volume binding will only succeed if the type of
+                                                  the specified object matches some installed volume populator or dynamic
+                                                  provisioner.
                                                 properties:
                                                   apiGroup:
-                                                    description: APIGroup is the group
-                                                      for the resource being referenced.
-                                                      If APIGroup is not specified,
-                                                      the specified Kind must be in
-                                                      the core API group. For any
-                                                      other third-party types, APIGroup
-                                                      is required.
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
                                                     type: string
                                                   kind:
                                                     description: Kind is the type
@@ -6596,54 +6050,42 @@ spec:
                                                       of resource being referenced
                                                     type: string
                                                   namespace:
-                                                    description: Namespace is the
-                                                      namespace of resource being
-                                                      referenced Note that when a
-                                                      namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
-                                                      object is required in the referent
-                                                      namespace to allow that namespace's
-                                                      owner to accept the reference.
-                                                      See the ReferenceGrant documentation
-                                                      for details. (Alpha) This field
-                                                      requires the CrossNamespaceVolumeDataSource
-                                                      feature gate to be enabled.
+                                                    description: |-
+                                                      Namespace is the namespace of resource being referenced
+                                                      Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                      (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                                     type: string
                                                 required:
                                                 - kind
                                                 - name
                                                 type: object
                                               resources:
-                                                description: 'resources represents
-                                                  the minimum resources the volume
-                                                  should have. If RecoverVolumeExpansionFailure
-                                                  feature is enabled users are allowed
-                                                  to specify resource requirements
-                                                  that are lower than previous value
-                                                  but must still be higher than capacity
-                                                  recorded in the status field of
-                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                description: |-
+                                                  resources represents the minimum resources the volume should have.
+                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  that are lower than previous value but must still be higher than capacity recorded in the
+                                                  status field of the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                                 properties:
                                                   claims:
-                                                    description: "Claims lists the
-                                                      names of resources, defined
-                                                      in spec.resourceClaims, that
-                                                      are used by this container.
-                                                      \n This is an alpha field and
-                                                      requires enabling the DynamicResourceAllocation
-                                                      feature gate. \n This field
-                                                      is immutable. It can only be
-                                                      set for containers."
+                                                    description: |-
+                                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                                      that are used by this container.
+
+
+                                                      This is an alpha field and requires enabling the
+                                                      DynamicResourceAllocation feature gate.
+
+
+                                                      This field is immutable. It can only be set for containers.
                                                     items:
                                                       description: ResourceClaim references
                                                         one entry in PodSpec.ResourceClaims.
                                                       properties:
                                                         name:
-                                                          description: Name must match
-                                                            the name of one entry
-                                                            in pod.spec.resourceClaims
-                                                            of the Pod where this
-                                                            field is used. It makes
-                                                            that resource available
+                                                          description: |-
+                                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                                            the Pod where this field is used. It makes that resource available
                                                             inside a container.
                                                           type: string
                                                       required:
@@ -6660,10 +6102,9 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: 'Limits describes
-                                                      the maximum amount of compute
-                                                      resources allowed. More info:
-                                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    description: |-
+                                                      Limits describes the maximum amount of compute resources allowed.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -6672,15 +6113,11 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: 'Requests describes
-                                                      the minimum amount of compute
-                                                      resources required. If Requests
-                                                      is omitted for a container,
-                                                      it defaults to Limits if that
-                                                      is explicitly specified, otherwise
-                                                      to an implementation-defined
-                                                      value. Requests cannot exceed
-                                                      Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    description: |-
+                                                      Requests describes the minimum amount of compute resources required.
+                                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                 type: object
                                               selector:
@@ -6693,11 +6130,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -6705,23 +6140,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -6733,28 +6161,22 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               storageClassName:
-                                                description: 'storageClassName is
-                                                  the name of the StorageClass required
-                                                  by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                description: |-
+                                                  storageClassName is the name of the StorageClass required by the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                                 type: string
                                               volumeMode:
-                                                description: volumeMode defines what
-                                                  type of volume is required by the
-                                                  claim. Value of Filesystem is implied
-                                                  when not included in claim spec.
+                                                description: |-
+                                                  volumeMode defines what type of volume is required by the claim.
+                                                  Value of Filesystem is implied when not included in claim spec.
                                                 type: string
                                               volumeName:
                                                 description: volumeName is the binding
@@ -6772,13 +6194,11 @@ spec:
                                       and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. TODO: how do we prevent
-                                          errors in the filesystem from compromising
-                                          the machine'
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       lun:
                                         description: 'lun is Optional: FC target lun
@@ -6786,9 +6206,9 @@ spec:
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'readOnly is Optional: Defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.'
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       targetWWNs:
                                         description: 'targetWWNs is Optional: FC target
@@ -6797,29 +6217,27 @@ spec:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'wwids Optional: FC volume world
-                                          wide identifiers (wwids) Either wwids or
-                                          combination of targetWWNs and lun must be
-                                          set, but not both simultaneously.'
+                                        description: |-
+                                          wwids Optional: FC volume world wide identifiers (wwids)
+                                          Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: flexVolume represents a generic volume
-                                      resource that is provisioned/attached using
-                                      an exec based plugin.
+                                    description: |-
+                                      flexVolume represents a generic volume resource that is
+                                      provisioned/attached using an exec based plugin.
                                     properties:
                                       driver:
                                         description: driver is the name of the driver
                                           to use for this volume.
                                         type: string
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". The default filesystem depends
-                                          on FlexVolume script.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
@@ -6828,24 +6246,23 @@ spec:
                                           holds extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'readOnly is Optional: defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.'
+                                        description: |-
+                                          readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is Optional: secretRef
-                                          is reference to the secret object containing
-                                          sensitive information to pass to the plugin
-                                          scripts. This may be empty if no secret
-                                          object is specified. If the secret object
-                                          contains more than one secret, all secrets
-                                          are passed to the plugin scripts.'
+                                        description: |-
+                                          secretRef is Optional: secretRef is reference to the secret object containing
+                                          sensitive information to pass to the plugin scripts. This may be
+                                          empty if no secret object is specified. If the secret object
+                                          contains more than one secret, all secrets are passed to the plugin
+                                          scripts.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -6858,9 +6275,9 @@ spec:
                                       on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: datasetName is Name of the dataset
-                                          stored as metadata -> name on the dataset
-                                          for Flocker should be considered as deprecated
+                                        description: |-
+                                          datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                          should be considered as deprecated
                                         type: string
                                       datasetUUID:
                                         description: datasetUUID is the UUID of the
@@ -6869,60 +6286,55 @@ spec:
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'gcePersistentDisk represents a GCE
-                                      Disk resource that is attached to a kubelet''s
-                                      host machine and then exposed to the pod. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    description: |-
+                                      gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                     properties:
                                       fsType:
-                                        description: 'fsType is filesystem type of
-                                          the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       partition:
-                                        description: 'partition is the partition in
-                                          the volume that you want to mount. If omitted,
-                                          the default is to mount by volume name.
-                                          Examples: For volume /dev/sda1, you specify
-                                          the partition as "1". Similarly, the volume
-                                          partition for /dev/sda is "0" (or you can
-                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'pdName is unique name of the
-                                          PD resource in GCE. Used to identify the
-                                          disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         type: boolean
                                     required:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'gitRepo represents a git repository
-                                      at a particular revision. DEPRECATED: GitRepo
-                                      is deprecated. To provision a container with
-                                      a git repo, mount an EmptyDir into an InitContainer
-                                      that clones the repo using git, then mount the
-                                      EmptyDir into the Pod''s container.'
+                                    description: |-
+                                      gitRepo represents a git repository at a particular revision.
+                                      DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                      EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                      into the Pod's container.
                                     properties:
                                       directory:
-                                        description: directory is the target directory
-                                          name. Must not contain or start with '..'.  If
-                                          '.' is supplied, the volume directory will
-                                          be the git repository.  Otherwise, if specified,
-                                          the volume will contain the git repository
-                                          in the subdirectory with the given name.
+                                        description: |-
+                                          directory is the target directory name.
+                                          Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                          git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                          the subdirectory with the given name.
                                         type: string
                                       repository:
                                         description: repository is the URL
@@ -6935,54 +6347,58 @@ spec:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'glusterfs represents a Glusterfs
-                                      mount on the host that shares a pod''s lifetime.
-                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                    description: |-
+                                      glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                     properties:
                                       endpoints:
-                                        description: 'endpoints is the endpoint name
-                                          that details Glusterfs topology. More info:
-                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          endpoints is the endpoint name that details Glusterfs topology.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: string
                                       path:
-                                        description: 'path is the Glusterfs volume
-                                          path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          path is the Glusterfs volume path.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          Glusterfs volume to be mounted with read-only
-                                          permissions. Defaults to false. More info:
-                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: boolean
                                     required:
                                     - endpoints
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'hostPath represents a pre-existing
-                                      file or directory on the host machine that is
-                                      directly exposed to the container. This is generally
-                                      used for system agents or other privileged things
-                                      that are allowed to see the host machine. Most
-                                      containers will NOT need this. More info: https://kubernetes.'
+                                    description: |-
+                                      hostPath represents a pre-existing file or directory on the host
+                                      machine that is directly exposed to the container. This is generally
+                                      used for system agents or other privileged things that are allowed
+                                      to see the host machine. Most containers will NOT need this.
+                                      More info: https://kubernetes.
                                     properties:
                                       path:
-                                        description: 'path of the directory on the
-                                          host. If the path is a symlink, it will
-                                          follow the link to the real path. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        description: |-
+                                          path of the directory on the host.
+                                          If the path is a symlink, it will follow the link to the real path.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                         type: string
                                       type:
-                                        description: 'type for HostPath Volume Defaults
-                                          to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        description: |-
+                                          type for HostPath Volume
+                                          Defaults to ""
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'iscsi represents an ISCSI Disk resource
-                                      that is attached to a kubelet''s host machine
-                                      and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                    description: |-
+                                      iscsi represents an ISCSI Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://examples.k8s.io/volumes/iscsi/README.md
                                     properties:
                                       chapAuthDiscovery:
                                         description: chapAuthDiscovery defines whether
@@ -6993,31 +6409,27 @@ spec:
                                           support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       initiatorName:
-                                        description: initiatorName is the custom iSCSI
-                                          Initiator Name. If initiatorName is specified
-                                          with iscsiInterface simultaneously, new
-                                          iSCSI interface <target portal>:<volume
-                                          name> will be created for the connection.
+                                        description: |-
+                                          initiatorName is the custom iSCSI Initiator Name.
+                                          If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                          <target portal>:<volume name> will be created for the connection.
                                         type: string
                                       iqn:
                                         description: iqn is the target iSCSI Qualified
                                           Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iscsiInterface is the interface
-                                          Name that uses an iSCSI transport. Defaults
-                                          to 'default' (tcp).
+                                        description: |-
+                                          iscsiInterface is the interface Name that uses an iSCSI transport.
+                                          Defaults to 'default' (tcp).
                                         type: string
                                       lun:
                                         description: lun represents iSCSI Target Lun
@@ -7025,35 +6437,33 @@ spec:
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: portals is the iSCSI Target Portal
-                                          List. The portal is either an IP or ip_addr:port
-                                          if the port is other than default (typically
-                                          TCP ports 860 and 3260).
+                                        description: |-
+                                          portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false.
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
                                         type: boolean
                                       secretRef:
                                         description: secretRef is the CHAP Secret
                                           for iSCSI target and initiator authentication
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       targetPortal:
-                                        description: targetPortal is iSCSI Target
-                                          Portal. The Portal is either an IP or ip_addr:port
-                                          if the port is other than default (typically
-                                          TCP ports 860 and 3260).
+                                        description: |-
+                                          targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -7061,45 +6471,51 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'name of the volume. Must be a DNS_LABEL
-                                      and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: |-
+                                      name of the volume.
+                                      Must be a DNS_LABEL and unique within the pod.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                   nfs:
-                                    description: 'nfs represents an NFS mount on the
-                                      host that shares a pod''s lifetime More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    description: |-
+                                      nfs represents an NFS mount on the host that shares a pod's lifetime
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                     properties:
                                       path:
-                                        description: 'path that is exported by the
-                                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          path that is exported by the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          NFS export to be mounted with read-only
-                                          permissions. Defaults to false. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          readOnly here will force the NFS export to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: boolean
                                       server:
-                                        description: 'server is the hostname or IP
-                                          address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          server is the hostname or IP address of the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: string
                                     required:
                                     - path
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'persistentVolumeClaimVolumeSource
-                                      represents a reference to a PersistentVolumeClaim
-                                      in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    description: |-
+                                      persistentVolumeClaimVolumeSource represents a reference to a
+                                      PersistentVolumeClaim in the same namespace.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                     properties:
                                       claimName:
-                                        description: 'claimName is the name of a PersistentVolumeClaim
-                                          in the same namespace as the pod using this
-                                          volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        description: |-
+                                          claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                         type: string
                                       readOnly:
-                                        description: readOnly Will force the ReadOnly
-                                          setting in VolumeMounts. Default false.
+                                        description: |-
+                                          readOnly Will force the ReadOnly setting in VolumeMounts.
+                                          Default false.
                                         type: boolean
                                     required:
                                     - claimName
@@ -7110,11 +6526,10 @@ spec:
                                       mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       pdID:
                                         description: pdID is the ID that identifies
@@ -7129,16 +6544,15 @@ spec:
                                       machine
                                     properties:
                                       fsType:
-                                        description: fSType represents the filesystem
-                                          type to mount Must be a filesystem type
-                                          supported by the host operating system.
-                                          Ex. "ext4", "xfs". Implicitly inferred to
-                                          be "ext4" if unspecified.
+                                        description: |-
+                                          fSType represents the filesystem type to mount
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       volumeID:
                                         description: volumeID uniquely identifies
@@ -7152,14 +6566,11 @@ spec:
                                       secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: defaultMode are the mode bits
-                                          used to set permissions on created files
-                                          by default. Must be an octal value between
-                                          0000 and 0777 or a decimal value between
-                                          0 and 511. YAML accepts both octal and decimal
-                                          values, JSON requires decimal values for
-                                          mode bits. Directories within the path are
-                                          not affected by this setting.
+                                        description: |-
+                                          defaultMode are the mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       sources:
@@ -7174,15 +6585,12 @@ spec:
                                                 the configMap data to project
                                               properties:
                                                 items:
-                                                  description: items if unspecified,
-                                                    each key-value pair in the Data
-                                                    field of the referenced ConfigMap
-                                                    will be projected into the volume
-                                                    as a file whose name is the key
-                                                    and content is the value. If specified,
-                                                    the listed keys will be projected
-                                                    into the specified paths, and
-                                                    unlisted keys will not be present.
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    ConfigMap will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7192,27 +6600,19 @@ spec:
                                                           to project.
                                                         type: string
                                                       mode:
-                                                        description: 'mode is Optional:
-                                                          mode bits used to set permissions
-                                                          on this file. Must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: path is the relative
-                                                          path of the file to map
-                                                          the key to. May not be an
-                                                          absolute path. May not contain
-                                                          the path element '..'. May
-                                                          not start with the string
-                                                          '..'.
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -7220,10 +6620,10 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: optional specify whether
@@ -7267,17 +6667,11 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
-                                                          on this file, must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7292,12 +6686,9 @@ spec:
                                                           ''..'''
                                                         type: string
                                                       resourceFieldRef:
-                                                        description: 'Selects a resource
-                                                          of the container: only resources
-                                                          limits and requests (limits.cpu,
-                                                          limits.memory, requests.cpu
-                                                          and requests.memory) are
-                                                          currently supported.'
+                                                        description: |-
+                                                          Selects a resource of the container: only resources limits and requests
+                                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                         properties:
                                                           containerName:
                                                             description: 'Container
@@ -7332,15 +6723,12 @@ spec:
                                                 the secret data to project
                                               properties:
                                                 items:
-                                                  description: items if unspecified,
-                                                    each key-value pair in the Data
-                                                    field of the referenced Secret
-                                                    will be projected into the volume
-                                                    as a file whose name is the key
-                                                    and content is the value. If specified,
-                                                    the listed keys will be projected
-                                                    into the specified paths, and
-                                                    unlisted keys will not be present.
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    Secret will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7350,27 +6738,19 @@ spec:
                                                           to project.
                                                         type: string
                                                       mode:
-                                                        description: 'mode is Optional:
-                                                          mode bits used to set permissions
-                                                          on this file. Must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: path is the relative
-                                                          path of the file to map
-                                                          the key to. May not be an
-                                                          absolute path. May not contain
-                                                          the path element '..'. May
-                                                          not start with the string
-                                                          '..'.
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -7378,10 +6758,10 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: optional field specify
@@ -7396,35 +6776,26 @@ spec:
                                                 data to project
                                               properties:
                                                 audience:
-                                                  description: audience is the intended
-                                                    audience of the token. A recipient
-                                                    of a token must identify itself
-                                                    with an identifier specified in
-                                                    the audience of the token, and
-                                                    otherwise should reject the token.
-                                                    The audience defaults to the identifier
-                                                    of the apiserver.
+                                                  description: |-
+                                                    audience is the intended audience of the token. A recipient of a token
+                                                    must identify itself with an identifier specified in the audience of the
+                                                    token, and otherwise should reject the token. The audience defaults to the
+                                                    identifier of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: expirationSeconds is
-                                                    the requested duration of validity
-                                                    of the service account token.
-                                                    As the token approaches expiration,
-                                                    the kubelet volume plugin will
-                                                    proactively rotate the service
-                                                    account token. The kubelet will
-                                                    start trying to rotate the token
-                                                    if the token is older than 80
-                                                    percent of its time to live or
-                                                    if the token is older than 24
-                                                    hours.Defaults to 1 hour and must
-                                                    be at least 10 minutes.
+                                                  description: |-
+                                                    expirationSeconds is the requested duration of validity of the service
+                                                    account token. As the token approaches expiration, the kubelet volume
+                                                    plugin will proactively rotate the service account token. The kubelet will
+                                                    start trying to rotate the token if the token is older than 80 percent of
+                                                    its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                    and must be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: path is the path relative
-                                                    to the mount point of the file
-                                                    to project the token into.
+                                                  description: |-
+                                                    path is the path relative to the mount point of the file to project the
+                                                    token into.
                                                   type: string
                                               required:
                                               - path
@@ -7437,29 +6808,29 @@ spec:
                                       on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: group to map volume access to
+                                        description: |-
+                                          group to map volume access to
                                           Default is no group
                                         type: string
                                       readOnly:
-                                        description: readOnly here will force the
-                                          Quobyte volume to be mounted with read-only
-                                          permissions. Defaults to false.
+                                        description: |-
+                                          readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                          Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: registry represents a single
-                                          or multiple Quobyte Registry services specified
-                                          as a string as host:port pair (multiple
-                                          entries are separated with commas) which
-                                          acts as the central registry for volumes
+                                        description: |-
+                                          registry represents a single or multiple Quobyte Registry services
+                                          specified as a string as host:port pair (multiple entries are separated with commas)
+                                          which acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: tenant owning the given Quobyte
-                                          volume in the Backend Used with dynamically
-                                          provisioned Quobyte volumes, value is set
-                                          by the plugin
+                                        description: |-
+                                          tenant owning the given Quobyte volume in the Backend
+                                          Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                         type: string
                                       user:
-                                        description: user to map volume access to
+                                        description: |-
+                                          user to map volume access to
                                           Defaults to serivceaccount user
                                         type: string
                                       volume:
@@ -7471,61 +6842,68 @@ spec:
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'rbd represents a Rados Block Device
-                                      mount on the host that shares a pod''s lifetime.
-                                      More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                    description: |-
+                                      rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       image:
-                                        description: 'image is the rados image name.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       keyring:
-                                        description: 'keyring is the path to key ring
-                                          for RBDUser. Default is /etc/ceph/keyring.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          keyring is the path to key ring for RBDUser.
+                                          Default is /etc/ceph/keyring.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       monitors:
-                                        description: 'monitors is a collection of
-                                          Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          monitors is a collection of Ceph monitors.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'pool is the rados pool name.
-                                          Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          pool is the rados pool name.
+                                          Default is rbd.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is name of the authentication
-                                          secret for RBDUser. If provided overrides
-                                          keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          secretRef is name of the authentication secret for RBDUser. If provided
+                                          overrides keyring.
+                                          Default is nil.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       user:
-                                        description: 'user is the rados user name.
-                                          Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          user is the rados user name.
+                                          Default is admin.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                     required:
                                     - image
@@ -7536,10 +6914,11 @@ spec:
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Default is "xfs".
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs".
+                                          Default is "xfs".
                                         type: string
                                       gateway:
                                         description: gateway is the host address of
@@ -7551,21 +6930,20 @@ spec:
                                           configured storage.
                                         type: string
                                       readOnly:
-                                        description: readOnly Defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: secretRef references to the secret
-                                          for ScaleIO user and other sensitive information.
-                                          If this is not provided, Login operation
-                                          will fail.
+                                        description: |-
+                                          secretRef references to the secret for ScaleIO user and other
+                                          sensitive information. If this is not provided, Login operation will fail.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -7575,9 +6953,9 @@ spec:
                                           false
                                         type: boolean
                                       storageMode:
-                                        description: storageMode indicates whether
-                                          the storage for a volume should be ThickProvisioned
-                                          or ThinProvisioned. Default is ThinProvisioned.
+                                        description: |-
+                                          storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                          Default is ThinProvisioned.
                                         type: string
                                       storagePool:
                                         description: storagePool is the ScaleIO Storage
@@ -7588,9 +6966,9 @@ spec:
                                           system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: volumeName is the name of a volume
-                                          already created in the ScaleIO system that
-                                          is associated with this volume source.
+                                        description: |-
+                                          volumeName is the name of a volume already created in the ScaleIO system
+                                          that is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -7598,29 +6976,26 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'secret represents a secret that
-                                      should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    description: |-
+                                      secret represents a secret that should populate this volume.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                     properties:
                                       defaultMode:
-                                        description: 'defaultMode is Optional: mode
-                                          bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values
+                                          for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
-                                        description: items If unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          Secret will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present.
+                                        description: |-
+                                          items If unspecified, each key-value pair in the Data field of the referenced
+                                          Secret will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -7629,23 +7004,19 @@ spec:
                                               description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'mode is Optional: mode
-                                                bits used to set permissions on this
-                                                file. Must be an octal value between
-                                                0000 and 0777 or a decimal value between
-                                                0 and 511. YAML accepts both octal
-                                                and decimal values, JSON requires
-                                                decimal values for mode bits. If not
-                                                specified, the volume defaultMode
-                                                will be used.'
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
-                                              description: path is the relative path
-                                                of the file to map the key to. May
-                                                not be an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -7657,9 +7028,9 @@ spec:
                                           the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'secretName is the name of the
-                                          secret in the pod''s namespace to use. More
-                                          info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        description: |-
+                                          secretName is the name of the secret in the pod's namespace to use.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                         type: string
                                     type: object
                                   storageos:
@@ -7667,45 +7038,41 @@ spec:
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: secretRef specifies the secret
-                                          to use for obtaining the StorageOS API credentials.  If
-                                          not specified, default values will be attempted.
+                                        description: |-
+                                          secretRef specifies the secret to use for obtaining the StorageOS API
+                                          credentials.  If not specified, default values will be attempted.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       volumeName:
-                                        description: volumeName is the human-readable
-                                          name of the StorageOS volume.  Volume names
-                                          are only unique within a namespace.
+                                        description: |-
+                                          volumeName is the human-readable name of the StorageOS volume.  Volume
+                                          names are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: volumeNamespace specifies the
-                                          scope of the volume within StorageOS.  If
-                                          no namespace is specified then the Pod's
-                                          namespace will be used.  This allows the
-                                          Kubernetes name scoping to be mirrored within
-                                          StorageOS for tighter integration. Set VolumeName
-                                          to any name to override the default behaviour.
-                                          Set to "default" if you are not using namespaces
-                                          within StorageOS.
+                                        description: |-
+                                          volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                          namespace is specified then the Pod's namespace will be used.  This allows the
+                                          Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                          Set VolumeName to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces within StorageOS.
                                         type: string
                                     type: object
                                   vsphereVolume:
@@ -7714,11 +7081,10 @@ spec:
                                       machine
                                     properties:
                                       fsType:
-                                        description: fsType is filesystem type to
-                                          mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
                                         description: storagePolicyID is the storage
@@ -7745,20 +7111,27 @@ spec:
                           type: object
                       type: object
                   type: object
-                description: 'A map of TFReplicaType (type) to ReplicaSpec (value).
-                  Specifies the TF cluster configuration. For example, { "PS": ReplicaSpec,
-                  "Worker": ReplicaSpec, }'
+                description: |-
+                  A map of TFReplicaType (type) to ReplicaSpec (value). Specifies the TF cluster configuration.
+                  For example,
+                    {
+                      "PS": ReplicaSpec,
+                      "Worker": ReplicaSpec,
+                    }
                 type: object
             required:
             - tfReplicaSpecs
             type: object
           status:
-            description: Most recently observed status of the TFJob. Populated by
-              the system. Read-only.
+            description: |-
+              Most recently observed status of the TFJob.
+              Populated by the system.
+              Read-only.
             properties:
               completionTime:
-                description: Represents time when the job was completed. It is not
-                  guaranteed to be set in happens-before order across separate operations.
+                description: |-
+                  Represents time when the job was completed. It is not guaranteed to
+                  be set in happens-before order across separate operations.
                   It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
@@ -7796,9 +7169,10 @@ spec:
                   type: object
                 type: array
               lastReconcileTime:
-                description: Represents last time when the job was reconciled. It
-                  is not guaranteed to be set in happens-before order across separate
-                  operations. It is represented in RFC3339 form and is in UTC.
+                description: |-
+                  Represents last time when the job was reconciled. It is not guaranteed to
+                  be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               replicaStatuses:
@@ -7821,25 +7195,25 @@ spec:
                           description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -7851,33 +7225,33 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     selector:
-                      description: A Selector is a label query over a set of resources.
-                        The result of matchLabels and matchExpressions are ANDed.
-                        An empty Selector matches all objects. A null Selector matches
-                        no objects.
+                      description: |-
+                        A Selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty Selector matches all objects. A null
+                        Selector matches no objects.
                       type: string
                     succeeded:
                       description: The number of pods which reached phase Succeeded.
                       format: int32
                       type: integer
                   type: object
-                description: ReplicaStatuses is map of ReplicaType and ReplicaStatus,
+                description: |-
+                  ReplicaStatuses is map of ReplicaType and ReplicaStatus,
                   specifies the status of each replica.
                 type: object
               startTime:
-                description: Represents time when the job was acknowledged by the
-                  job controller. It is not guaranteed to be set in happens-before
-                  order across separate operations. It is represented in RFC3339 form
-                  and is in UTC.
+                description: |-
+                  Represents time when the job was acknowledged by the job controller.
+                  It is not guaranteed to be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
             type: object

--- a/manifests/base/crds/kubeflow.org_xgboostjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_xgboostjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: xgboostjobs.kubeflow.org
 spec:
   group: kubeflow.org
@@ -27,14 +27,19 @@ spec:
         description: XGBoostJob is the Schema for the xgboostjobs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -42,13 +47,14 @@ spec:
             description: XGBoostJobSpec defines the desired state of XGBoostJob
             properties:
               runPolicy:
-                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                  Important: Run "make" to regenerate code after modifying this file'
+                description: |-
+                  INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
                 properties:
                   activeDeadlineSeconds:
-                    description: Specifies the duration in seconds relative to the
-                      startTime that the job may be active before the system tries
-                      to terminate it; value must be positive integer.
+                    description: |-
+                      Specifies the duration in seconds relative to the startTime that the job may be active
+                      before the system tries to terminate it; value must be positive integer.
                     format: int64
                     type: integer
                   backoffLimit:
@@ -57,8 +63,9 @@ spec:
                     format: int32
                     type: integer
                   cleanPodPolicy:
-                    description: CleanPodPolicy defines the policy to kill pods after
-                      the job completes. Default to None.
+                    description: |-
+                      CleanPodPolicy defines the policy to kill pods after the job completes.
+                      Default to None.
                     type: string
                   schedulingPolicy:
                     description: SchedulingPolicy defines the policy related to scheduling,
@@ -85,18 +92,20 @@ spec:
                     type: object
                   suspend:
                     default: false
-                    description: suspend specifies whether the Job controller should
-                      create Pods or not. If a Job is created with suspend set to
-                      true, no Pods are created by the Job controller. If a Job is
-                      suspended after creation (i.e. the flag goes from false to true),
-                      the Job controller will delete all active Pods and PodGroups
-                      associated with this Job. Users must design their workload to
-                      gracefully handle this.
+                    description: |-
+                      suspend specifies whether the Job controller should create Pods or not.
+                      If a Job is created with suspend set to true, no Pods are created by
+                      the Job controller. If a Job is suspended after creation (i.e. the
+                      flag goes from false to true), the Job controller will delete all
+                      active Pods and PodGroups associated with this Job.
+                      Users must design their workload to gracefully handle this.
                     type: boolean
                   ttlSecondsAfterFinished:
-                    description: TTLSecondsAfterFinished is the TTL to clean up jobs.
+                    description: |-
+                      TTLSecondsAfterFinished is the TTL to clean up jobs.
                       It may take extra ReconcilePeriod seconds for the cleanup, since
-                      reconcile gets called periodically. Default to infinite.
+                      reconcile gets called periodically.
+                      Default to infinite.
                     format: int32
                     type: integer
                 type: object
@@ -105,21 +114,27 @@ spec:
                   description: ReplicaSpec is a description of the replica
                   properties:
                     replicas:
-                      description: Replicas is the desired number of replicas of the
-                        given template. If unspecified, defaults to 1.
+                      description: |-
+                        Replicas is the desired number of replicas of the given template.
+                        If unspecified, defaults to 1.
                       format: int32
                       type: integer
                     restartPolicy:
-                      description: Restart policy for all replicas within the job.
-                        One of Always, OnFailure, Never and ExitCode. Default to Never.
+                      description: |-
+                        Restart policy for all replicas within the job.
+                        One of Always, OnFailure, Never and ExitCode.
+                        Default to Never.
                       type: string
                     template:
-                      description: Template is the object that describes the pod that
+                      description: |-
+                        Template is the object that describes the pod that
                         will be created for this replica. RestartPolicy in PodTemplateSpec
                         will be overide by RestartPolicy in ReplicaSpec
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          description: |-
+                            Standard object's metadata.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                           properties:
                             annotations:
                               additionalProperties:
@@ -139,15 +154,15 @@ spec:
                               type: string
                           type: object
                         spec:
-                          description: 'Specification of the desired behavior of the
-                            pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                          description: |-
+                            Specification of the desired behavior of the pod.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                           properties:
                             activeDeadlineSeconds:
-                              description: Optional duration in seconds the pod may
-                                be active on the node relative to StartTime before
-                                the system will actively try to mark it failed and
-                                kill associated containers. Value must be a positive
-                                integer.
+                              description: |-
+                                Optional duration in seconds the pod may be active on the node relative to
+                                StartTime before the system will actively try to mark it failed and kill associated containers.
+                                Value must be a positive integer.
                               format: int64
                               type: integer
                             affinity:
@@ -158,21 +173,17 @@ spec:
                                     rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.
                                       items:
-                                        description: An empty preferred scheduling
-                                          term matches all objects with implicit weight
-                                          0 (i.e. it's a no-op). A null preferred
-                                          scheduling term matches no objects (i.e.
-                                          is also a no-op).
+                                        description: |-
+                                          An empty preferred scheduling term matches all objects with implicit weight 0
+                                          (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                         properties:
                                           preference:
                                             description: A node selector term, associated
@@ -182,35 +193,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -223,35 +225,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -274,57 +267,46 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified
-                                        by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to an update), the
-                                        system may or may not try to eventually evict
-                                        the pod from its node.
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to an update), the system
+                                        may or may not try to eventually evict the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
                                           description: Required. A list of node selector
                                             terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector
-                                              term matches no objects. The requirements
-                                              of them are ANDed. The TopologySelectorTerm
-                                              type implements a subset of the NodeSelectorTerm.
+                                            description: |-
+                                              A null or empty node selector term matches no objects. The requirements of
+                                              them are ANDed.
+                                              The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
                                                 description: A list of node selector
                                                   requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -337,35 +319,26 @@ spec:
                                                 description: A list of node selector
                                                   requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
                                                   properties:
                                                     key:
                                                       description: The label key that
                                                         the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's
-                                                        relationship to a set of values.
-                                                        Valid operators are In, NotIn,
-                                                        Exists, DoesNotExist. Gt,
-                                                        and Lt.
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string
-                                                        values. If the operator is
-                                                        In or NotIn, the values array
-                                                        must be non-empty. If the
-                                                        operator is Exists or DoesNotExist,
-                                                        the values array must be empty.
-                                                        If the operator is Gt or Lt,
-                                                        the values array must have
-                                                        a single element, which will
-                                                        be interpreted as an integer.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -388,15 +361,13 @@ spec:
                                     etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the affinity expressions
-                                        specified by this field, but it may choose
-                                        a node that violates one or more of the expressions.
-                                        The node that is most preferred is the one
-                                        with the greatest sum of weights, i.e. for
-                                        each node that meets all of the scheduling
-                                        requirements (resource request, requiredDuringScheduling
-                                        affinity expressions, etc.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -417,11 +388,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -429,23 +398,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -457,29 +419,20 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaceSelector:
-                                                description: A label query over the
-                                                  set of namespaces that the term
-                                                  applies to. The term is applied
-                                                  to the union of the namespaces selected
-                                                  by this field and the ones listed
-                                                  in the namespaces field. null selector
-                                                  and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -487,11 +440,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -499,23 +450,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -527,50 +471,37 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaces:
-                                                description: namespaces specifies
-                                                  a static list of namespace names
-                                                  that the term applies to. The term
-                                                  is applied to the union of the namespaces
-                                                  listed in this field and the ones
-                                                  selected by namespaceSelector. null
-                                                  or empty namespaces list and null
-                                                  namespaceSelector means "this pod's
-                                                  namespace".
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching
-                                              the corresponding podAffinityTerm, in
-                                              the range 1-100.
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -579,24 +510,20 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified
-                                        by this field are not met at scheduling time,
-                                        the pod will not be scheduled onto the node.
-                                        If the affinity requirements specified by
-                                        this field cease to be met at some point during
-                                        pod execution (e.g. due to a pod label update),
-                                        the system may or may not try to eventually
-                                        evict the pod from its node.
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
                                       items:
-                                        description: Defines a set of pods (namely
-                                          those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -607,10 +534,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -618,21 +544,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -645,25 +565,19 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
@@ -671,10 +585,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -682,21 +595,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -709,39 +616,29 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace".
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -754,13 +651,11 @@ spec:
                                     node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule
-                                        pods to nodes that satisfy the anti-affinity
-                                        expressions specified by this field, but it
-                                        may choose a node that violates one or more
-                                        of the expressions. The node that is most
-                                        preferred is the one with the greatest sum
-                                        of weights, i.e.
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the anti-affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
                                       items:
                                         description: The weights of all of the matched
                                           WeightedPodAffinityTerm fields are added
@@ -781,11 +676,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -793,23 +686,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -821,29 +707,20 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaceSelector:
-                                                description: A label query over the
-                                                  set of namespaces that the term
-                                                  applies to. The term is applied
-                                                  to the union of the namespaces selected
-                                                  by this field and the ones listed
-                                                  in the namespaces field. null selector
-                                                  and null or empty namespaces list
-                                                  means "this pod's namespace". An
-                                                  empty selector ({}) matches all
-                                                  namespaces.
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -851,11 +728,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -863,23 +738,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -891,50 +759,37 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               namespaces:
-                                                description: namespaces specifies
-                                                  a static list of namespace names
-                                                  that the term applies to. The term
-                                                  is applied to the union of the namespaces
-                                                  listed in this field and the ones
-                                                  selected by namespaceSelector. null
-                                                  or empty namespaces list and null
-                                                  namespaceSelector means "this pod's
-                                                  namespace".
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching
-                                              the corresponding podAffinityTerm, in
-                                              the range 1-100.
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -943,24 +798,20 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements
-                                        specified by this field are not met at scheduling
-                                        time, the pod will not be scheduled onto the
-                                        node. If the anti-affinity requirements specified
-                                        by this field cease to be met at some point
-                                        during pod execution (e.g. due to a pod label
-                                        update), the system may or may not try to
-                                        eventually evict the pod from its node.
+                                      description: |-
+                                        If the anti-affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the anti-affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
                                       items:
-                                        description: Defines a set of pods (namely
-                                          those matching the labelSelector relative
-                                          to the given namespace(s)) that this pod
-                                          should be co-located (affinity) or not co-located
-                                          (anti-affinity) with, where co-located is
-                                          defined as running on a node whose value
-                                          of the label with key <topologyKey> matches
-                                          that of any node on which a pod of the set
-                                          of pods is running
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
                                         properties:
                                           labelSelector:
                                             description: A label query over a set
@@ -971,10 +822,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -982,21 +832,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -1009,25 +853,19 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaceSelector:
-                                            description: A label query over the set
-                                              of namespaces that the term applies
-                                              to. The term is applied to the union
-                                              of the namespaces selected by this field
-                                              and the ones listed in the namespaces
-                                              field. null selector and null or empty
-                                              namespaces list means "this pod's namespace".
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
                                             properties:
                                               matchExpressions:
@@ -1035,10 +873,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -1046,21 +883,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -1073,39 +904,29 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           namespaces:
-                                            description: namespaces specifies a static
-                                              list of namespace names that the term
-                                              applies to. The term is applied to the
-                                              union of the namespaces listed in this
-                                              field and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null
-                                              namespaceSelector means "this pod's
-                                              namespace".
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -1119,41 +940,39 @@ spec:
                                 mounted.
                               type: boolean
                             containers:
-                              description: List of containers belonging to the pod.
-                                Containers cannot currently be added or removed. There
-                                must be at least one container in a Pod. Cannot be
-                                updated.
+                              description: |-
+                                List of containers belonging to the pod.
+                                Containers cannot currently be added or removed.
+                                There must be at least one container in a Pod.
+                                Cannot be updated.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
-                                      provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The container image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
-                                      used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The container image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -1163,16 +982,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -1186,10 +1002,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1200,11 +1016,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -1220,12 +1034,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -1259,10 +1070,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -1278,15 +1089,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -1295,10 +1104,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -1315,10 +1124,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -1329,48 +1138,43 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images
-                                      This field is optional to allow higher level
-                                      config management to default or override container
-                                      images in workload controllers like Deployments
-                                      and StatefulSets.'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system
-                                      should take in response to container lifecycle
-                                      events. Cannot be updated.
+                                    description: |-
+                                      Actions that the management system should take in response to container lifecycle events.
+                                      Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1380,10 +1184,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -1395,11 +1198,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -1418,25 +1219,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1447,41 +1247,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1491,10 +1284,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -1506,11 +1298,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -1529,25 +1319,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1558,10 +1347,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -1569,35 +1358,31 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness.
+                                    description: |-
+                                      Periodic probe of container liveness.
                                       Container will be restarted if the probe fails.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -1610,11 +1395,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -1624,9 +1410,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -1636,11 +1422,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -1658,36 +1442,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -1702,55 +1485,52 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as
-                                      a DNS_LABEL. Each container in a pod must have
-                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    description: |-
+                                      Name of the container specified as a DNS_LABEL.
+                                      Each container in a pod must have a unique name (DNS_LABEL).
+                                      Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the
-                                      container. Not specifying a port here DOES NOT
-                                      prevent that port from being exposed. Any port
-                                      which is listening on the default "0.0.0.0"
-                                      address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
+                                    description: |-
+                                      List of ports to expose from the container. Not specifying a port here
+                                      DOES NOT prevent that port from being exposed. Any port which is
+                                      listening on the default "0.0.0.0" address inside a container will be
+                                      accessible from the network.
+                                      Modifying this array with strategic merge patch may corrupt the data.
                                       For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -1758,24 +1538,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -1786,36 +1566,31 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service
-                                      readiness. Container will be removed from service
-                                      endpoints if the probe fails. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Periodic probe of container service readiness.
+                                      Container will be removed from service endpoints if the probe fails.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -1828,11 +1603,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -1842,9 +1618,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -1854,11 +1630,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -1876,36 +1650,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -1920,30 +1693,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -1954,14 +1724,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -1970,26 +1740,31 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Compute Resources required by this container.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -2005,9 +1780,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2016,48 +1791,41 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: RestartPolicy defines the restart
-                                      behavior of individual containers in a pod.
-                                      This field may only be set for init containers,
-                                      and the only allowed value is "Always". For
-                                      non-init containers or when this field is not
-                                      specified, the restart behavior is defined by
-                                      the Pod's restart policy and the container type.
+                                    description: |-
+                                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                                      This field may only be set for init containers, and the only allowed value is "Always".
+                                      For non-init containers or when this field is not specified,
+                                      the restart behavior is defined by the Pod's restart policy and the container type.
                                     type: string
                                   securityContext:
-                                    description: 'SecurityContext defines the security
-                                      options the container should be run with. If
-                                      set, the fields of SecurityContext override
-                                      the equivalent fields of PodSecurityContext.
-                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    description: |-
+                                      SecurityContext defines the security options the container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -2075,68 +1843,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2156,52 +1915,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -2209,60 +1960,46 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: StartupProbe indicates that the Pod
-                                      has successfully initialized. If specified,
-                                      no other probes are executed until this completes
-                                      successfully. If this probe fails, the Pod will
-                                      be restarted, just as if the livenessProbe failed.
+                                    description: |-
+                                      StartupProbe indicates that the Pod has successfully initialized.
+                                      If specified, no other probes are executed until this completes successfully.
+                                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -2275,11 +2012,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -2289,9 +2027,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -2301,11 +2039,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -2323,36 +2059,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -2367,72 +2102,62 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -2456,46 +2181,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -2503,34 +2227,36 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             dnsConfig:
-                              description: Specifies the DNS parameters of a pod.
-                                Parameters specified here will be merged to the generated
-                                DNS configuration based on DNSPolicy.
+                              description: |-
+                                Specifies the DNS parameters of a pod.
+                                Parameters specified here will be merged to the generated DNS
+                                configuration based on DNSPolicy.
                               properties:
                                 nameservers:
-                                  description: A list of DNS name server IP addresses.
-                                    This will be appended to the base nameservers
-                                    generated from DNSPolicy. Duplicated nameservers
-                                    will be removed.
+                                  description: |-
+                                    A list of DNS name server IP addresses.
+                                    This will be appended to the base nameservers generated from DNSPolicy.
+                                    Duplicated nameservers will be removed.
                                   items:
                                     type: string
                                   type: array
                                 options:
-                                  description: A list of DNS resolver options. This
-                                    will be merged with the base options generated
-                                    from DNSPolicy. Duplicated entries will be removed.
-                                    Resolution options given in Options will override
-                                    those that appear in the base DNSPolicy.
+                                  description: |-
+                                    A list of DNS resolver options.
+                                    This will be merged with the base options generated from DNSPolicy.
+                                    Duplicated entries will be removed. Resolution options given in Options
+                                    will override those that appear in the base DNSPolicy.
                                   items:
                                     description: PodDNSConfigOption defines DNS resolver
                                       options of a pod.
@@ -2543,75 +2269,68 @@ spec:
                                     type: object
                                   type: array
                                 searches:
-                                  description: A list of DNS search domains for host-name
-                                    lookup. This will be appended to the base search
-                                    paths generated from DNSPolicy. Duplicated search
-                                    paths will be removed.
+                                  description: |-
+                                    A list of DNS search domains for host-name lookup.
+                                    This will be appended to the base search paths generated from DNSPolicy.
+                                    Duplicated search paths will be removed.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
-                              description: Set DNS policy for the pod. Defaults to
-                                "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
-                                'ClusterFirst', 'Default' or 'None'. DNS parameters
-                                given in DNSConfig will be merged with the policy
-                                selected with DNSPolicy. To have DNS options set along
-                                with hostNetwork, you have to specify DNS policy explicitly
-                                to 'ClusterFirstWithHostNet'.
+                              description: |-
+                                Set DNS policy for the pod.
+                                Defaults to "ClusterFirst".
+                                Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                                DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                                To have DNS options set along with hostNetwork, you have to specify DNS policy
+                                explicitly to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
-                              description: 'EnableServiceLinks indicates whether information
-                                about services should be injected into pod''s environment
-                                variables, matching the syntax of Docker links. Optional:
-                                Defaults to true.'
+                              description: |-
+                                EnableServiceLinks indicates whether information about services should be injected into pod's
+                                environment variables, matching the syntax of Docker links.
+                                Optional: Defaults to true.
                               type: boolean
                             ephemeralContainers:
-                              description: List of ephemeral containers run in this
-                                pod. Ephemeral containers may be run in an existing
-                                pod to perform user-initiated actions such as debugging.
-                                This list cannot be specified when creating a pod,
-                                and it cannot be modified by updating the pod spec.
-                                In order to add an ephemeral container to an existing
-                                pod, use the pod's ephemeralcontainers subresource.
+                              description: |-
+                                List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                                pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                                creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                                ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
                               items:
-                                description: An EphemeralContainer is a temporary
-                                  container that you may add to an existing Pod for
-                                  user-initiated activities such as debugging. Ephemeral
-                                  containers have no resource or scheduling guarantees,
-                                  and they will not be restarted when they exit or
-                                  when a Pod is removed or restarted. The kubelet
-                                  may evict a Pod if an ephemeral container causes
-                                  the Pod to exceed its resource allocation.
+                                description: |-
+                                  An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                                  user-initiated activities such as debugging. Ephemeral containers have no resource or
+                                  scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                                  removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                                  Pod to exceed its resource allocation.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. Double $$ are reduced
-                                      to a single $, which allows for escaping the
-                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                      produce the string literal "$(VAR_NAME)".'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)".
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The image''s ENTRYPOINT is used if
-                                      this is not provided. Variable references $(VAR_NAME)
-                                      are expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -2621,16 +2340,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -2644,10 +2360,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -2658,11 +2374,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -2678,12 +2392,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -2717,10 +2428,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -2736,15 +2447,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -2753,10 +2462,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -2773,10 +2482,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -2787,43 +2496,40 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
                                     description: Lifecycle is not allowed for ephemeral
                                       containers.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2833,10 +2539,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -2848,11 +2553,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -2871,25 +2574,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2900,41 +2602,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2944,10 +2639,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -2959,11 +2653,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -2982,25 +2674,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -3011,10 +2702,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -3030,26 +2721,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -3062,11 +2747,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -3076,9 +2762,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -3088,11 +2774,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3110,36 +2794,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -3154,38 +2837,34 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the ephemeral container specified
-                                      as a DNS_LABEL. This name must be unique among
-                                      all containers, init containers and ephemeral
-                                      containers.
+                                    description: |-
+                                      Name of the ephemeral container specified as a DNS_LABEL.
+                                      This name must be unique among all containers, init containers and ephemeral containers.
                                     type: string
                                   ports:
                                     description: Ports are not allowed for ephemeral
@@ -3195,9 +2874,9 @@ spec:
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -3205,24 +2884,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -3241,26 +2920,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -3273,11 +2946,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -3287,9 +2961,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -3299,11 +2973,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3321,36 +2993,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -3365,30 +3036,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -3399,14 +3067,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -3415,27 +3083,30 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: Resources are not allowed for ephemeral
-                                      containers. Ephemeral containers use spare resources
+                                    description: |-
+                                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
                                       already allocated to the pod.
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -3451,9 +3122,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -3462,45 +3133,40 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: Restart policy for the container
-                                      to manage the restart behavior of each container
-                                      within a pod. This may only be set for init
-                                      containers. You cannot set this field on ephemeral
-                                      containers.
+                                    description: |-
+                                      Restart policy for the container to manage the restart behavior of each
+                                      container within a pod.
+                                      This may only be set for init containers. You cannot set this field on
+                                      ephemeral containers.
                                     type: string
                                   securityContext:
-                                    description: 'Optional: SecurityContext defines
-                                      the security options the ephemeral container
-                                      should be run with. If set, the fields of SecurityContext
-                                      override the equivalent fields of PodSecurityContext.'
+                                    description: |-
+                                      Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -3518,68 +3184,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3599,52 +3256,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -3652,25 +3301,18 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
@@ -3683,26 +3325,20 @@ spec:
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -3715,11 +3351,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -3729,9 +3366,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -3741,11 +3378,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -3763,36 +3398,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -3807,81 +3441,71 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   targetContainerName:
-                                    description: "If set, the name of the container
-                                      from PodSpec that this ephemeral container targets.
-                                      The ephemeral container will be run in the namespaces
-                                      (IPC, PID, etc) of this container. If not set
-                                      then the ephemeral container uses the namespaces
-                                      configured in the Pod spec. \n The container
-                                      runtime must implement support for this feature."
+                                    description: |-
+                                      If set, the name of the container from PodSpec that this ephemeral container targets.
+                                      The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                      If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+
+                                      The container runtime must implement support for this feature.
                                     type: string
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -3905,47 +3529,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Subpath mounts are not allowed for
-                                      ephemeral containers. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -3953,24 +3575,24 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             hostAliases:
-                              description: HostAliases is an optional list of hosts
-                                and IPs that will be injected into the pod's hosts
-                                file if specified. This is only valid for non-hostNetwork
-                                pods.
+                              description: |-
+                                HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                file if specified. This is only valid for non-hostNetwork pods.
                               items:
-                                description: HostAlias holds the mapping between IP
-                                  and hostnames that will be injected as an entry
-                                  in the pod's hosts file.
+                                description: |-
+                                  HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                  pod's hosts file.
                                 properties:
                                   hostnames:
                                     description: Hostnames for the above IP address.
@@ -3983,93 +3605,89 @@ spec:
                                 type: object
                               type: array
                             hostIPC:
-                              description: 'Use the host''s ipc namespace. Optional:
-                                Default to false.'
+                              description: |-
+                                Use the host's ipc namespace.
+                                Optional: Default to false.
                               type: boolean
                             hostNetwork:
-                              description: Host networking requested for this pod.
-                                Use the host's network namespace. If this option is
-                                set, the ports that will be used must be specified.
+                              description: |-
+                                Host networking requested for this pod. Use the host's network namespace.
+                                If this option is set, the ports that will be used must be specified.
                                 Default to false.
                               type: boolean
                             hostPID:
-                              description: 'Use the host''s pid namespace. Optional:
-                                Default to false.'
+                              description: |-
+                                Use the host's pid namespace.
+                                Optional: Default to false.
                               type: boolean
                             hostUsers:
-                              description: 'Use the host''s user namespace. Optional:
-                                Default to true. If set to true or not present, the
-                                pod will be run in the host user namespace, useful
-                                for when the pod needs a feature only available to
-                                the host user namespace, such as loading a kernel
-                                module with CAP_SYS_MODULE. When set to false, a new
-                                userns is created for the pod.'
+                              description: |-
+                                Use the host's user namespace.
+                                Optional: Default to true.
+                                If set to true or not present, the pod will be run in the host user namespace, useful
+                                for when the pod needs a feature only available to the host user namespace, such as
+                                loading a kernel module with CAP_SYS_MODULE.
+                                When set to false, a new userns is created for the pod.
                               type: boolean
                             hostname:
-                              description: Specifies the hostname of the Pod If not
-                                specified, the pod's hostname will be set to a system-defined
-                                value.
+                              description: |-
+                                Specifies the hostname of the Pod
+                                If not specified, the pod's hostname will be set to a system-defined value.
                               type: string
                             imagePullSecrets:
-                              description: 'ImagePullSecrets is an optional list of
-                                references to secrets in the same namespace to use
-                                for pulling any of the images used by this PodSpec.
-                                If specified, these secrets will be passed to individual
-                                puller implementations for them to use. More info:
-                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                              description: |-
+                                ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                If specified, these secrets will be passed to individual puller implementations for them to use.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                               items:
-                                description: LocalObjectReference contains enough
-                                  information to let you locate the referenced object
-                                  inside the same namespace.
+                                description: |-
+                                  LocalObjectReference contains enough information to let you locate the
+                                  referenced object inside the same namespace.
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               type: array
                             initContainers:
-                              description: List of initialization containers belonging
-                                to the pod. Init containers are executed in order
-                                prior to containers being started. If any init container
-                                fails, the pod is considered to have failed and is
-                                handled according to its restartPolicy. The name for
-                                an init container or normal container must be unique
-                                among all containers.
+                              description: |-
+                                List of initialization containers belonging to the pod.
+                                Init containers are executed in order prior to containers being started. If any
+                                init container fails, the pod is considered to have failed and is handled according
+                                to its restartPolicy. The name for an init container or normal container must be
+                                unique among all containers.
                               items:
                                 description: A single application container that you
                                   want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The
-                                      container image''s CMD is used if this is not
-                                      provided. Variable references $(VAR_NAME) are
-                                      expanded using the container''s environment.
-                                      If a variable cannot be resolved, the reference
-                                      in the input string will be unchanged. Double
-                                      $$ are reduced to a single $, which allows for
-                                      escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The container image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within
-                                      a shell. The container image''s ENTRYPOINT is
-                                      used if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      Double $$ are reduced to a single $, which allows
-                                      for escaping the $(VAR_NAME) syntax: i.e.'
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The container image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to
-                                      set in the container. Cannot be updated.
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
                                     items:
                                       description: EnvVar represents an environment
                                         variable present in a Container.
@@ -4079,16 +3697,13 @@ spec:
                                             Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previously defined
-                                            environment variables in the container
-                                            and any service environment variables.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                            will produce the string literal "$(VAR_NAME)".'
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -4102,10 +3717,10 @@ spec:
                                                   description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -4116,11 +3731,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
-                                              description: 'Selects a field of the
-                                                pod: supports metadata.name, metadata.namespace,
-                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                spec.nodeName, spec.serviceAccountName,
-                                                status.hostIP, status.podIP, status.podIPs.'
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                               properties:
                                                 apiVersion:
                                                   description: Version of the schema
@@ -4136,12 +3749,9 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                limits.ephemeral-storage, requests.cpu,
-                                                requests.memory and requests.ephemeral-storage)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -4175,10 +3785,10 @@ spec:
                                                     secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: Specify whether the
@@ -4194,15 +3804,13 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment
-                                      variables in the container. The keys defined
-                                      within a source must be a C_IDENTIFIER. All
-                                      invalid keys will be reported as an event when
-                                      the container is starting. When a key exists
-                                      in multiple sources, the value associated with
-                                      the last source will take precedence. Values
-                                      defined by an Env with a duplicate key will
-                                      take precedence. Cannot be updated.
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
                                     items:
                                       description: EnvFromSource represents the source
                                         of a set of ConfigMaps
@@ -4211,10 +3819,10 @@ spec:
                                           description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the ConfigMap
@@ -4231,10 +3839,10 @@ spec:
                                           description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: Specify whether the Secret
@@ -4245,48 +3853,43 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Container image name. More info:
-                                      https://kubernetes.io/docs/concepts/containers/images
-                                      This field is optional to allow higher level
-                                      config management to default or override container
-                                      images in workload controllers like Deployments
-                                      and StatefulSets.'
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always,
-                                      Never, IfNotPresent. Defaults to Always if :latest
-                                      tag is specified, or IfNotPresent otherwise.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system
-                                      should take in response to container lifecycle
-                                      events. Cannot be updated.
+                                    description: |-
+                                      Actions that the management system should take in response to container lifecycle events.
+                                      Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately
-                                          after a container is created. If the handler
-                                          fails, the container is terminated and restarted
-                                          according to its restart policy. Other management
-                                          of the container blocks until the hook completes.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4296,10 +3899,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -4311,11 +3913,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -4334,25 +3934,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -4363,41 +3962,34 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: PreStop is called immediately
-                                          before a container is terminated due to
-                                          an API request or management event such
-                                          as liveness/startup probe failure, preemption,
-                                          resource contention, etc. The handler is
-                                          not called if the container crashes or exits.
-                                          The Pod's termination grace period countdown
-                                          begins before the PreStop hook is executed.
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed.
                                         properties:
                                           exec:
                                             description: Exec specifies the action
                                               to take.
                                             properties:
                                               command:
-                                                description: Command is the command
-                                                  line to execute inside the container,
-                                                  the working directory for the command  is
-                                                  root ('/') in the container's filesystem.
-                                                  The command is simply exec'd, it
-                                                  is not run inside a shell, so traditional
-                                                  shell instructions ('|', etc) won't
-                                                  work. To use a shell, you need to
-                                                  explicitly call out to that shell.
-                                                  Exit status of 0 is treated as live/healthy
-                                                  and non-zero is unhealthy.
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4407,10 +3999,9 @@ spec:
                                               request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect
-                                                  to, defaults to the pod IP. You
-                                                  probably want to set "Host" in httpHeaders
-                                                  instead.
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
                                                 description: Custom headers to set
@@ -4422,11 +4013,9 @@ spec:
                                                     HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field
-                                                        name. This will be canonicalized
-                                                        upon output, so case-variant
-                                                        names will be understood as
-                                                        the same header.
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                       type: string
                                                     value:
                                                       description: The header field
@@ -4445,25 +4034,24 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting
-                                                  to the host. Defaults to HTTP.
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: Deprecated. TCPSocket is
-                                              NOT supported as a LifecycleHandler
-                                              and kept for the backward compatibility.
-                                              There are no validation of this field
-                                              and lifecycle hooks will fail in runtime
-                                              when tcp handler is specified.
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -4474,10 +4062,10 @@ spec:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the
-                                                  port to access on the container.
-                                                  Number must be in the range 1 to
-                                                  65535. Name must be an IANA_SVC_NAME.
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -4485,35 +4073,31 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness.
+                                    description: |-
+                                      Periodic probe of container liveness.
                                       Container will be restarted if the probe fails.
-                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -4526,11 +4110,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -4540,9 +4125,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -4552,11 +4137,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -4574,36 +4157,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -4618,55 +4200,52 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as
-                                      a DNS_LABEL. Each container in a pod must have
-                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    description: |-
+                                      Name of the container specified as a DNS_LABEL.
+                                      Each container in a pod must have a unique name (DNS_LABEL).
+                                      Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the
-                                      container. Not specifying a port here DOES NOT
-                                      prevent that port from being exposed. Any port
-                                      which is listening on the default "0.0.0.0"
-                                      address inside a container will be accessible
-                                      from the network. Modifying this array with
-                                      strategic merge patch may corrupt the data.
+                                    description: |-
+                                      List of ports to expose from the container. Not specifying a port here
+                                      DOES NOT prevent that port from being exposed. Any port which is
+                                      listening on the default "0.0.0.0" address inside a container will be
+                                      accessible from the network.
+                                      Modifying this array with strategic merge patch may corrupt the data.
                                       For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                     items:
                                       description: ContainerPort represents a network
                                         port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on
-                                            the pod's IP address. This must be a valid
-                                            port number, 0 < x < 65536.
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
@@ -4674,24 +4253,24 @@ spec:
                                             port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on
-                                            the host. If specified, this must be a
-                                            valid port number, 0 < x < 65536. If HostNetwork
-                                            is specified, this must match ContainerPort.
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
                                             Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be
-                                            an IANA_SVC_NAME and unique within the
-                                            pod. Each named port in a pod must have
-                                            a unique name. Name for the port that
-                                            can be referred to by services.
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be
-                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -4702,36 +4281,31 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service
-                                      readiness. Container will be removed from service
-                                      endpoints if the probe fails. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Periodic probe of container service readiness.
+                                      Container will be removed from service endpoints if the probe fails.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -4744,11 +4318,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -4758,9 +4333,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -4770,11 +4345,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -4792,36 +4365,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -4836,30 +4408,27 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
@@ -4870,14 +4439,14 @@ spec:
                                         resource resize policy for the container.
                                       properties:
                                         resourceName:
-                                          description: 'Name of the resource to which
-                                            this resource resize policy applies. Supported
-                                            values: cpu, memory.'
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
                                           type: string
                                         restartPolicy:
-                                          description: Restart policy to apply when
-                                            specified resource is resized. If not
-                                            specified, it defaults to NotRequired.
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
                                           type: string
                                       required:
                                       - resourceName
@@ -4886,26 +4455,31 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   resources:
-                                    description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Compute Resources required by this container.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     properties:
                                       claims:
-                                        description: "Claims lists the names of resources,
-                                          defined in spec.resourceClaims, that are
-                                          used by this container. \n This is an alpha
-                                          field and requires enabling the DynamicResourceAllocation
-                                          feature gate. \n This field is immutable.
-                                          It can only be set for containers."
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
                                         items:
                                           description: ResourceClaim references one
                                             entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
-                                              description: Name must match the name
-                                                of one entry in pod.spec.resourceClaims
-                                                of the Pod where this field is used.
-                                                It makes that resource available inside
-                                                a container.
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
                                               type: string
                                           required:
                                           - name
@@ -4921,9 +4495,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum
-                                          amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -4932,48 +4506,41 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                          amount of compute resources required. If
-                                          Requests is omitted for a container, it
-                                          defaults to Limits if that is explicitly
-                                          specified, otherwise to an implementation-defined
-                                          value. Requests cannot exceed Limits. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   restartPolicy:
-                                    description: RestartPolicy defines the restart
-                                      behavior of individual containers in a pod.
-                                      This field may only be set for init containers,
-                                      and the only allowed value is "Always". For
-                                      non-init containers or when this field is not
-                                      specified, the restart behavior is defined by
-                                      the Pod's restart policy and the container type.
+                                    description: |-
+                                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                                      This field may only be set for init containers, and the only allowed value is "Always".
+                                      For non-init containers or when this field is not specified,
+                                      the restart behavior is defined by the Pod's restart policy and the container type.
                                     type: string
                                   securityContext:
-                                    description: 'SecurityContext defines the security
-                                      options the container should be run with. If
-                                      set, the fields of SecurityContext override
-                                      the equivalent fields of PodSecurityContext.
-                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    description: |-
+                                      SecurityContext defines the security options the container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls
-                                          whether a process can gain more privileges
-                                          than its parent process. This bool directly
-                                          controls if the no_new_privs flag will be
-                                          set on the container process. AllowPrivilegeEscalation
-                                          is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.'
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop
-                                          when running containers. Defaults to the
-                                          default set of capabilities granted by the
-                                          container runtime. Note that this field
-                                          cannot be set when spec.os.name is windows.
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -4991,68 +4558,59 @@ spec:
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode.
-                                          Processes in privileged containers are essentially
-                                          equivalent to root on the host. Defaults
-                                          to false. Note that this field cannot be
-                                          set when spec.os.name is windows.
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of
-                                          proc mount to use for the containers. The
-                                          default is DefaultProcMount which uses the
-                                          container runtime defaults for readonly
-                                          paths and masked paths. This requires the
-                                          ProcMountType feature flag to be enabled.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a
-                                          read-only root filesystem. Default is false.
-                                          Note that this field cannot be set when
-                                          spec.os.name is windows.
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint
-                                          of the container process. Uses runtime default
-                                          if unset. May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container
-                                          must run as a non-root user. If true, the
-                                          Kubelet will validate the image at runtime
-                                          to ensure that it does not run as UID 0
-                                          (root) and fail to start the container if
-                                          it does. If unset or false, no such validation
-                                          will be performed. May also be set in PodSecurityContext.
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint
-                                          of the container process. Defaults to user
-                                          specified in image metadata if unspecified.
-                                          May also be set in PodSecurityContext.  If
-                                          set in both SecurityContext and PodSecurityContext,
-                                          the value specified in SecurityContext takes
-                                          precedence. Note that this field cannot
-                                          be set when spec.os.name is windows.
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied
-                                          to the container. If unspecified, the container
-                                          runtime will allocate a random SELinux context
-                                          for each container.  May also be set in
-                                          PodSecurityContext.  If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -5072,52 +4630,44 @@ spec:
                                             type: string
                                         type: object
                                       seccompProfile:
-                                        description: The seccomp options to use by
-                                          this container. If seccomp options are provided
-                                          at both the pod & container level, the container
-                                          options override the pod options. Note that
-                                          this field cannot be set when spec.os.name
-                                          is windows.
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
                                         properties:
                                           localhostProfile:
-                                            description: localhostProfile indicates
-                                              a profile defined in a file on the node
-                                              should be used. The profile must be
-                                              preconfigured on the node to work. Must
-                                              be a descending path, relative to the
-                                              kubelet's configured seccomp profile
-                                              location. Must be set if type is "Localhost".
-                                              Must NOT be set for any other type.
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
                                             type: string
                                           type:
-                                            description: "type indicates which kind
-                                              of seccomp profile will be applied.
-                                              Valid options are: \n Localhost - a
-                                              profile defined in a file on the node
-                                              should be used. RuntimeDefault - the
-                                              container runtime default profile should
-                                              be used. Unconfined - no profile should
-                                              be applied."
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
                                             type: string
                                         required:
                                         - type
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings
-                                          applied to all containers. If unspecified,
-                                          the options from the PodSecurityContext
-                                          will be used. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence. Note
-                                          that this field cannot be set when spec.os.name
-                                          is linux.
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where
-                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                              inlines the contents of the GMSA credential
-                                              spec named by the GMSACredentialSpecName
-                                              field.
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
                                             description: GMSACredentialSpecName is
@@ -5125,60 +4675,46 @@ spec:
                                               to use.
                                             type: string
                                           hostProcess:
-                                            description: HostProcess determines if
-                                              a container should be run as a 'Host
-                                              Process' container. All of a Pod's containers
-                                              must have the same effective HostProcess
-                                              value (it is not allowed to have a mix
-                                              of HostProcess containers and non-HostProcess
-                                              containers). In addition, if HostProcess
-                                              is true then HostNetwork must also be
-                                              set to true.
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
                                             type: boolean
                                           runAsUserName:
-                                            description: The UserName in Windows to
-                                              run the entrypoint of the container
-                                              process. Defaults to the user specified
-                                              in image metadata if unspecified. May
-                                              also be set in PodSecurityContext. If
-                                              set in both SecurityContext and PodSecurityContext,
-                                              the value specified in SecurityContext
-                                              takes precedence.
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: StartupProbe indicates that the Pod
-                                      has successfully initialized. If specified,
-                                      no other probes are executed until this completes
-                                      successfully. If this probe fails, the Pod will
-                                      be restarted, just as if the livenessProbe failed.
+                                    description: |-
+                                      StartupProbe indicates that the Pod has successfully initialized.
+                                      If specified, no other probes are executed until this completes successfully.
+                                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
                                     properties:
                                       exec:
                                         description: Exec specifies the action to
                                           take.
                                         properties:
                                           command:
-                                            description: Command is the command line
-                                              to execute inside the container, the
-                                              working directory for the command  is
-                                              root ('/') in the container's filesystem.
-                                              The command is simply exec'd, it is
-                                              not run inside a shell, so traditional
-                                              shell instructions ('|', etc) won't
-                                              work. To use a shell, you need to explicitly
-                                              call out to that shell. Exit status
-                                              of 0 is treated as live/healthy and
-                                              non-zero is unhealthy.
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures
-                                          for the probe to be considered failed after
-                                          having succeeded. Defaults to 3. Minimum
-                                          value is 1.
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       grpc:
@@ -5191,11 +4727,12 @@ spec:
                                             format: int32
                                             type: integer
                                           service:
-                                            description: "Service is the name of the
-                                              service to place in the gRPC HealthCheckRequest
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
                                               (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                              \n If this is not specified, the default
-                                              behavior is defined by gRPC."
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
                                             type: string
                                         required:
                                         - port
@@ -5205,9 +4742,9 @@ spec:
                                           to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to,
-                                              defaults to the pod IP. You probably
-                                              want to set "Host" in httpHeaders instead.
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
                                             description: Custom headers to set in
@@ -5217,11 +4754,9 @@ spec:
                                                 custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name.
-                                                    This will be canonicalized upon
-                                                    output, so case-variant names
-                                                    will be understood as the same
-                                                    header.
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                   type: string
                                                 value:
                                                   description: The header field value
@@ -5239,36 +4774,35 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting
-                                              to the host. Defaults to HTTP.
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the
-                                          container has started before liveness probes
-                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform
-                                          the probe. Default to 10 seconds. Minimum
-                                          value is 1.
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes
-                                          for the probe to be considered successful
-                                          after having failed. Defaults to 1. Must
-                                          be 1 for liveness and startup. Minimum value
-                                          is 1.
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
@@ -5283,72 +4817,62 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port
-                                              to access on the container. Number must
-                                              be in the range 1 to 65535. Name must
-                                              be an IANA_SVC_NAME.
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       terminationGracePeriodSeconds:
-                                        description: Optional duration in seconds
-                                          the pod needs to terminate gracefully upon
-                                          probe failure. The grace period is the duration
-                                          in seconds after the processes running in
-                                          the pod are sent a termination signal and
-                                          the time when the processes are forcibly
-                                          halted with a kill signal. Set this value
-                                          longer than the expected cleanup time for
-                                          your process.
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
                                         format: int64
                                         type: integer
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which
-                                          the probe times out. Defaults to 1 second.
-                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate
-                                      a buffer for stdin in the container runtime.
-                                      If this is not set, reads from stdin in the
-                                      container will always result in EOF. Default
-                                      is false.
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should
-                                      close the stdin channel after it has been opened
-                                      by a single attach. When stdin is true the stdin
-                                      stream will remain open across multiple attach
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
                                       sessions.
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file
-                                      to which the container''s termination message
-                                      will be written is mounted into the container''s
-                                      filesystem. Message written is intended to be
-                                      brief final status, such as an assertion failure
-                                      message. Will be truncated by the node if greater
-                                      than 4096 bytes. The total message length across
-                                      all containers will be limited to 12kb. Defaults
-                                      to /dev/termination-log.'
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message
-                                      should be populated. File will use the contents
-                                      of terminationMessagePath to populate the container
-                                      status message on both success and failure.
-                                      FallbackToLogsOnError will use the last chunk
-                                      of container log output if the termination message
-                                      file is empty and the container exited with
-                                      an error.
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate
-                                      a TTY for itself, also requires 'stdin' to be
-                                      true. Default is false.
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
                                     type: boolean
                                   volumeDevices:
                                     description: volumeDevices is the list of block
@@ -5372,46 +4896,45 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem.
+                                      Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at
-                                            which the volume should be mounted.  Must
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
                                             not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines
-                                            how mounts are propagated from the host
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
                                             to container and the other way around.
-                                            When not set, MountPropagationNone is
-                                            used. This field is beta in 1.10.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
                                           type: string
                                         name:
                                           description: This must match the Name of
                                             a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true,
-                                            read-write otherwise (false or unspecified).
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
                                             Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from
-                                            which the container's volume should be
-                                            mounted. Defaults to "" (volume's root).
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume
-                                            from which the container's volume should
-                                            be mounted. Behaves similarly to SubPath
-                                            but environment variable references $(VAR_NAME)
-                                            are expanded using the container's environment.
-                                            Defaults to "" (volume's root). SubPathExpr
-                                            and SubPath are mutually exclusive.
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -5419,47 +4942,54 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If
-                                      not specified, the container runtime's default
-                                      will be used, which might be configured in the
-                                      container image. Cannot be updated.
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             nodeName:
-                              description: NodeName is a request to schedule this
-                                pod onto a specific node. If it is non-empty, the
-                                scheduler simply schedules this pod onto that node,
-                                assuming that it fits resource requirements.
+                              description: |-
+                                NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
+                                the scheduler simply schedules this pod onto that node, assuming that it fits resource
+                                requirements.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: 'NodeSelector is a selector which must
-                                be true for the pod to fit on a node. Selector which
-                                must match a node''s labels for the pod to be scheduled
-                                on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                              description: |-
+                                NodeSelector is a selector which must be true for the pod to fit on a node.
+                                Selector which must match a node's labels for the pod to be scheduled on that node.
+                                More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                               type: object
                               x-kubernetes-map-type: atomic
                             os:
-                              description: "Specifies the OS of the containers in
-                                the pod. Some pod and container fields are restricted
-                                if this is set. \n If the OS field is set to linux,
-                                the following fields must be unset: -securityContext.windowsOptions
-                                \n If the OS field is set to windows, following fields
-                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
-                                - spec.securityContext.seLinuxOptions - spec.securityContext."
+                              description: |-
+                                Specifies the OS of the containers in the pod.
+                                Some pod and container fields are restricted if this is set.
+
+
+                                If the OS field is set to linux, the following fields must be unset:
+                                -securityContext.windowsOptions
+
+
+                                If the OS field is set to windows, following fields must be unset:
+                                - spec.hostPID
+                                - spec.hostIPC
+                                - spec.hostUsers
+                                - spec.securityContext.seLinuxOptions
+                                - spec.securityContext.
                               properties:
                                 name:
-                                  description: 'Name is the name of the operating
-                                    system. The currently supported values are linux
-                                    and windows. Additional value may be defined in
-                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                    Clients should expect to handle additional values
-                                    and treat unrecognized values in this field as
-                                    os: null'
+                                  description: |-
+                                    Name is the name of the operating system. The currently supported values are linux and windows.
+                                    Additional value may be defined in future and can be one of:
+                                    https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values and treat unrecognized values in this field as os: null
                                   type: string
                               required:
                               - name
@@ -5471,44 +5001,43 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: Overhead represents the resource overhead
-                                associated with running a pod for a given RuntimeClass.
-                                This field will be autopopulated at admission time
-                                by the RuntimeClass admission controller. If the RuntimeClass
-                                admission controller is enabled, overhead must not
-                                be set in Pod create requests. The RuntimeClass admission
-                                controller will reject Pod create requests which have
-                                the overhead already set.
+                              description: |-
+                                Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                                This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                                the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                                The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                                set.
                               type: object
                             preemptionPolicy:
-                              description: PreemptionPolicy is the Policy for preempting
-                                pods with lower priority. One of Never, PreemptLowerPriority.
+                              description: |-
+                                PreemptionPolicy is the Policy for preempting pods with lower priority.
+                                One of Never, PreemptLowerPriority.
                                 Defaults to PreemptLowerPriority if unset.
                               type: string
                             priority:
-                              description: The priority value. Various system components
-                                use this field to find the priority of the pod. When
-                                Priority Admission Controller is enabled, it prevents
-                                users from setting this field. The admission controller
-                                populates this field from PriorityClassName. The higher
-                                the value, the higher the priority.
+                              description: |-
+                                The priority value. Various system components use this field to find the
+                                priority of the pod. When Priority Admission Controller is enabled, it
+                                prevents users from setting this field. The admission controller populates
+                                this field from PriorityClassName.
+                                The higher the value, the higher the priority.
                               format: int32
                               type: integer
                             priorityClassName:
-                              description: If specified, indicates the pod's priority.
-                                "system-node-critical" and "system-cluster-critical"
-                                are two special keywords which indicate the highest
-                                priorities with the former being the highest priority.
-                                Any other name must be defined by creating a PriorityClass
-                                object with that name. If not specified, the pod priority
-                                will be default or zero if there is no default.
+                              description: |-
+                                If specified, indicates the pod's priority. "system-node-critical" and
+                                "system-cluster-critical" are two special keywords which indicate the
+                                highest priorities with the former being the highest priority. Any other
+                                name must be defined by creating a PriorityClass object with that name.
+                                If not specified, the pod priority will be default or zero if there is no
+                                default.
                               type: string
                             readinessGates:
-                              description: 'If specified, all readiness gates will
-                                be evaluated for pod readiness. A pod is ready when
-                                all its containers are ready AND all conditions specified
-                                in the readiness gates have status equal to "True"
-                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                              description: |-
+                                If specified, all readiness gates will be evaluated for pod readiness.
+                                A pod is ready when all its containers are ready AND
+                                all conditions specified in the readiness gates have status equal to "True"
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
                               items:
                                 description: PodReadinessGate contains the reference
                                   to a pod condition
@@ -5522,40 +5051,47 @@ spec:
                                 type: object
                               type: array
                             resourceClaims:
-                              description: "ResourceClaims defines which ResourceClaims
-                                must be allocated and reserved before the Pod is allowed
-                                to start. The resources will be made available to
-                                those containers which consume them by name. \n This
-                                is an alpha field and requires enabling the DynamicResourceAllocation
-                                feature gate. \n This field is immutable."
+                              description: |-
+                                ResourceClaims defines which ResourceClaims must be allocated
+                                and reserved before the Pod is allowed to start. The resources
+                                will be made available to those containers which consume them
+                                by name.
+
+
+                                This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate.
+
+
+                                This field is immutable.
                               items:
-                                description: PodResourceClaim references exactly one
-                                  ResourceClaim through a ClaimSource. It adds a name
-                                  to it that uniquely identifies the ResourceClaim
-                                  inside the Pod. Containers that need access to the
-                                  ResourceClaim reference it with this name.
+                                description: |-
+                                  PodResourceClaim references exactly one ResourceClaim through a ClaimSource.
+                                  It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                                  Containers that need access to the ResourceClaim reference it with this name.
                                 properties:
                                   name:
-                                    description: Name uniquely identifies this resource
-                                      claim inside the pod. This must be a DNS_LABEL.
+                                    description: |-
+                                      Name uniquely identifies this resource claim inside the pod.
+                                      This must be a DNS_LABEL.
                                     type: string
                                   source:
                                     description: Source describes where to find the
                                       ResourceClaim.
                                     properties:
                                       resourceClaimName:
-                                        description: ResourceClaimName is the name
-                                          of a ResourceClaim object in the same namespace
-                                          as this pod.
+                                        description: |-
+                                          ResourceClaimName is the name of a ResourceClaim object in the same
+                                          namespace as this pod.
                                         type: string
                                       resourceClaimTemplateName:
-                                        description: "ResourceClaimTemplateName is
-                                          the name of a ResourceClaimTemplate object
-                                          in the same namespace as this pod. \n The
-                                          template will be used to create a new ResourceClaim,
-                                          which will be bound to this pod. When this
-                                          pod is deleted, the ResourceClaim will also
-                                          be deleted."
+                                        description: |-
+                                          ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                          object in the same namespace as this pod.
+
+
+                                          The template will be used to create a new ResourceClaim, which will
+                                          be bound to this pod. When this pod is deleted, the ResourceClaim
+                                          will also be deleted.
                                         type: string
                                     type: object
                                 required:
@@ -5566,42 +5102,44 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             restartPolicy:
-                              description: 'Restart policy for all containers within
-                                the pod. One of Always, OnFailure, Never. In some
-                                contexts, only a subset of those values may be permitted.
-                                Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                              description: |-
+                                Restart policy for all containers within the pod.
+                                One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                                Default to Always.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass
-                                object in the node.k8s.io group, which should be used
-                                to run this pod.  If no RuntimeClass resource matches
-                                the named class, the pod will not be run. If unset
-                                or empty, the "legacy" RuntimeClass will be used,
-                                which is an implicit class with an empty definition
-                                that uses the default runtime handler. More info:
-                                https://git.k8s.'
+                              description: |-
+                                RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                                to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                                If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                                empty definition that uses the default runtime handler.
+                                More info: https://git.k8s.
                               type: string
                             schedulerName:
-                              description: If specified, the pod will be dispatched
-                                by specified scheduler. If not specified, the pod
-                                will be dispatched by default scheduler.
+                              description: |-
+                                If specified, the pod will be dispatched by specified scheduler.
+                                If not specified, the pod will be dispatched by default scheduler.
                               type: string
                             schedulingGates:
-                              description: "SchedulingGates is an opaque list of values
-                                that if specified will block scheduling the pod. If
-                                schedulingGates is not empty, the pod will stay in
-                                the SchedulingGated state and the scheduler will not
-                                attempt to schedule the pod. \n SchedulingGates can
-                                only be set at pod creation time, and be removed only
-                                afterwards. \n This is a beta feature enabled by the
-                                PodSchedulingReadiness feature gate."
+                              description: |-
+                                SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                                If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                                scheduler will not attempt to schedule the pod.
+
+
+                                SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+
+
+                                This is a beta feature enabled by the PodSchedulingReadiness feature gate.
                               items:
                                 description: PodSchedulingGate is associated to a
                                   Pod to guard its scheduling.
                                 properties:
                                   name:
-                                    description: Name of the scheduling gate. Each
-                                      scheduling gate must have a unique name field.
+                                    description: |-
+                                      Name of the scheduling gate.
+                                      Each scheduling gate must have a unique name field.
                                     type: string
                                 required:
                                 - name
@@ -5611,70 +5149,67 @@ spec:
                               - name
                               x-kubernetes-list-type: map
                             securityContext:
-                              description: 'SecurityContext holds pod-level security
-                                attributes and common container settings. Optional:
-                                Defaults to empty.  See type description for default
-                                values of each field.'
+                              description: |-
+                                SecurityContext holds pod-level security attributes and common container settings.
+                                Optional: Defaults to empty.  See type description for default values of each field.
                               properties:
                                 fsGroup:
-                                  description: "A special supplemental group that
-                                    applies to all containers in a pod. Some volume
-                                    types allow the Kubelet to change the ownership
-                                    of that volume to be owned by the pod: \n 1. The
-                                    owning GID will be the FSGroup 2. The setgid bit
-                                    is set (new files created in the volume will be
-                                    owned by FSGroup) 3."
+                                  description: |-
+                                    A special supplemental group that applies to all containers in a pod.
+                                    Some volume types allow the Kubelet to change the ownership of that volume
+                                    to be owned by the pod:
+
+
+                                    1. The owning GID will be the FSGroup
+                                    2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                    3.
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior
-                                    of changing ownership and permission of the volume
-                                    before being exposed inside Pod. This field will
-                                    only apply to volume types which support fsGroup
-                                    based ownership(and permissions). It will have
-                                    no effect on ephemeral volume types such as: secret,
-                                    configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified, "Always" is used.'
+                                  description: |-
+                                    fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                    before being exposed inside Pod. This field will only apply to
+                                    volume types which support fsGroup based ownership(and permissions).
+                                    It will have no effect on ephemeral volume types such as: secret, configmaps
+                                    and emptydir.
+                                    Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
                                   type: string
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the
-                                    container process. Uses runtime default if unset.
-                                    May also be set in SecurityContext.  If set in
-                                    both SecurityContext and PodSecurityContext, the
-                                    value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run
-                                    as a non-root user. If true, the Kubelet will
-                                    validate the image at runtime to ensure that it
-                                    does not run as UID 0 (root) and fail to start
-                                    the container if it does. If unset or false, no
-                                    such validation will be performed. May also be
-                                    set in SecurityContext.
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in SecurityContext.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the
-                                    container process. Defaults to user specified
-                                    in image metadata if unspecified. May also be
-                                    set in SecurityContext.  If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in
-                                    SecurityContext takes precedence for that container.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to
-                                    all containers. If unspecified, the container
-                                    runtime will allocate a random SELinux context
-                                    for each container.  May also be set in SecurityContext.  If
-                                    set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence
-                                    for that container. Note that this field cannot
-                                    be set when spec.os.name is windows.
+                                  description: |-
+                                    The SELinux context to be applied to all containers.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in SecurityContext.  If set in
+                                    both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                    takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5694,49 +5229,45 @@ spec:
                                       type: string
                                   type: object
                                 seccompProfile:
-                                  description: The seccomp options to use by the containers
-                                    in this pod. Note that this field cannot be set
-                                    when spec.os.name is windows.
+                                  description: |-
+                                    The seccomp options to use by the containers in this pod.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
-                                      description: localhostProfile indicates a profile
-                                        defined in a file on the node should be used.
-                                        The profile must be preconfigured on the node
-                                        to work. Must be a descending path, relative
-                                        to the kubelet's configured seccomp profile
-                                        location. Must be set if type is "Localhost".
-                                        Must NOT be set for any other type.
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
                                       type: string
                                     type:
-                                      description: "type indicates which kind of seccomp
-                                        profile will be applied. Valid options are:
-                                        \n Localhost - a profile defined in a file
-                                        on the node should be used. RuntimeDefault
-                                        - the container runtime default profile should
-                                        be used. Unconfined - no profile should be
-                                        applied."
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
                                       type: string
                                   required:
                                   - type
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first
-                                    process run in each container, in addition to
-                                    the container's primary GID, the fsGroup (if specified),
-                                    and group memberships defined in the container
-                                    image for the uid of the container process. If
-                                    unspecified, no additional groups are added to
-                                    any container.
+                                  description: |-
+                                    A list of groups applied to the first process run in each container, in addition
+                                    to the container's primary GID, the fsGroup (if specified), and group memberships
+                                    defined in the container image for the uid of the container process. If unspecified,
+                                    no additional groups are added to any container.
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls
-                                    used for the pod. Pods with unsupported sysctls
-                                    (by the container runtime) might fail to launch.
-                                    Note that this field cannot be set when spec.os.name
-                                    is windows.
+                                  description: |-
+                                    Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                    sysctls (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name is windows.
                                   items:
                                     description: Sysctl defines a kernel parameter
                                       to be set
@@ -5753,173 +5284,151 @@ spec:
                                     type: object
                                   type: array
                                 windowsOptions:
-                                  description: The Windows specific settings applied
-                                    to all containers. If unspecified, the options
-                                    within a container's SecurityContext will be used.
-                                    If set in both SecurityContext and PodSecurityContext,
-                                    the value specified in SecurityContext takes precedence.
-                                    Note that this field cannot be set when spec.os.name
-                                    is linux.
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options within a container's SecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the
-                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                        inlines the contents of the GMSA credential
-                                        spec named by the GMSACredentialSpecName field.
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
                                     hostProcess:
-                                      description: HostProcess determines if a container
-                                        should be run as a 'Host Process' container.
-                                        All of a Pod's containers must have the same
-                                        effective HostProcess value (it is not allowed
-                                        to have a mix of HostProcess containers and
-                                        non-HostProcess containers). In addition,
-                                        if HostProcess is true then HostNetwork must
-                                        also be set to true.
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
                                       type: boolean
                                     runAsUserName:
-                                      description: The UserName in Windows to run
-                                        the entrypoint of the container process. Defaults
-                                        to the user specified in image metadata if
-                                        unspecified. May also be set in PodSecurityContext.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: 'DeprecatedServiceAccount is a depreciated
-                                alias for ServiceAccountName. Deprecated: Use serviceAccountName
-                                instead.'
+                              description: |-
+                                DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+                                Deprecated: Use serviceAccountName instead.
                               type: string
                             serviceAccountName:
-                              description: 'ServiceAccountName is the name of the
-                                ServiceAccount to use to run this pod. More info:
-                                https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                              description: |-
+                                ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                               type: string
                             setHostnameAsFQDN:
-                              description: If true the pod's hostname will be configured
-                                as the pod's FQDN, rather than the leaf name (the
-                                default). In Linux containers, this means setting
-                                the FQDN in the hostname field of the kernel (the
-                                nodename field of struct utsname).
+                              description: |-
+                                If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                                In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
                               type: boolean
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between
-                                all of the containers in a pod. When this is set containers
-                                will be able to view and signal processes from other
-                                containers in the same pod, and the first process
-                                in each container will not be assigned PID 1. HostPID
-                                and ShareProcessNamespace cannot both be set. Optional:
-                                Default to false.'
+                              description: |-
+                                Share a single process namespace between all of the containers in a pod.
+                                When this is set containers will be able to view and signal processes from other containers
+                                in the same pod, and the first process in each container will not be assigned PID 1.
+                                HostPID and ShareProcessNamespace cannot both be set.
+                                Optional: Default to false.
                               type: boolean
                             subdomain:
-                              description: If specified, the fully qualified Pod hostname
-                                will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                                domain>". If not specified, the pod will not have
-                                a domainname at all.
+                              description: |-
+                                If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                                If not specified, the pod will not have a domainname at all.
                               type: string
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs
-                                to terminate gracefully. May be decreased in delete
-                                request. Value must be non-negative integer. The value
-                                zero indicates stop immediately via the kill signal
-                                (no opportunity to shut down). If this value is nil,
-                                the default grace period will be used instead.
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                If this value is nil, the default grace period will be used instead.
                               format: int64
                               type: integer
                             tolerations:
                               description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to
-                                  tolerates any taint that matches the triple <key,value,effect>
-                                  using the matching operator <operator>.
+                                description: |-
+                                  The pod this Toleration is attached to tolerates any taint that matches
+                                  the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect
-                                      to match. Empty means match all taint effects.
-                                      When specified, allowed values are NoSchedule,
-                                      PreferNoSchedule and NoExecute.
+                                    description: |-
+                                      Effect indicates the taint effect to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration
-                                      applies to. Empty means match all taint keys.
-                                      If the key is empty, operator must be Exists;
-                                      this combination means to match all values and
-                                      all keys.
+                                    description: |-
+                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship
-                                      to the value. Valid operators are Exists and
-                                      Equal. Defaults to Equal. Exists is equivalent
-                                      to wildcard for value, so that a pod can tolerate
-                                      all taints of a particular category.
+                                    description: |-
+                                      Operator represents a key's relationship to the value.
+                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Exists is equivalent to wildcard for value, so that a pod can
+                                      tolerate all taints of a particular category.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the
-                                      period of time the toleration (which must be
-                                      of effect NoExecute, otherwise this field is
-                                      ignored) tolerates the taint. By default, it
-                                      is not set, which means tolerate the taint forever
-                                      (do not evict). Zero and negative values will
-                                      be treated as 0 (evict immediately) by the system.
+                                    description: |-
+                                      TolerationSeconds represents the period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                      negative values will be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration
-                                      matches to. If the operator is Exists, the value
-                                      should be empty, otherwise just a regular string.
+                                    description: |-
+                                      Value is the taint value the toleration matches to.
+                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how
-                                a group of pods ought to spread across topology domains.
-                                Scheduler will schedule pods in a way which abides
-                                by the constraints. All topologySpreadConstraints
-                                are ANDed.
+                              description: |-
+                                TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                                domains. Scheduler will schedule pods in a way which abides by the constraints.
+                                All topologySpreadConstraints are ANDed.
                               items:
                                 description: TopologySpreadConstraint specifies how
                                   to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: LabelSelector is used to find matching
-                                      pods. Pods that match this label selector are
-                                      counted to determine the number of pods in their
-                                      corresponding topology domain.
+                                    description: |-
+                                      LabelSelector is used to find matching pods.
+                                      Pods that match this label selector are counted to determine the number of pods
+                                      in their corresponding topology domain.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
                                           label selector requirements. The requirements
                                           are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -5932,91 +5441,79 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label
-                                      keys to select the pods over which spreading
-                                      will be calculated. The keys are used to lookup
-                                      values from the incoming pod labels, those key-value
-                                      labels are ANDed with labelSelector to select
-                                      the group of existing pods over which spreading
-                                      will be calculated for the incoming pod. The
-                                      same key is forbidden to exist in both MatchLabelKeys
-                                      and LabelSelector.
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select the pods over which
+                                      spreading will be calculated. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are ANDed with labelSelector
+                                      to select the group of existing pods over which spreading will be calculated
+                                      for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   maxSkew:
-                                    description: MaxSkew describes the degree to which
-                                      pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                                      it is the maximum permitted difference between
-                                      the number of matching pods in the target topology
-                                      and the global minimum. The global minimum is
-                                      the minimum number of matching pods in an eligible
-                                      domain or zero if the number of eligible domains
-                                      is less than MinDomains.
+                                    description: |-
+                                      MaxSkew describes the degree to which pods may be unevenly distributed.
+                                      When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                      between the number of matching pods in the target topology and the global minimum.
+                                      The global minimum is the minimum number of matching pods in an eligible domain
+                                      or zero if the number of eligible domains is less than MinDomains.
                                     format: int32
                                     type: integer
                                   minDomains:
-                                    description: MinDomains indicates a minimum number
-                                      of eligible domains. When the number of eligible
-                                      domains with matching topology keys is less
-                                      than minDomains, Pod Topology Spread treats
-                                      "global minimum" as 0, and then the calculation
-                                      of Skew is performed. And when the number of
-                                      eligible domains with matching topology keys
-                                      equals or greater than minDomains, this value
-                                      has no effect on scheduling.
+                                    description: |-
+                                      MinDomains indicates a minimum number of eligible domains.
+                                      When the number of eligible domains with matching topology keys is less than minDomains,
+                                      Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                      And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                      this value has no effect on scheduling.
                                     format: int32
                                     type: integer
                                   nodeAffinityPolicy:
-                                    description: "NodeAffinityPolicy indicates how
-                                      we will treat Pod's nodeAffinity/nodeSelector
-                                      when calculating pod topology spread skew. Options
-                                      are: - Honor: only nodes matching nodeAffinity/nodeSelector
-                                      are included in the calculations. - Ignore:
-                                      nodeAffinity/nodeSelector are ignored. All nodes
-                                      are included in the calculations. \n If this
-                                      value is nil, the behavior is equivalent to
-                                      the Honor policy."
+                                    description: |-
+                                      NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                      when calculating pod topology spread skew. Options are:
+                                      - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                      - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                                      If this value is nil, the behavior is equivalent to the Honor policy.
                                     type: string
                                   nodeTaintsPolicy:
-                                    description: "NodeTaintsPolicy indicates how we
-                                      will treat node taints when calculating pod
-                                      topology spread skew. Options are: - Honor:
-                                      nodes without taints, along with tainted nodes
-                                      for which the incoming pod has a toleration,
-                                      are included. - Ignore: node taints are ignored.
-                                      All nodes are included. \n If this value is
-                                      nil, the behavior is equivalent to the Ignore
-                                      policy."
+                                    description: |-
+                                      NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                      pod topology spread skew. Options are:
+                                      - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                      has a toleration, are included.
+                                      - Ignore: node taints are ignored. All nodes are included.
+
+
+                                      If this value is nil, the behavior is equivalent to the Ignore policy.
                                     type: string
                                   topologyKey:
-                                    description: TopologyKey is the key of node labels.
-                                      Nodes that have a label with this key and identical
-                                      values are considered to be in the same topology.
-                                      We consider each <key, value> as a "bucket",
-                                      and try to put balanced number of pods into
-                                      each bucket. We define a domain as a particular
-                                      instance of a topology.
+                                    description: |-
+                                      TopologyKey is the key of node labels. Nodes that have a label with this key
+                                      and identical values are considered to be in the same topology.
+                                      We consider each <key, value> as a "bucket", and try to put balanced number
+                                      of pods into each bucket.
+                                      We define a domain as a particular instance of a topology.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: WhenUnsatisfiable indicates how to
-                                      deal with a pod if it doesn't satisfy the spread
-                                      constraint. - DoNotSchedule (default) tells
-                                      the scheduler not to schedule it. - ScheduleAnyway
-                                      tells the scheduler to schedule the pod in any
-                                      location, but giving higher precedence to topologies
-                                      that would help reduce the skew.
+                                    description: |-
+                                      WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                      the spread constraint.
+                                      - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                      - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                        but giving higher precedence to topologies that would help reduce the
+                                        skew.
                                     type: string
                                 required:
                                 - maxSkew
@@ -6029,49 +5526,45 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: 'List of volumes that can be mounted by
-                                containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                              description: |-
+                                List of volumes that can be mounted by containers belonging to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes
                               items:
                                 description: Volume represents a named volume in a
                                   pod that may be accessed by any container in the
                                   pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'awsElasticBlockStore represents
-                                      an AWS Disk resource that is attached to a kubelet''s
-                                      host machine and then exposed to the pod. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    description: |-
+                                      awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       partition:
-                                        description: 'partition is the partition in
-                                          the volume that you want to mount. If omitted,
-                                          the default is to mount by volume name.
-                                          Examples: For volume /dev/sda1, you specify
-                                          the partition as "1". Similarly, the volume
-                                          partition for /dev/sda is "0" (or you can
-                                          leave the property empty).'
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'readOnly value true will force
-                                          the readOnly setting in VolumeMounts. More
-                                          info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: |-
+                                          readOnly value true will force the readOnly setting in VolumeMounts.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                         type: boolean
                                       volumeID:
-                                        description: 'volumeID is unique ID of the
-                                          persistent disk resource in AWS (Amazon
-                                          EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: |-
+                                          volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                         type: string
                                     required:
                                     - volumeID
@@ -6094,11 +5587,10 @@ spec:
                                           in the blob storage
                                         type: string
                                       fsType:
-                                        description: fsType is Filesystem type to
-                                          mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is Filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       kind:
                                         description: 'kind expected values are Shared:
@@ -6108,9 +5600,9 @@ spec:
                                           availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: readOnly Defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                     required:
                                     - diskName
@@ -6122,9 +5614,9 @@ spec:
                                       the pod.
                                     properties:
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretName:
                                         description: secretName is the  name of secret
@@ -6144,9 +5636,9 @@ spec:
                                       on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'monitors is Required: Monitors
-                                          is a collection of Ceph monitors More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          monitors is Required: Monitors is a collection of Ceph monitors
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         items:
                                           type: string
                                         type: array
@@ -6156,71 +5648,72 @@ spec:
                                           tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'readOnly is Optional: Defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.
-                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: boolean
                                       secretFile:
-                                        description: 'secretFile is Optional: SecretFile
-                                          is the path to key ring for User, default
-                                          is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: string
                                       secretRef:
-                                        description: 'secretRef is Optional: SecretRef
-                                          is reference to the authentication secret
-                                          for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       user:
-                                        description: 'user is optional: User is the
-                                          rados user name, default is admin More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: |-
+                                          user is optional: User is the rados user name, default is admin
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'cinder represents a cinder volume
-                                      attached and mounted on kubelets host machine.
-                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    description: |-
+                                      cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: string
                                       readOnly:
-                                        description: 'readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is optional: points
-                                          to a secret object containing parameters
-                                          used to connect to OpenStack.'
+                                        description: |-
+                                          secretRef is optional: points to a secret object containing parameters used to connect
+                                          to OpenStack.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       volumeID:
-                                        description: 'volumeID used to identify the
-                                          volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: |-
+                                          volumeID used to identify the volume in cinder.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                         type: string
                                     required:
                                     - volumeID
@@ -6230,25 +5723,21 @@ spec:
                                       that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'defaultMode is optional: mode
-                                          bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          defaultMode is optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
-                                        description: items if unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          ConfigMap will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present.
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -6257,23 +5746,19 @@ spec:
                                               description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'mode is Optional: mode
-                                                bits used to set permissions on this
-                                                file. Must be an octal value between
-                                                0000 and 0777 or a decimal value between
-                                                0 and 511. YAML accepts both octal
-                                                and decimal values, JSON requires
-                                                decimal values for mode bits. If not
-                                                specified, the volume defaultMode
-                                                will be used.'
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
-                                              description: path is the relative path
-                                                of the file to map the key to. May
-                                                not be an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -6281,10 +5766,10 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: optional specify whether the
@@ -6298,48 +5783,43 @@ spec:
                                       by certain external CSI drivers (Beta feature).
                                     properties:
                                       driver:
-                                        description: driver is the name of the CSI
-                                          driver that handles this volume. Consult
-                                          with your admin for the correct name as
-                                          registered in the cluster.
+                                        description: |-
+                                          driver is the name of the CSI driver that handles this volume.
+                                          Consult with your admin for the correct name as registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: fsType to mount. Ex. "ext4",
-                                          "xfs", "ntfs". If not provided, the empty
-                                          value is passed to the associated CSI driver
-                                          which will determine the default filesystem
-                                          to apply.
+                                        description: |-
+                                          fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                          If not provided, the empty value is passed to the associated CSI driver
+                                          which will determine the default filesystem to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: nodePublishSecretRef is a reference
-                                          to the secret object containing sensitive
-                                          information to pass to the CSI driver to
-                                          complete the CSI NodePublishVolume and NodeUnpublishVolume
-                                          calls. This field is optional, and  may
-                                          be empty if no secret is required. If the
-                                          secret object contains more than one secret,
-                                          all secret references are passed.
+                                        description: |-
+                                          nodePublishSecretRef is a reference to the secret object containing
+                                          sensitive information to pass to the CSI driver to complete the CSI
+                                          NodePublishVolume and NodeUnpublishVolume calls.
+                                          This field is optional, and  may be empty if no secret is required. If the
+                                          secret object contains more than one secret, all secret references are passed.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       readOnly:
-                                        description: readOnly specifies a read-only
-                                          configuration for the volume. Defaults to
-                                          false (read/write).
+                                        description: |-
+                                          readOnly specifies a read-only configuration for the volume.
+                                          Defaults to false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: volumeAttributes stores driver-specific
-                                          properties that are passed to the CSI driver.
-                                          Consult your driver's documentation for
-                                          supported values.
+                                        description: |-
+                                          volumeAttributes stores driver-specific properties that are passed to the CSI
+                                          driver. Consult your driver's documentation for supported values.
                                         type: object
                                     required:
                                     - driver
@@ -6349,16 +5829,13 @@ spec:
                                       about the pod that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on
-                                          created files by default. Must be a Optional:
-                                          mode bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          Optional: mode bits to use on created files by default. Must be a
+                                          Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
@@ -6388,14 +5865,11 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file, must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.'
+                                              description: |-
+                                                Optional: mode bits used to set permissions on this file, must be an octal value
+                                                between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
@@ -6407,11 +5881,9 @@ spec:
                                                 path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of
-                                                the container: only resources limits
-                                                and requests (limits.cpu, limits.memory,
-                                                requests.cpu and requests.memory)
-                                                are currently supported.'
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                               properties:
                                                 containerName:
                                                   description: 'Container name: required
@@ -6441,56 +5913,51 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'emptyDir represents a temporary
-                                      directory that shares a pod''s lifetime. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    description: |-
+                                      emptyDir represents a temporary directory that shares a pod's lifetime.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     properties:
                                       medium:
-                                        description: 'medium represents what type
-                                          of storage medium should back this directory.
-                                          The default is "" which means to use the
-                                          node''s default medium. Must be an empty
-                                          string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: |-
+                                          medium represents what type of storage medium should back this directory.
+                                          The default is "" which means to use the node's default medium.
+                                          Must be an empty string (default) or Memory.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'sizeLimit is the total amount
-                                          of local storage required for this EmptyDir
-                                          volume. The size limit is also applicable
-                                          for memory medium. The maximum usage on
-                                          memory medium EmptyDir would be the minimum
-                                          value between the SizeLimit specified here
-                                          and the sum of memory limits of all containers
-                                          in a pod. The default is nil which means
-                                          that the limit is undefined. More info:
-                                          https://kubernetes.'
+                                        description: |-
+                                          sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                          The size limit is also applicable for memory medium.
+                                          The maximum usage on memory medium EmptyDir would be the minimum value between
+                                          the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                          The default is nil which means that the limit is undefined.
+                                          More info: https://kubernetes.
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: ephemeral represents a volume that
-                                      is handled by a cluster storage driver. The
-                                      volume's lifecycle is tied to the pod that defines
-                                      it - it will be created before the pod starts,
+                                    description: |-
+                                      ephemeral represents a volume that is handled by a cluster storage driver.
+                                      The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                                       and deleted when the pod is removed.
                                     properties:
                                       volumeClaimTemplate:
-                                        description: Will be used to create a stand-alone
-                                          PVC to provision the volume. The pod in
-                                          which this EphemeralVolumeSource is embedded
-                                          will be the owner of the PVC, i.e. the PVC
-                                          will be deleted together with the pod.  The
-                                          name of the PVC will be `<pod name>-<volume
-                                          name>` where `<volume name>` is the name
-                                          from the `PodSpec.Volumes` array entry.
+                                        description: |-
+                                          Will be used to create a stand-alone PVC to provision the volume.
+                                          The pod in which this EphemeralVolumeSource is embedded will be the
+                                          owner of the PVC, i.e. the PVC will be deleted together with the
+                                          pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                          `<volume name>` is the name from the `PodSpec.Volumes` array
+                                          entry.
                                         properties:
                                           metadata:
-                                            description: May contain labels and annotations
-                                              that will be copied into the PVC when
-                                              creating it. No other fields are allowed
-                                              and will be rejected during validation.
+                                            description: |-
+                                              May contain labels and annotations that will be copied into the PVC
+                                              when creating it. No other fields are allowed and will be rejected during
+                                              validation.
                                             properties:
                                               annotations:
                                                 additionalProperties:
@@ -6510,39 +5977,32 @@ spec:
                                                 type: string
                                             type: object
                                           spec:
-                                            description: The specification for the
-                                              PersistentVolumeClaim. The entire content
-                                              is copied unchanged into the PVC that
-                                              gets created from this template. The
-                                              same fields as in a PersistentVolumeClaim
+                                            description: |-
+                                              The specification for the PersistentVolumeClaim. The entire content is
+                                              copied unchanged into the PVC that gets created from this
+                                              template. The same fields as in a PersistentVolumeClaim
                                               are also valid here.
                                             properties:
                                               accessModes:
-                                                description: 'accessModes contains
-                                                  the desired access modes the volume
-                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                description: |-
+                                                  accessModes contains the desired access modes the volume should have.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                                 items:
                                                   type: string
                                                 type: array
                                               dataSource:
-                                                description: 'dataSource field can
-                                                  be used to specify either: * An
-                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                description: |-
+                                                  dataSource field can be used to specify either:
+                                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                                   * An existing PVC (PersistentVolumeClaim)
-                                                  If the provisioner or an external
-                                                  controller can support the specified
-                                                  data source, it will create a new
-                                                  volume based on the contents of
-                                                  the specified data source.'
+                                                  If the provisioner or an external controller can support the specified data source,
+                                                  it will create a new volume based on the contents of the specified data source.
                                                 properties:
                                                   apiGroup:
-                                                    description: APIGroup is the group
-                                                      for the resource being referenced.
-                                                      If APIGroup is not specified,
-                                                      the specified Kind must be in
-                                                      the core API group. For any
-                                                      other third-party types, APIGroup
-                                                      is required.
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
                                                     type: string
                                                   kind:
                                                     description: Kind is the type
@@ -6558,26 +6018,19 @@ spec:
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               dataSourceRef:
-                                                description: dataSourceRef specifies
-                                                  the object from which to populate
-                                                  the volume with data, if a non-empty
-                                                  volume is desired. This may be any
-                                                  object from a non-empty API group
-                                                  (non core object) or a PersistentVolumeClaim
-                                                  object. When this field is specified,
-                                                  volume binding will only succeed
-                                                  if the type of the specified object
-                                                  matches some installed volume populator
-                                                  or dynamic provisioner.
+                                                description: |-
+                                                  dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                                  volume is desired. This may be any object from a non-empty API group (non
+                                                  core object) or a PersistentVolumeClaim object.
+                                                  When this field is specified, volume binding will only succeed if the type of
+                                                  the specified object matches some installed volume populator or dynamic
+                                                  provisioner.
                                                 properties:
                                                   apiGroup:
-                                                    description: APIGroup is the group
-                                                      for the resource being referenced.
-                                                      If APIGroup is not specified,
-                                                      the specified Kind must be in
-                                                      the core API group. For any
-                                                      other third-party types, APIGroup
-                                                      is required.
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
                                                     type: string
                                                   kind:
                                                     description: Kind is the type
@@ -6588,54 +6041,42 @@ spec:
                                                       of resource being referenced
                                                     type: string
                                                   namespace:
-                                                    description: Namespace is the
-                                                      namespace of resource being
-                                                      referenced Note that when a
-                                                      namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
-                                                      object is required in the referent
-                                                      namespace to allow that namespace's
-                                                      owner to accept the reference.
-                                                      See the ReferenceGrant documentation
-                                                      for details. (Alpha) This field
-                                                      requires the CrossNamespaceVolumeDataSource
-                                                      feature gate to be enabled.
+                                                    description: |-
+                                                      Namespace is the namespace of resource being referenced
+                                                      Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                      (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                                     type: string
                                                 required:
                                                 - kind
                                                 - name
                                                 type: object
                                               resources:
-                                                description: 'resources represents
-                                                  the minimum resources the volume
-                                                  should have. If RecoverVolumeExpansionFailure
-                                                  feature is enabled users are allowed
-                                                  to specify resource requirements
-                                                  that are lower than previous value
-                                                  but must still be higher than capacity
-                                                  recorded in the status field of
-                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                description: |-
+                                                  resources represents the minimum resources the volume should have.
+                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  that are lower than previous value but must still be higher than capacity recorded in the
+                                                  status field of the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                                 properties:
                                                   claims:
-                                                    description: "Claims lists the
-                                                      names of resources, defined
-                                                      in spec.resourceClaims, that
-                                                      are used by this container.
-                                                      \n This is an alpha field and
-                                                      requires enabling the DynamicResourceAllocation
-                                                      feature gate. \n This field
-                                                      is immutable. It can only be
-                                                      set for containers."
+                                                    description: |-
+                                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                                      that are used by this container.
+
+
+                                                      This is an alpha field and requires enabling the
+                                                      DynamicResourceAllocation feature gate.
+
+
+                                                      This field is immutable. It can only be set for containers.
                                                     items:
                                                       description: ResourceClaim references
                                                         one entry in PodSpec.ResourceClaims.
                                                       properties:
                                                         name:
-                                                          description: Name must match
-                                                            the name of one entry
-                                                            in pod.spec.resourceClaims
-                                                            of the Pod where this
-                                                            field is used. It makes
-                                                            that resource available
+                                                          description: |-
+                                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                                            the Pod where this field is used. It makes that resource available
                                                             inside a container.
                                                           type: string
                                                       required:
@@ -6652,10 +6093,9 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: 'Limits describes
-                                                      the maximum amount of compute
-                                                      resources allowed. More info:
-                                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    description: |-
+                                                      Limits describes the maximum amount of compute resources allowed.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -6664,15 +6104,11 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: 'Requests describes
-                                                      the minimum amount of compute
-                                                      resources required. If Requests
-                                                      is omitted for a container,
-                                                      it defaults to Limits if that
-                                                      is explicitly specified, otherwise
-                                                      to an implementation-defined
-                                                      value. Requests cannot exceed
-                                                      Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    description: |-
+                                                      Requests describes the minimum amount of compute resources required.
+                                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                 type: object
                                               selector:
@@ -6685,11 +6121,9 @@ spec:
                                                       requirements. The requirements
                                                       are ANDed.
                                                     items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
                                                       properties:
                                                         key:
                                                           description: key is the
@@ -6697,23 +6131,16 @@ spec:
                                                             applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -6725,28 +6152,22 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               storageClassName:
-                                                description: 'storageClassName is
-                                                  the name of the StorageClass required
-                                                  by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                description: |-
+                                                  storageClassName is the name of the StorageClass required by the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                                 type: string
                                               volumeMode:
-                                                description: volumeMode defines what
-                                                  type of volume is required by the
-                                                  claim. Value of Filesystem is implied
-                                                  when not included in claim spec.
+                                                description: |-
+                                                  volumeMode defines what type of volume is required by the claim.
+                                                  Value of Filesystem is implied when not included in claim spec.
                                                 type: string
                                               volumeName:
                                                 description: volumeName is the binding
@@ -6764,13 +6185,11 @@ spec:
                                       and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. TODO: how do we prevent
-                                          errors in the filesystem from compromising
-                                          the machine'
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       lun:
                                         description: 'lun is Optional: FC target lun
@@ -6778,9 +6197,9 @@ spec:
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'readOnly is Optional: Defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.'
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       targetWWNs:
                                         description: 'targetWWNs is Optional: FC target
@@ -6789,29 +6208,27 @@ spec:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'wwids Optional: FC volume world
-                                          wide identifiers (wwids) Either wwids or
-                                          combination of targetWWNs and lun must be
-                                          set, but not both simultaneously.'
+                                        description: |-
+                                          wwids Optional: FC volume world wide identifiers (wwids)
+                                          Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: flexVolume represents a generic volume
-                                      resource that is provisioned/attached using
-                                      an exec based plugin.
+                                    description: |-
+                                      flexVolume represents a generic volume resource that is
+                                      provisioned/attached using an exec based plugin.
                                     properties:
                                       driver:
                                         description: driver is the name of the driver
                                           to use for this volume.
                                         type: string
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". The default filesystem depends
-                                          on FlexVolume script.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
@@ -6820,24 +6237,23 @@ spec:
                                           holds extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'readOnly is Optional: defaults
-                                          to false (read/write). ReadOnly here will
-                                          force the ReadOnly setting in VolumeMounts.'
+                                        description: |-
+                                          readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is Optional: secretRef
-                                          is reference to the secret object containing
-                                          sensitive information to pass to the plugin
-                                          scripts. This may be empty if no secret
-                                          object is specified. If the secret object
-                                          contains more than one secret, all secrets
-                                          are passed to the plugin scripts.'
+                                        description: |-
+                                          secretRef is Optional: secretRef is reference to the secret object containing
+                                          sensitive information to pass to the plugin scripts. This may be
+                                          empty if no secret object is specified. If the secret object
+                                          contains more than one secret, all secrets are passed to the plugin
+                                          scripts.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -6850,9 +6266,9 @@ spec:
                                       on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: datasetName is Name of the dataset
-                                          stored as metadata -> name on the dataset
-                                          for Flocker should be considered as deprecated
+                                        description: |-
+                                          datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                          should be considered as deprecated
                                         type: string
                                       datasetUUID:
                                         description: datasetUUID is the UUID of the
@@ -6861,60 +6277,55 @@ spec:
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'gcePersistentDisk represents a GCE
-                                      Disk resource that is attached to a kubelet''s
-                                      host machine and then exposed to the pod. More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    description: |-
+                                      gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                     properties:
                                       fsType:
-                                        description: 'fsType is filesystem type of
-                                          the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       partition:
-                                        description: 'partition is the partition in
-                                          the volume that you want to mount. If omitted,
-                                          the default is to mount by volume name.
-                                          Examples: For volume /dev/sda1, you specify
-                                          the partition as "1". Similarly, the volume
-                                          partition for /dev/sda is "0" (or you can
-                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'pdName is unique name of the
-                                          PD resource in GCE. Used to identify the
-                                          disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                         type: boolean
                                     required:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'gitRepo represents a git repository
-                                      at a particular revision. DEPRECATED: GitRepo
-                                      is deprecated. To provision a container with
-                                      a git repo, mount an EmptyDir into an InitContainer
-                                      that clones the repo using git, then mount the
-                                      EmptyDir into the Pod''s container.'
+                                    description: |-
+                                      gitRepo represents a git repository at a particular revision.
+                                      DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                      EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                      into the Pod's container.
                                     properties:
                                       directory:
-                                        description: directory is the target directory
-                                          name. Must not contain or start with '..'.  If
-                                          '.' is supplied, the volume directory will
-                                          be the git repository.  Otherwise, if specified,
-                                          the volume will contain the git repository
-                                          in the subdirectory with the given name.
+                                        description: |-
+                                          directory is the target directory name.
+                                          Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                          git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                          the subdirectory with the given name.
                                         type: string
                                       repository:
                                         description: repository is the URL
@@ -6927,54 +6338,58 @@ spec:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'glusterfs represents a Glusterfs
-                                      mount on the host that shares a pod''s lifetime.
-                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                    description: |-
+                                      glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                     properties:
                                       endpoints:
-                                        description: 'endpoints is the endpoint name
-                                          that details Glusterfs topology. More info:
-                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          endpoints is the endpoint name that details Glusterfs topology.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: string
                                       path:
-                                        description: 'path is the Glusterfs volume
-                                          path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          path is the Glusterfs volume path.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          Glusterfs volume to be mounted with read-only
-                                          permissions. Defaults to false. More info:
-                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: |-
+                                          readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                         type: boolean
                                     required:
                                     - endpoints
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'hostPath represents a pre-existing
-                                      file or directory on the host machine that is
-                                      directly exposed to the container. This is generally
-                                      used for system agents or other privileged things
-                                      that are allowed to see the host machine. Most
-                                      containers will NOT need this. More info: https://kubernetes.'
+                                    description: |-
+                                      hostPath represents a pre-existing file or directory on the host
+                                      machine that is directly exposed to the container. This is generally
+                                      used for system agents or other privileged things that are allowed
+                                      to see the host machine. Most containers will NOT need this.
+                                      More info: https://kubernetes.
                                     properties:
                                       path:
-                                        description: 'path of the directory on the
-                                          host. If the path is a symlink, it will
-                                          follow the link to the real path. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        description: |-
+                                          path of the directory on the host.
+                                          If the path is a symlink, it will follow the link to the real path.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                         type: string
                                       type:
-                                        description: 'type for HostPath Volume Defaults
-                                          to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        description: |-
+                                          type for HostPath Volume
+                                          Defaults to ""
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'iscsi represents an ISCSI Disk resource
-                                      that is attached to a kubelet''s host machine
-                                      and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                    description: |-
+                                      iscsi represents an ISCSI Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://examples.k8s.io/volumes/iscsi/README.md
                                     properties:
                                       chapAuthDiscovery:
                                         description: chapAuthDiscovery defines whether
@@ -6985,31 +6400,27 @@ spec:
                                           support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       initiatorName:
-                                        description: initiatorName is the custom iSCSI
-                                          Initiator Name. If initiatorName is specified
-                                          with iscsiInterface simultaneously, new
-                                          iSCSI interface <target portal>:<volume
-                                          name> will be created for the connection.
+                                        description: |-
+                                          initiatorName is the custom iSCSI Initiator Name.
+                                          If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                          <target portal>:<volume name> will be created for the connection.
                                         type: string
                                       iqn:
                                         description: iqn is the target iSCSI Qualified
                                           Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iscsiInterface is the interface
-                                          Name that uses an iSCSI transport. Defaults
-                                          to 'default' (tcp).
+                                        description: |-
+                                          iscsiInterface is the interface Name that uses an iSCSI transport.
+                                          Defaults to 'default' (tcp).
                                         type: string
                                       lun:
                                         description: lun represents iSCSI Target Lun
@@ -7017,35 +6428,33 @@ spec:
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: portals is the iSCSI Target Portal
-                                          List. The portal is either an IP or ip_addr:port
-                                          if the port is other than default (typically
-                                          TCP ports 860 and 3260).
+                                        description: |-
+                                          portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false.
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
                                         type: boolean
                                       secretRef:
                                         description: secretRef is the CHAP Secret
                                           for iSCSI target and initiator authentication
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       targetPortal:
-                                        description: targetPortal is iSCSI Target
-                                          Portal. The Portal is either an IP or ip_addr:port
-                                          if the port is other than default (typically
-                                          TCP ports 860 and 3260).
+                                        description: |-
+                                          targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -7053,45 +6462,51 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'name of the volume. Must be a DNS_LABEL
-                                      and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: |-
+                                      name of the volume.
+                                      Must be a DNS_LABEL and unique within the pod.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                   nfs:
-                                    description: 'nfs represents an NFS mount on the
-                                      host that shares a pod''s lifetime More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    description: |-
+                                      nfs represents an NFS mount on the host that shares a pod's lifetime
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                     properties:
                                       path:
-                                        description: 'path that is exported by the
-                                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          path that is exported by the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          NFS export to be mounted with read-only
-                                          permissions. Defaults to false. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          readOnly here will force the NFS export to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: boolean
                                       server:
-                                        description: 'server is the hostname or IP
-                                          address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        description: |-
+                                          server is the hostname or IP address of the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                         type: string
                                     required:
                                     - path
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'persistentVolumeClaimVolumeSource
-                                      represents a reference to a PersistentVolumeClaim
-                                      in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    description: |-
+                                      persistentVolumeClaimVolumeSource represents a reference to a
+                                      PersistentVolumeClaim in the same namespace.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                     properties:
                                       claimName:
-                                        description: 'claimName is the name of a PersistentVolumeClaim
-                                          in the same namespace as the pod using this
-                                          volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        description: |-
+                                          claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                         type: string
                                       readOnly:
-                                        description: readOnly Will force the ReadOnly
-                                          setting in VolumeMounts. Default false.
+                                        description: |-
+                                          readOnly Will force the ReadOnly setting in VolumeMounts.
+                                          Default false.
                                         type: boolean
                                     required:
                                     - claimName
@@ -7102,11 +6517,10 @@ spec:
                                       mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       pdID:
                                         description: pdID is the ID that identifies
@@ -7121,16 +6535,15 @@ spec:
                                       machine
                                     properties:
                                       fsType:
-                                        description: fSType represents the filesystem
-                                          type to mount Must be a filesystem type
-                                          supported by the host operating system.
-                                          Ex. "ext4", "xfs". Implicitly inferred to
-                                          be "ext4" if unspecified.
+                                        description: |-
+                                          fSType represents the filesystem type to mount
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       volumeID:
                                         description: volumeID uniquely identifies
@@ -7144,14 +6557,11 @@ spec:
                                       secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: defaultMode are the mode bits
-                                          used to set permissions on created files
-                                          by default. Must be an octal value between
-                                          0000 and 0777 or a decimal value between
-                                          0 and 511. YAML accepts both octal and decimal
-                                          values, JSON requires decimal values for
-                                          mode bits. Directories within the path are
-                                          not affected by this setting.
+                                        description: |-
+                                          defaultMode are the mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       sources:
@@ -7166,15 +6576,12 @@ spec:
                                                 the configMap data to project
                                               properties:
                                                 items:
-                                                  description: items if unspecified,
-                                                    each key-value pair in the Data
-                                                    field of the referenced ConfigMap
-                                                    will be projected into the volume
-                                                    as a file whose name is the key
-                                                    and content is the value. If specified,
-                                                    the listed keys will be projected
-                                                    into the specified paths, and
-                                                    unlisted keys will not be present.
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    ConfigMap will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7184,27 +6591,19 @@ spec:
                                                           to project.
                                                         type: string
                                                       mode:
-                                                        description: 'mode is Optional:
-                                                          mode bits used to set permissions
-                                                          on this file. Must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: path is the relative
-                                                          path of the file to map
-                                                          the key to. May not be an
-                                                          absolute path. May not contain
-                                                          the path element '..'. May
-                                                          not start with the string
-                                                          '..'.
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -7212,10 +6611,10 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: optional specify whether
@@ -7259,17 +6658,11 @@ spec:
                                                         type: object
                                                         x-kubernetes-map-type: atomic
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
-                                                          on this file, must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
@@ -7284,12 +6677,9 @@ spec:
                                                           ''..'''
                                                         type: string
                                                       resourceFieldRef:
-                                                        description: 'Selects a resource
-                                                          of the container: only resources
-                                                          limits and requests (limits.cpu,
-                                                          limits.memory, requests.cpu
-                                                          and requests.memory) are
-                                                          currently supported.'
+                                                        description: |-
+                                                          Selects a resource of the container: only resources limits and requests
+                                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                         properties:
                                                           containerName:
                                                             description: 'Container
@@ -7324,15 +6714,12 @@ spec:
                                                 the secret data to project
                                               properties:
                                                 items:
-                                                  description: items if unspecified,
-                                                    each key-value pair in the Data
-                                                    field of the referenced Secret
-                                                    will be projected into the volume
-                                                    as a file whose name is the key
-                                                    and content is the value. If specified,
-                                                    the listed keys will be projected
-                                                    into the specified paths, and
-                                                    unlisted keys will not be present.
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    Secret will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present.
                                                   items:
                                                     description: Maps a string key
                                                       to a path within a volume.
@@ -7342,27 +6729,19 @@ spec:
                                                           to project.
                                                         type: string
                                                       mode:
-                                                        description: 'mode is Optional:
-                                                          mode bits used to set permissions
-                                                          on this file. Must be an
-                                                          octal value between 0000
-                                                          and 0777 or a decimal value
-                                                          between 0 and 511. YAML
-                                                          accepts both octal and decimal
-                                                          values, JSON requires decimal
-                                                          values for mode bits. If
-                                                          not specified, the volume
-                                                          defaultMode will be used.'
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: path is the relative
-                                                          path of the file to map
-                                                          the key to. May not be an
-                                                          absolute path. May not contain
-                                                          the path element '..'. May
-                                                          not start with the string
-                                                          '..'.
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -7370,10 +6749,10 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent.
+                                                  description: |-
+                                                    Name of the referent.
                                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                    TODO: Add other useful fields.
-                                                    apiVersion, kind, uid?'
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                                   type: string
                                                 optional:
                                                   description: optional field specify
@@ -7388,35 +6767,26 @@ spec:
                                                 data to project
                                               properties:
                                                 audience:
-                                                  description: audience is the intended
-                                                    audience of the token. A recipient
-                                                    of a token must identify itself
-                                                    with an identifier specified in
-                                                    the audience of the token, and
-                                                    otherwise should reject the token.
-                                                    The audience defaults to the identifier
-                                                    of the apiserver.
+                                                  description: |-
+                                                    audience is the intended audience of the token. A recipient of a token
+                                                    must identify itself with an identifier specified in the audience of the
+                                                    token, and otherwise should reject the token. The audience defaults to the
+                                                    identifier of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: expirationSeconds is
-                                                    the requested duration of validity
-                                                    of the service account token.
-                                                    As the token approaches expiration,
-                                                    the kubelet volume plugin will
-                                                    proactively rotate the service
-                                                    account token. The kubelet will
-                                                    start trying to rotate the token
-                                                    if the token is older than 80
-                                                    percent of its time to live or
-                                                    if the token is older than 24
-                                                    hours.Defaults to 1 hour and must
-                                                    be at least 10 minutes.
+                                                  description: |-
+                                                    expirationSeconds is the requested duration of validity of the service
+                                                    account token. As the token approaches expiration, the kubelet volume
+                                                    plugin will proactively rotate the service account token. The kubelet will
+                                                    start trying to rotate the token if the token is older than 80 percent of
+                                                    its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                    and must be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: path is the path relative
-                                                    to the mount point of the file
-                                                    to project the token into.
+                                                  description: |-
+                                                    path is the path relative to the mount point of the file to project the
+                                                    token into.
                                                   type: string
                                               required:
                                               - path
@@ -7429,29 +6799,29 @@ spec:
                                       on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: group to map volume access to
+                                        description: |-
+                                          group to map volume access to
                                           Default is no group
                                         type: string
                                       readOnly:
-                                        description: readOnly here will force the
-                                          Quobyte volume to be mounted with read-only
-                                          permissions. Defaults to false.
+                                        description: |-
+                                          readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                          Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: registry represents a single
-                                          or multiple Quobyte Registry services specified
-                                          as a string as host:port pair (multiple
-                                          entries are separated with commas) which
-                                          acts as the central registry for volumes
+                                        description: |-
+                                          registry represents a single or multiple Quobyte Registry services
+                                          specified as a string as host:port pair (multiple entries are separated with commas)
+                                          which acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: tenant owning the given Quobyte
-                                          volume in the Backend Used with dynamically
-                                          provisioned Quobyte volumes, value is set
-                                          by the plugin
+                                        description: |-
+                                          tenant owning the given Quobyte volume in the Backend
+                                          Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                         type: string
                                       user:
-                                        description: user to map volume access to
+                                        description: |-
+                                          user to map volume access to
                                           Defaults to serivceaccount user
                                         type: string
                                       volume:
@@ -7463,61 +6833,68 @@ spec:
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'rbd represents a Rados Block Device
-                                      mount on the host that shares a pod''s lifetime.
-                                      More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                    description: |-
+                                      rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md
                                     properties:
                                       fsType:
-                                        description: 'fsType is the filesystem type
-                                          of the volume that you want to mount. Tip:
-                                          Ensure that the filesystem type is supported
-                                          by the host operating system. Examples:
-                                          "ext4", "xfs", "ntfs". Implicitly inferred
-                                          to be "ext4" if unspecified. More info:
-                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
                                         type: string
                                       image:
-                                        description: 'image is the rados image name.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       keyring:
-                                        description: 'keyring is the path to key ring
-                                          for RBDUser. Default is /etc/ceph/keyring.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          keyring is the path to key ring for RBDUser.
+                                          Default is /etc/ceph/keyring.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       monitors:
-                                        description: 'monitors is a collection of
-                                          Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          monitors is a collection of Ceph monitors.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'pool is the rados pool name.
-                                          Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          pool is the rados pool name.
+                                          Default is rbd.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                       readOnly:
-                                        description: 'readOnly here will force the
-                                          ReadOnly setting in VolumeMounts. Defaults
-                                          to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: boolean
                                       secretRef:
-                                        description: 'secretRef is name of the authentication
-                                          secret for RBDUser. If provided overrides
-                                          keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          secretRef is name of the authentication secret for RBDUser. If provided
+                                          overrides keyring.
+                                          Default is nil.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       user:
-                                        description: 'user is the rados user name.
-                                          Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: |-
+                                          user is the rados user name.
+                                          Default is admin.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                         type: string
                                     required:
                                     - image
@@ -7528,10 +6905,11 @@ spec:
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Default is "xfs".
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs".
+                                          Default is "xfs".
                                         type: string
                                       gateway:
                                         description: gateway is the host address of
@@ -7543,21 +6921,20 @@ spec:
                                           configured storage.
                                         type: string
                                       readOnly:
-                                        description: readOnly Defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: secretRef references to the secret
-                                          for ScaleIO user and other sensitive information.
-                                          If this is not provided, Login operation
-                                          will fail.
+                                        description: |-
+                                          secretRef references to the secret for ScaleIO user and other
+                                          sensitive information. If this is not provided, Login operation will fail.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -7567,9 +6944,9 @@ spec:
                                           false
                                         type: boolean
                                       storageMode:
-                                        description: storageMode indicates whether
-                                          the storage for a volume should be ThickProvisioned
-                                          or ThinProvisioned. Default is ThinProvisioned.
+                                        description: |-
+                                          storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                          Default is ThinProvisioned.
                                         type: string
                                       storagePool:
                                         description: storagePool is the ScaleIO Storage
@@ -7580,9 +6957,9 @@ spec:
                                           system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: volumeName is the name of a volume
-                                          already created in the ScaleIO system that
-                                          is associated with this volume source.
+                                        description: |-
+                                          volumeName is the name of a volume already created in the ScaleIO system
+                                          that is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -7590,29 +6967,26 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'secret represents a secret that
-                                      should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    description: |-
+                                      secret represents a secret that should populate this volume.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                     properties:
                                       defaultMode:
-                                        description: 'defaultMode is Optional: mode
-                                          bits used to set permissions on created
-                                          files by default. Must be an octal value
-                                          between 0000 and 0777 or a decimal value
-                                          between 0 and 511. YAML accepts both octal
-                                          and decimal values, JSON requires decimal
-                                          values for mode bits. Defaults to 0644.
-                                          Directories within the path are not affected
-                                          by this setting.'
+                                        description: |-
+                                          defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values
+                                          for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
                                         format: int32
                                         type: integer
                                       items:
-                                        description: items If unspecified, each key-value
-                                          pair in the Data field of the referenced
-                                          Secret will be projected into the volume
-                                          as a file whose name is the key and content
-                                          is the value. If specified, the listed keys
-                                          will be projected into the specified paths,
-                                          and unlisted keys will not be present.
+                                        description: |-
+                                          items If unspecified, each key-value pair in the Data field of the referenced
+                                          Secret will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present.
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -7621,23 +6995,19 @@ spec:
                                               description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'mode is Optional: mode
-                                                bits used to set permissions on this
-                                                file. Must be an octal value between
-                                                0000 and 0777 or a decimal value between
-                                                0 and 511. YAML accepts both octal
-                                                and decimal values, JSON requires
-                                                decimal values for mode bits. If not
-                                                specified, the volume defaultMode
-                                                will be used.'
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
                                               format: int32
                                               type: integer
                                             path:
-                                              description: path is the relative path
-                                                of the file to map the key to. May
-                                                not be an absolute path. May not contain
-                                                the path element '..'. May not start
-                                                with the string '..'.
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -7649,9 +7019,9 @@ spec:
                                           the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'secretName is the name of the
-                                          secret in the pod''s namespace to use. More
-                                          info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        description: |-
+                                          secretName is the name of the secret in the pod's namespace to use.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                         type: string
                                     type: object
                                   storageos:
@@ -7659,45 +7029,41 @@ spec:
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: fsType is the filesystem type
-                                          to mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: readOnly defaults to false (read/write).
-                                          ReadOnly here will force the ReadOnly setting
-                                          in VolumeMounts.
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: secretRef specifies the secret
-                                          to use for obtaining the StorageOS API credentials.  If
-                                          not specified, default values will be attempted.
+                                        description: |-
+                                          secretRef specifies the secret to use for obtaining the StorageOS API
+                                          credentials.  If not specified, default values will be attempted.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       volumeName:
-                                        description: volumeName is the human-readable
-                                          name of the StorageOS volume.  Volume names
-                                          are only unique within a namespace.
+                                        description: |-
+                                          volumeName is the human-readable name of the StorageOS volume.  Volume
+                                          names are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: volumeNamespace specifies the
-                                          scope of the volume within StorageOS.  If
-                                          no namespace is specified then the Pod's
-                                          namespace will be used.  This allows the
-                                          Kubernetes name scoping to be mirrored within
-                                          StorageOS for tighter integration. Set VolumeName
-                                          to any name to override the default behaviour.
-                                          Set to "default" if you are not using namespaces
-                                          within StorageOS.
+                                        description: |-
+                                          volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                          namespace is specified then the Pod's namespace will be used.  This allows the
+                                          Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                          Set VolumeName to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces within StorageOS.
                                         type: string
                                     type: object
                                   vsphereVolume:
@@ -7706,11 +7072,10 @@ spec:
                                       machine
                                     properties:
                                       fsType:
-                                        description: fsType is filesystem type to
-                                          mount. Must be a filesystem type supported
-                                          by the host operating system. Ex. "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified.
+                                        description: |-
+                                          fsType is filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
                                         description: storagePolicyID is the storage
@@ -7746,8 +7111,9 @@ spec:
               Job.
             properties:
               completionTime:
-                description: Represents time when the job was completed. It is not
-                  guaranteed to be set in happens-before order across separate operations.
+                description: |-
+                  Represents time when the job was completed. It is not guaranteed to
+                  be set in happens-before order across separate operations.
                   It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
@@ -7785,9 +7151,10 @@ spec:
                   type: object
                 type: array
               lastReconcileTime:
-                description: Represents last time when the job was reconciled. It
-                  is not guaranteed to be set in happens-before order across separate
-                  operations. It is represented in RFC3339 form and is in UTC.
+                description: |-
+                  Represents last time when the job was reconciled. It is not guaranteed to
+                  be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               replicaStatuses:
@@ -7810,25 +7177,25 @@ spec:
                           description: matchExpressions is a list of label selector
                             requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector
                                   applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -7840,33 +7207,33 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     selector:
-                      description: A Selector is a label query over a set of resources.
-                        The result of matchLabels and matchExpressions are ANDed.
-                        An empty Selector matches all objects. A null Selector matches
-                        no objects.
+                      description: |-
+                        A Selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty Selector matches all objects. A null
+                        Selector matches no objects.
                       type: string
                     succeeded:
                       description: The number of pods which reached phase Succeeded.
                       format: int32
                       type: integer
                   type: object
-                description: ReplicaStatuses is map of ReplicaType and ReplicaStatus,
+                description: |-
+                  ReplicaStatuses is map of ReplicaType and ReplicaStatus,
                   specifies the status of each replica.
                 type: object
               startTime:
-                description: Represents time when the job was acknowledged by the
-                  job controller. It is not guaranteed to be set in happens-before
-                  order across separate operations. It is represented in RFC3339 form
-                  and is in UTC.
+                description: |-
+                  Represents time when the job was acknowledged by the job controller.
+                  It is not guaranteed to be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
             type: object


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Upgrade controller-gen to v0.14.0, in order to avoid runtime panic when conducting `make install` with Go 1.22.
(About this problem and solution is mentioned in [controller-gen: #888](https://github.com/kubernetes-sigs/controller-tools/issues/888))

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2025

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
