### PR TITLE
[SDK] Fix Incorrect Events in get_job_logs API

### DIFF
--- a/sdk/python/kubeflow/training/utils/utils.py
+++ b/sdk/python/kubeflow/training/utils/utils.py
@@ -415,7 +415,7 @@ def add_event_to_dict(
 ):
     """Add Kubernetes event to the dict with this format:
     ```
-    {"<Object Kind> <Object Name>": "<Event Timestamp> <Event Message>"}
+    {"<Object Kind>/<Object Name>": "<Event Timestamp> <Event Message>"}
     ```
     """
     if (
@@ -423,10 +423,10 @@ def add_event_to_dict(
         and event.involved_object.name == object_name
         and event.metadata.creation_timestamp >= object_creation_timestamp
     ):
+        event_key = f"{object_kind.lower()}/{object_name}"
         event_time = event.metadata.creation_timestamp.strftime("%Y-%m-%d %H:%M:%S")
         event_msg = f"{event_time} {event.message}"
-        if object_name not in events_dict:
-            events_dict[f"{object_kind} {object_name}"] = [event_msg]
+        if event_key not in events_dict:
+            events_dict[event_key] = [event_msg]
         else:
-            events_dict[f"{object_kind} {object_name}"] += [event_msg]
-    return events_dict
+            events_dict[event_key] += [event_msg]


### PR DESCRIPTION
I fixed `add_event_to_dict` function to correctly check key in `events_dict` dictionary.
I introduced this bug in this commit: https://github.com/kubeflow/training-operator/pull/1975/commits/b2d9c365fdcf7ba71988e8bfe803ac7584a85447.

Also, I made the key as follows:
```
<object_kind>/<object_name>
pytorchjob/training-job
```


/assign @kubeflow/wg-training-leads @droctothorpe 