### PR TITLE
Remove deadcode related to PodDisruptionBudget

### DIFF
--- a/pkg/controller.v1/common/job_controller.go
+++ b/pkg/controller.v1/common/job_controller.go
@@ -48,15 +48,6 @@ var (
 	// key function but it should be just fine for non delete events.
 	KeyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
 
-	// Prometheus metrics
-	createdPDBCount = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "created_pod_disruption_policies_total",
-		Help: "The total number of created pod disruption policies",
-	})
-	deletedPDBCount = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "deleted_pod_disruption_policies_total",
-		Help: "The total number of deleted pod disruption policies",
-	})
 	createdPodGroupsCount = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "created_pod_groups_total",
 		Help: "The total number of created pod groups",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Actually, we never operate PDB in the training-operator, and those functions are never referred from any others.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
