### PR TITLE
Automated cherry pick of #2109: changed package name to flake8 to fix pip install

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -19,7 +19,7 @@ TESTS_REQUIRES = [
     "pytest-tornasync",
     "mypy",
     "black==24.3.0",
-    "flake==4.0.1",
+    "flake8==4.0.1",
 ]
 
 REQUIRES = [


### PR DESCRIPTION
Cherry pick of #2109 on v1.8-branch.
#2109: changed package name to flake8 to fix pip install
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

I stole the commit since #2109 was not signed in CLA...
