### PR TITLE
Update `huggingface_hub` Version in the storage initializer to fix ImportError

### DIFF
--- a/sdk/python/kubeflow/storage_initializer/requirements.txt
+++ b/sdk/python/kubeflow/storage_initializer/requirements.txt
@@ -2,4 +2,4 @@ peft==0.3.0
 datasets==2.15.0
 transformers==4.38.0
 boto3==1.33.9
-huggingface_hub==0.19.3
+huggingface_hub==0.23.4


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to the update of `huggingface_hub`, `split_torch_state_dict_into_shards` is not supported in v0.19.3. Therefore, I updated the version in the `requirements.txt` for the storage initializer to fix the "ImportError".

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2179 

**Checklist:**
