### PR TITLE
fix:  suspend job status can not turn into Suspended and report error…

### DIFF
--- a/pkg/controller.v1/common/job.go
+++ b/pkg/controller.v1/common/job.go
@@ -383,9 +383,12 @@ func (jc *JobController) CleanUpResources(
 			jc.Recorder.Eventf(runtimeObject, corev1.EventTypeNormal, "SuccessfulDeletePodGroup", "Deleted PodGroup: %v", metaObject.GetName())
 		}
 	}
-	if err := jc.CleanupJob(runPolicy, jobStatus, runtimeObject); err != nil {
-		return err
+	if !trainutil.IsJobSuspended(runPolicy) {
+		if err := jc.CleanupJob(runPolicy, jobStatus, runtimeObject); err != nil {
+			return err
+		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
What this PR does / why we need it:

Fixed a bug ,  when turn a job's suspend runpolicy into true, it's condation never become into Suspened and report error "job completion time is nil, cannot cleanup"




