### PR TITLE
changed package name to flake8 to fix pytests pip install

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -19,7 +19,7 @@ TESTS_REQUIRES = [
     "pytest-tornasync",
     "mypy",
     "black==24.3.0",
-    "flake==4.0.1",
+    "flake8==4.0.1",
 ]
 
 REQUIRES = [


### PR DESCRIPTION
 I run into this error trying to pip install for pytest `pip install '.[test]':`

```
ERROR: Could not find a version that satisfies the requirement flake==4.0.1; extra == "test" (from kubeflow-training[test]) (from versions: none)
ERROR: No matching distribution found for flake==4.0.1; extra == "test"
```

When changing the line to `"flake8==4.0.1",` I get a successful run:

```
Successfully built kubeflow-training
Installing collected packages: kubeflow-training
  Attempting uninstall: kubeflow-training
    Found existing installation: kubeflow-training 1.7.0
    Uninstalling kubeflow-training-1.7.0:
      Successfully uninstalled kubeflow-training-1.7.0
Successfully installed kubeflow-training-1.7.0
```

No changes to the version, or anything else really.