### PR TITLE
Add GitHub Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,50 @@
+name: Bug Report
+description: Tell us about a problem you are experiencing with Training Operator
+labels: ["kind/bug", "lifecycle/needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this Training Operator bug report!
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: |
+        Please provide as much info as possible. Not doing so may result in your bug not being
+        addressed in a timely manner.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      value: |
+        Kubernetes version:
+        ```bash
+        $ kubectl version
+
+        ```
+        Training Operator version:
+        ```bash
+        $ kubectl get pods -n kubeflow -l control-plane=kubeflow-training-operator -o jsonpath="{.items[*].spec.containers[*].image}"
+
+        ```
+        Training Operator Python SDK version:
+        ```bash
+        $ pip show kubeflow-training
+
+        ```
+    validations:
+      required: true
+  - type: input
+    id: votes
+    attributes:
+      label: Impacted by this bug?
+      value: Give it a 👍 We prioritize the issues with most 👍

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: true
+
+contact_links:
+  - name: Training Operator Documentation
+    url: https://www.kubeflow.org/docs/components/training/
+    about: Much help can be found in the docs
+  - name: Kubeflow Training Slack Channel
+    url: https://cloud-native.slack.com/archives/C0742LDFZ4K
+    about: Ask the Training Operator community on Slack

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,28 @@
+name: Feature Request
+description: Suggest an idea for Training Operator
+labels: ["kind/feature", "lifecycle/needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this Training Operator feature request!
+  - type: textarea
+    id: feature
+    attributes:
+      label: What you would like to be added?
+      description: |
+        A clear and concise description of what you want to add to Training Operator.
+        Please consider to write Training Operator enhancement proposal if it is a large feature request.
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why is this needed?
+    validations:
+      required: true
+  - type: input
+    id: votes
+    attributes:
+      label: Love this feature?
+      value: Give it a 👍 We prioritize the features with most 👍


### PR DESCRIPTION
I added similar issue template to help us triage issues: https://github.com/kubeflow/katib/pull/2335

/assign @kubeflow/wg-training-leads 