### PR TITLE
Support arm64 for Hugging Face trainer

### DIFF
--- a/.github/workflows/publish-core-images.yaml
+++ b/.github/workflows/publish-core-images.yaml
@@ -34,4 +34,4 @@ jobs:
           - component-name: trainer-huggingface
             dockerfile: sdk/python/kubeflow/trainer/Dockerfile
             context: sdk/python/kubeflow/trainer
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64

--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -28,16 +28,19 @@ runs:
     - name: Remove unnecessary files
       shell: bash
       run: |
+        echo "Disk usage before cleanup:"
+        df -hT
+
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf /opt/ghc
-        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf /usr/local/share/boost
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         sudo rm -rf /usr/local/lib/android
         sudo rm -rf /usr/local/share/powershell
         sudo rm -rf /usr/share/swift
-        
+
         echo "Disk usage after cleanup:"
-        df -h
+        df -hT
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -42,6 +42,13 @@ runs:
         echo "Disk usage after cleanup:"
         df -hT
 
+    - name: Prune docker images
+      shell: bash
+      run: |
+        docker image prune -a -f
+        docker system df
+        df -hT
+
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v2
       with:

--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -49,6 +49,24 @@ runs:
         docker system df
         df -hT
 
+    - name: Move docker data directory
+      shell: bash
+      run: |
+        echo "Stopping docker service ..."
+        sudo systemctl stop docker
+        DOCKER_DEFAULT_ROOT_DIR=/var/lib/docker
+        DOCKER_ROOT_DIR=/mnt/docker
+        echo "Moving ${DOCKER_DEFAULT_ROOT_DIR} -> ${DOCKER_ROOT_DIR}"
+        sudo mv ${DOCKER_DEFAULT_ROOT_DIR} ${DOCKER_ROOT_DIR}
+        echo "Creating symlink ${DOCKER_DEFAULT_ROOT_DIR} -> ${DOCKER_ROOT_DIR}"
+        sudo ln -s ${DOCKER_ROOT_DIR} ${DOCKER_DEFAULT_ROOT_DIR}
+        echo "$(sudo ls -l ${DOCKER_DEFAULT_ROOT_DIR})"
+        echo "Starting docker service ..."
+        sudo systemctl daemon-reload
+        sudo systemctl start docker
+        echo "Docker service status:"
+        sudo systemctl --no-pager -l -o short status docker
+
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v2
       with:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Following suggestion from @tenzen-y I have implemented a fix in the CI workflow to add support for multi-platform _linux/amd64_ and _linux/arm64_ image building for the Hugging Face trainer.

The necessary code changes follow from https://github.com/kserve/kserve/pull/3411.

In particular, docker images are pruned and the docker data directory is moved from the root volume to the _/mnt_ volume.

The resulting reduction in disk space usage in the root volume helps the CI workflow to complete without errors.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes https://github.com/kubeflow/training-operator/issues/1986

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
