### PR TITLE
CI: Use a mode=min in the builder cache

### DIFF
--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -93,4 +93,4 @@ runs:
         push: ${{ inputs.push }}
         tags: ${{ steps.meta.outputs.tags }}
         cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-to: type=gha


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I replaced cache-to mode with min (default value) to avoid the following timeout errors:

```
#7 writing layer sha256:202111e1e67fd289b555ea0a5f198b9919220afe610c9e070268fdd75c3dd5e2 600.1s done
#7 ERROR: error writing layer blob: maximum timeout reached
------
 > exporting to GitHub Actions Cache:
------
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
ERROR: failed to solve: error writing layer blob: maximum timeout reached
Error: buildx failed with: ERROR: failed to solve: error writing layer blob: maximum timeout reached
```

https://github.com/kubeflow/training-operator/actions/runs/8635377472/job/23674563980?pr=2051#step:5:1294

xref: https://github.com/docker/buildx/issues/841

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
