### PR TITLE
PyTorchJob: Always show warnings when using elasticPolicy.nProcPerNode

### DIFF
--- a/pkg/webhooks/pytorch/pytorchjob_webhook.go
+++ b/pkg/webhooks/pytorch/pytorchjob_webhook.go
@@ -88,11 +88,13 @@ func validateSpec(spec trainingoperator.PyTorchJobSpec) (admission.Warnings, fie
 	var allErrs field.ErrorList
 	var warnings admission.Warnings
 
-	if spec.NprocPerNode != nil && spec.ElasticPolicy != nil && spec.ElasticPolicy.NProcPerNode != nil {
+	if spec.ElasticPolicy != nil && spec.ElasticPolicy.NProcPerNode != nil {
 		elasticNProcPerNodePath := specPath.Child("elasticPolicy").Child("nProcPerNode")
 		nprocPerNodePath := specPath.Child("nprocPerNode")
-		allErrs = append(allErrs, field.Forbidden(elasticNProcPerNodePath, fmt.Sprintf("must not be used with %s", nprocPerNodePath)))
 		warnings = append(warnings, fmt.Sprintf("%s is deprecated, use %s instead", elasticNProcPerNodePath.String(), nprocPerNodePath.String()))
+		if spec.NprocPerNode != nil {
+			allErrs = append(allErrs, field.Forbidden(elasticNProcPerNodePath, fmt.Sprintf("must not be used with %s", nprocPerNodePath)))
+		}
 	}
 	allErrs = append(allErrs, validatePyTorchReplicaSpecs(spec.PyTorchReplicaSpecs)...)
 	return warnings, allErrs

--- a/pkg/webhooks/pytorch/pytorchjob_webhook_test.go
+++ b/pkg/webhooks/pytorch/pytorchjob_webhook_test.go
@@ -218,6 +218,37 @@ func TestValidateV1PyTorchJob(t *testing.T) {
 				field.Forbidden(pytorchReplicaSpecPath.Key(string(trainingoperator.PyTorchJobReplicaTypeMaster)).Child("replicas"), ""),
 			},
 		},
+		"Spec.ElasticPolicy.NProcPerNode are set": {
+			pytorchJob: &trainingoperator.PyTorchJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: trainingoperator.PyTorchJobSpec{
+					ElasticPolicy: &trainingoperator.ElasticPolicy{
+						NProcPerNode: ptr.To[int32](1),
+					},
+					PyTorchReplicaSpecs: map[trainingoperator.ReplicaType]*trainingoperator.ReplicaSpec{
+						trainingoperator.PyTorchJobReplicaTypeMaster: {
+							Replicas: ptr.To[int32](1),
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  "pytorch",
+											Image: "gcr.io/kubeflow-ci/pytorch-dist-mnist_test:1.0",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantWarnings: admission.Warnings{
+				fmt.Sprintf("%s is deprecated, use %s instead",
+					specPath.Child("elasticPolicy").Child("nProcPerNode"), specPath.Child("nprocPerNode")),
+			},
+		},
 		"Spec.NprocPerNode and Spec.ElasticPolicy.NProcPerNode are set": {
 			pytorchJob: &trainingoperator.PyTorchJob{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Currently, the PyTorchJob webhook shows a warning only when the Job has the `.spec.nprocPerNode` and the `.spec.elasticPolicy.nProcPerNode`, but we should always show a warning when using the `.spec.elasticPolicy.nProcPerNode`.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
