### PR TITLE
Update the name of PVC in `train` API

### DIFF
--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -204,7 +204,7 @@ class TrainingClient(object):
             self.core_api.create_namespaced_persistent_volume_claim(
                 namespace=namespace,
                 body=utils.get_pvc_spec(
-                    pvc_name=constants.STORAGE_INITIALIZER,
+                    pvc_name=name,
                     namespace=namespace,
                     storage_config=storage_config,
                 ),
@@ -213,9 +213,9 @@ class TrainingClient(object):
             pvc_list = self.core_api.list_namespaced_persistent_volume_claim(namespace)
             # Check if the PVC with the specified name exists
             for pvc in pvc_list.items:
-                if pvc.metadata.name == constants.STORAGE_INITIALIZER:
+                if pvc.metadata.name == name:
                     print(
-                        f"PVC '{constants.STORAGE_INITIALIZER}' already exists in namespace "
+                        f"PVC '{name}' already exists in namespace "
                         f"{namespace}."
                     )
                     break

--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -276,17 +276,24 @@ class TrainingClient(object):
             resources=resources_per_worker,
         )
 
+        storage_initializer_volume = models.V1Volume(
+            name=constants.STORAGE_INITIALIZER,
+            persistent_volume_claim=models.V1PersistentVolumeClaimVolumeSource(
+                claim_name=name
+            ),
+        )
+
         # create worker pod spec
         worker_pod_template_spec = utils.get_pod_template_spec(
             containers=[container_spec],
-            volumes=[constants.STORAGE_INITIALIZER_VOLUME],
+            volumes=[storage_initializer_volume],
         )
 
         # create master pod spec
         master_pod_template_spec = utils.get_pod_template_spec(
             containers=[container_spec],
             init_containers=[init_container_spec],
-            volumes=[constants.STORAGE_INITIALIZER_VOLUME],
+            volumes=[storage_initializer_volume],
         )
 
         job = utils.get_pytorchjob_template(

--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -214,10 +214,7 @@ class TrainingClient(object):
             # Check if the PVC with the specified name exists
             for pvc in pvc_list.items:
                 if pvc.metadata.name == name:
-                    print(
-                        f"PVC '{name}' already exists in namespace "
-                        f"{namespace}."
-                    )
+                    print(f"PVC '{name}' already exists in namespace " f"{namespace}.")
                     break
             else:
                 raise RuntimeError(f"failed to create PVC. Error: {e}")

--- a/sdk/python/kubeflow/training/constants/constants.py
+++ b/sdk/python/kubeflow/training/constants/constants.py
@@ -84,12 +84,7 @@ STORAGE_INITIALIZER_VOLUME_MOUNT = models.V1VolumeMount(
     name=STORAGE_INITIALIZER,
     mount_path=INIT_CONTAINER_MOUNT_PATH,
 )
-STORAGE_INITIALIZER_VOLUME = models.V1Volume(
-    name=STORAGE_INITIALIZER,
-    persistent_volume_claim=models.V1PersistentVolumeClaimVolumeSource(
-        claim_name=STORAGE_INITIALIZER
-    ),
-)
+
 TRAINER_TRANSFORMER_IMAGE = "docker.io/kubeflow/trainer-huggingface"
 
 # TFJob constants.


### PR DESCRIPTION
**What this PR does / why we need it**:
According to [the discussion](https://github.com/kubeflow/katib/pull/2393#discussion_r1691781750), this PR updates the name of PVC in `train` API to have pvc_name == job_name. In this case, each job will have a separate PVC.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**