### PR TITLE
[SDK] Sync Transformers version for train API

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -64,6 +64,6 @@ setuptools.setup(
     tests_require=TESTS_REQUIRES,
     extras_require={
         "test": TESTS_REQUIRES,
-        "huggingface": ["transformers==4.37.2", "peft==0.3.0"],
+        "huggingface": ["transformers==4.38.0", "peft==0.3.0"],
     },
 )


### PR DESCRIPTION
We should keep Transformers version the same with [our Trainer image](https://github.com/kubeflow/training-operator/blob/master/sdk/python/kubeflow/trainer/requirements.txt#L3).

Otherwise, users can see the errors with incompatible arguments for HuggingFace [Trainer](https://github.com/kubeflow/training-operator/blob/bb8bba00ff0b48de922c523b0d3051f8b2d4ee74/sdk/python/kubeflow/trainer/hf_llm_training.py#L120-L125)

/assign @johnugeorge @deepanker13 @tenzen-y 