### PR TITLE
Automated cherry pick of #2079: fix volcano podgroup update issue

### DIFF
--- a/manifests/base/crds/kubeflow.org_mpijobs.yaml
+++ b/manifests/base/crds/kubeflow.org_mpijobs.yaml
@@ -7330,6 +7330,9 @@ spec:
                         type: string
                       queue:
                         type: string
+                        x-kubernetes-validations:
+                        - message: spec.runPolicy.schedulingPolicy.queue is immutable
+                          rule: self == oldSelf
                       scheduleTimeoutSeconds:
                         format: int32
                         type: integer

--- a/manifests/base/crds/kubeflow.org_mxjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_mxjobs.yaml
@@ -7333,6 +7333,9 @@ spec:
                         type: string
                       queue:
                         type: string
+                        x-kubernetes-validations:
+                        - message: spec.runPolicy.schedulingPolicy.queue is immutable
+                          rule: self == oldSelf
                       scheduleTimeoutSeconds:
                         format: int32
                         type: integer

--- a/manifests/base/crds/kubeflow.org_paddlejobs.yaml
+++ b/manifests/base/crds/kubeflow.org_paddlejobs.yaml
@@ -7812,6 +7812,9 @@ spec:
                         type: string
                       queue:
                         type: string
+                        x-kubernetes-validations:
+                        - message: spec.runPolicy.schedulingPolicy.queue is immutable
+                          rule: self == oldSelf
                       scheduleTimeoutSeconds:
                         format: int32
                         type: integer

--- a/manifests/base/crds/kubeflow.org_pytorchjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_pytorchjobs.yaml
@@ -7849,6 +7849,9 @@ spec:
                         type: string
                       queue:
                         type: string
+                        x-kubernetes-validations:
+                        - message: spec.runPolicy.schedulingPolicy.queue is immutable
+                          rule: self == oldSelf
                       scheduleTimeoutSeconds:
                         format: int32
                         type: integer

--- a/manifests/base/crds/kubeflow.org_tfjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_tfjobs.yaml
@@ -90,6 +90,9 @@ spec:
                         type: string
                       queue:
                         type: string
+                        x-kubernetes-validations:
+                        - message: spec.runPolicy.schedulingPolicy.queue is immutable
+                          rule: self == oldSelf
                       scheduleTimeoutSeconds:
                         format: int32
                         type: integer

--- a/manifests/base/crds/kubeflow.org_xgboostjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_xgboostjobs.yaml
@@ -86,6 +86,9 @@ spec:
                         type: string
                       queue:
                         type: string
+                        x-kubernetes-validations:
+                        - message: spec.runPolicy.schedulingPolicy.queue is immutable
+                          rule: self == oldSelf
                       scheduleTimeoutSeconds:
                         format: int32
                         type: integer

--- a/pkg/apis/kubeflow.org/v1/common_types.go
+++ b/pkg/apis/kubeflow.org/v1/common_types.go
@@ -226,7 +226,8 @@ type RunPolicy struct {
 // SchedulingPolicy encapsulates various scheduling policies of the distributed training
 // job, for example `minAvailable` for gang-scheduling.
 type SchedulingPolicy struct {
-	MinAvailable           *int32                                 `json:"minAvailable,omitempty"`
+	MinAvailable *int32 `json:"minAvailable,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="spec.runPolicy.schedulingPolicy.queue is immutable"
 	Queue                  string                                 `json:"queue,omitempty"`
 	MinResources           *map[v1.ResourceName]resource.Quantity `json:"minResources,omitempty"`
 	PriorityClass          string                                 `json:"priorityClass,omitempty"`

--- a/pkg/controller.v1/common/scheduling.go
+++ b/pkg/controller.v1/common/scheduling.go
@@ -19,8 +19,7 @@ package common
 import (
 	"fmt"
 
-	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
-
+	"github.com/google/go-cmp/cmp"
 	log "github.com/sirupsen/logrus"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type FillPodGroupSpecFunc func(object metav1.Object) (metav1.Object, error)
+type FillPodGroupSpecFunc func(object metav1.Object) error
 
 func (jc *JobController) SyncPodGroup(job metav1.Object, specFunc FillPodGroupSpecFunc) (metav1.Object, error) {
 	pgctl := jc.PodGroupControl
@@ -37,20 +36,14 @@ func (jc *JobController) SyncPodGroup(job metav1.Object, specFunc FillPodGroupSp
 	podGroup, err := pgctl.GetPodGroup(job.GetNamespace(), job.GetName())
 	if err == nil {
 		// update podGroup for gang scheduling
-		updatedSpecPodGroup, err := specFunc(podGroup)
-		if err != nil {
+		oldPodGroup := &podGroup
+		if err = specFunc(podGroup); err != nil {
 			return nil, fmt.Errorf("unable to fill the spec of PodGroup, '%v': %v", klog.KObj(podGroup), err)
 		}
-
-		existVolcanoPodGroup := podGroup.(*volcanov1beta1.PodGroup)
-		updatedSpecVolcanoPodGroup := updatedSpecPodGroup.(*volcanov1beta1.PodGroup)
-		// The hpa-controller may update the num of replicas
-		// https://github.com/kubeflow/common/pull/207
-		if existVolcanoPodGroup.Spec.MinMember != updatedSpecVolcanoPodGroup.Spec.MinMember {
-			// The queue name should not be changed after the pg is created
-			updatedSpecVolcanoPodGroup.Spec.Queue = existVolcanoPodGroup.Spec.Queue
-			return updatedSpecPodGroup, pgctl.UpdatePodGroup(updatedSpecPodGroup.(client.Object))
+		if diff := cmp.Diff(oldPodGroup, podGroup); len(diff) != 0 {
+			return podGroup, pgctl.UpdatePodGroup(podGroup.(client.Object))
 		}
+		return podGroup, nil
 	} else if client.IgnoreNotFound(err) != nil {
 		return nil, fmt.Errorf("unable to get a PodGroup: %v", err)
 	} else {
@@ -60,14 +53,13 @@ func (jc *JobController) SyncPodGroup(job metav1.Object, specFunc FillPodGroupSp
 		newPodGroup.SetNamespace(job.GetNamespace())
 		newPodGroup.SetAnnotations(job.GetAnnotations())
 		newPodGroup.SetOwnerReferences([]metav1.OwnerReference{*jc.GenOwnerReference(job)})
-		updatedSpecPodGroup, err := specFunc(newPodGroup)
-		if err != nil {
+		if err = specFunc(newPodGroup); err != nil {
 			return nil, fmt.Errorf("unable to fill the spec of PodGroup, '%v': %v", klog.KObj(newPodGroup), err)
 		}
 
-		err = pgctl.CreatePodGroup(updatedSpecPodGroup.(client.Object))
+		err = pgctl.CreatePodGroup(newPodGroup)
 		if err != nil {
-			return updatedSpecPodGroup, fmt.Errorf("unable to create PodGroup: %v", err)
+			return podGroup, fmt.Errorf("unable to create PodGroup: %v", err)
 		}
 		createdPodGroupsCount.Inc()
 	}

--- a/pkg/controller.v1/pytorch/pytorchjob_controller_test.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller_test.go
@@ -195,6 +195,29 @@ var _ = Describe("PyTorchJob controller", func() {
 			cond := getCondition(created.Status, kubeflowv1.JobSucceeded)
 			Expect(cond.Status).To(Equal(corev1.ConditionTrue))
 		})
+		It("Shouldn't be updated resources if spec.runPolicy.schedulingPolicy.queue is changed after the job is created", func() {
+			By("Creating a PyTorchJob with a specific queue")
+			job.Spec.RunPolicy.SchedulingPolicy = &kubeflowv1.SchedulingPolicy{}
+			job.Spec.RunPolicy.SchedulingPolicy.Queue = "initial-queue"
+			Expect(testK8sClient.Create(ctx, job)).Should(Succeed())
+
+			By("Attempting to update the PyTorchJob with a different queue value")
+			updatedJob := &kubeflowv1.PyTorchJob{}
+			Expect(testK8sClient.Get(ctx, client.ObjectKeyFromObject(job), updatedJob)).Should(Succeed(), "Failed to get PyTorchJob")
+
+			updatedJob.Spec.RunPolicy.SchedulingPolicy.Queue = "test"
+			err := testK8sClient.Update(ctx, updatedJob)
+
+			By("Checking that the queue update fails")
+			Expect(err).To(HaveOccurred(), "Expected an error when updating the queue, but update succeeded")
+			Expect(err.Error()).To(ContainSubstring("spec.runPolicy.schedulingPolicy.queue is immutable"), "The error message did not contain the expected message")
+
+			By("Validating the queue was not updated")
+			freshJob := &kubeflowv1.PyTorchJob{}
+			Expect(testK8sClient.Get(ctx, client.ObjectKeyFromObject(job), freshJob)).Should(Succeed(), "Failed to get PyTorchJob after update attempt")
+			Expect(freshJob.Spec.RunPolicy.SchedulingPolicy.Queue).To(Equal("initial-queue"), "The queue should remain as the initial value since it should be immutable")
+
+		})
 
 		It("Shouldn't create resources if PyTorchJob is suspended", func() {
 			By("By creating a new PyTorchJob with suspend=true")


### PR DESCRIPTION
Cherry pick of #2079 on v1.8-branch.
#2079: fix volcano podgroup update issue
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```