### PR TITLE
Release Training Operator Image for v1.8.0-rc.1

### DIFF
--- a/manifests/overlays/kubeflow/kustomization.yaml
+++ b/manifests/overlays/kubeflow/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - kubeflow-training-roles.yaml
 images:
   - name: kubeflow/training-operator
-    newTag: "v1-f8f7363"
+    newTag: "v1-4485b0a"
 # TODO (tenzen-y): Once we support cert-manager, we need to remove this secret generation.
 # REF: https://github.com/kubeflow/training-operator/issues/2049
 secretGenerator:

--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - namespace.yaml
 images:
   - name: kubeflow/training-operator
-    newTag: "v1-f8f7363"
+    newTag: "v1-4485b0a"
 secretGenerator:
   - name: training-operator-webhook-cert
     options:


### PR DESCRIPTION
I updated image tag for `v1.8.0-rc.1` release.

/assign @kubeflow/wg-training-leads 