### PR TITLE
Fix isort on examples/pytorch

### DIFF
--- a/examples/pytorch/cpu-demo/demo.py
+++ b/examples/pytorch/cpu-demo/demo.py
@@ -1,4 +1,5 @@
 import torch
+
 torch.distributed.init_process_group(init_method="env://")
 rank = torch.distributed.get_rank()
 world_size = torch.distributed.get_world_size()

--- a/examples/pytorch/elastic/echo/echo.py
+++ b/examples/pytorch/elastic/echo/echo.py
@@ -7,7 +7,6 @@ import time
 
 import torch.distributed as dist
 
-
 if __name__ == "__main__":
 
     env_dict = {


### PR DESCRIPTION
**What this PR does / why we need it**:

Python imports are out of order in examples/pytorch. 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_: NA