### PR TITLE
Update trainer to ensure type consistency for `train_args` and `lora_config`

### DIFF
--- a/sdk/python/kubeflow/trainer/hf_llm_training.py
+++ b/sdk/python/kubeflow/trainer/hf_llm_training.py
@@ -166,7 +166,9 @@ if __name__ == "__main__":
     logger.info("Starting HuggingFace LLM Trainer")
     args = parse_arguments()
     train_args = TrainingArguments(**json.loads(args.training_parameters))
-    reference_train_args = transformers.TrainingArguments(output_dir=train_args.output_dir)
+    reference_train_args = transformers.TrainingArguments(
+        output_dir=train_args.output_dir
+    )
     for key, val in train_args.to_dict().items():
         old_attr = getattr(reference_train_args, key, None)
         if old_attr is not None:

--- a/sdk/python/kubeflow/trainer/hf_llm_training.py
+++ b/sdk/python/kubeflow/trainer/hf_llm_training.py
@@ -109,7 +109,7 @@ def load_and_preprocess_data(dataset_dir, transformer_type, tokenizer):
 
 def setup_peft_model(model, lora_config):
     # Set up the PEFT model
-    lora_config = LoraConfig(**json.loads(args.lora_config))
+    lora_config = LoraConfig(**json.loads(lora_config))
     reference_lora_config = LoraConfig()
     for key, val in lora_config.__dict__.items():
         old_attr = getattr(reference_lora_config, key, None)

--- a/sdk/python/kubeflow/trainer/hf_llm_training.py
+++ b/sdk/python/kubeflow/trainer/hf_llm_training.py
@@ -109,7 +109,14 @@ def load_and_preprocess_data(dataset_dir, transformer_type, tokenizer):
 
 def setup_peft_model(model, lora_config):
     # Set up the PEFT model
-    lora_config = LoraConfig(**json.loads(lora_config))
+    lora_config = LoraConfig(**json.loads(args.lora_config))
+    reference_lora_config = LoraConfig()
+    for key, val in lora_config.__dict__.items():
+        old_attr = getattr(reference_lora_config, key, None)
+        if old_attr is not None:
+            val = type(old_attr)(val)
+        setattr(lora_config, key, val)
+
     model.enable_input_require_grads()
     model = get_peft_model(model, lora_config)
     return model
@@ -159,6 +166,13 @@ if __name__ == "__main__":
     logger.info("Starting HuggingFace LLM Trainer")
     args = parse_arguments()
     train_args = TrainingArguments(**json.loads(args.training_parameters))
+    reference_train_args = transformers.TrainingArguments(output_dir=train_args.output_dir)
+    for key, val in train_args.to_dict().items():
+        old_attr = getattr(reference_train_args, key, None)
+        if old_attr is not None:
+            val = type(old_attr)(val)
+        setattr(train_args, key, val)
+
     transformer_type = getattr(transformers, args.transformer_type)
 
     logger.info("Setup model and tokenizer")


### PR DESCRIPTION
**What this PR does / why we need it**:
Add data preprocessing for `train_args` and `lora_config` to ensure each parameter's type is consistent with the reference value. This will be necessary for developing the Katib `tune` API to optimize hyperparameters.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**
