### PR TITLE
KEP-2170: Make API specification more restricting

### DIFF
--- a/docs/proposals/2170-kubeflow-training-v2/README.md
+++ b/docs/proposals/2170-kubeflow-training-v2/README.md
@@ -322,10 +322,6 @@ type TrainingRuntimeRef struct {
 	// when TrainingRuntime is used in the kind.
 	Name string `json:"name"`
 
-	// APIVersion is the apiVersion for the runtime.
-	// Defaults to the v2alpha1.
-	APIVersion *string `json:apiVersion,omitempty`
-
 	// Kind for the runtime, which must be TrainingRuntime or ClusterTrainingRuntime.
 	// Defaults to the ClusterTrainingRuntime.
 	Kind *string `json:"kind,omitempty"`
@@ -1617,3 +1613,28 @@ So, we do not support the arbitrary values until we find reasonable use cases th
 need to reconcile the TrainJob.
 
 Note that we should implement the status transitions validations to once we support the arbitrary values in the `manageBy` field.
+
+### Support Multiple API Versions of TrainingRuntime
+
+We can consider to introduce the `version` field for runtime API version to the `.spec.trainingRuntimeRef`
+so that we can support multiple API versions of TrainingRuntime.
+
+It could mitigate the pain points when users upgrade the older API Version to newer API Version like alpha to beta.
+But, we do not aim to support both Alpha and Beta versions or both first Alpha and second Alpha versions in the specific training-operator release.
+Hence, the `version` field was not introduced.
+
+```go
+type TrainingRuntimeRef struct {
+	[...]
+
+	// APIVersion is the apiVersion for the runtime.
+	// Defaults to the v2alpha1.
+	Version *string `json:version,omitempty`
+
+	[...]
+}
+```
+
+However, we may want to revisit this discussion when we graduate the API version from Beta to GA
+because in general, it would be better to support both Beta and GA versions for a while
+so that we can align with the Kubernetes deprecation policy for mitigating migration obstacles.

--- a/docs/proposals/2170-kubeflow-training-v2/README.md
+++ b/docs/proposals/2170-kubeflow-training-v2/README.md
@@ -321,9 +321,9 @@ type TrainingRuntimeRef struct {
 type TrainJobStatus struct {
 	// Conditions for the TrainJob. Initially, it will have the same conditions as JobSet.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
-
-  // ReplicatedJobsStatus track the number of Jobs for each replicatedJob in JobSet.
-  ReplicatedJobsStatus []ReplicatedJobStatus `json:"replicatedJobsStatus,omitempty"`
+	
+	// ReplicatedJobsStatus track the number of Jobs for each replicatedJob in JobSet.
+	ReplicatedJobsStatus []ReplicatedJobStatus `json:"replicatedJobsStatus,omitempty"`
 }
 
 type ReplicatedJobStatus struct {

--- a/docs/proposals/2170-kubeflow-training-v2/README.md
+++ b/docs/proposals/2170-kubeflow-training-v2/README.md
@@ -305,17 +305,18 @@ type TrainJobSpec struct {
 }
 
 type TrainingRuntimeRef struct {
-	// Name for the training runtime.
+	// Name for the runtime.
+	// This must indicate the runtime deployed in the same namespace as the TrainJob
+	// when TrainingRuntime is used in the kind.
 	Name string `json:"name"`
+	
+	// APIVersion is the apiVersion for the runtime.
+	// Defaults to the v2alpha1.
+	APIVersion *string `json:apiVersion,omitempty`
 
-	// Namespace for the runtime. In that case, user should use TrainingRuntime
-	Namespace *string `json:"namespace,omitempty"`
-
-	// Kind for the runtime. TrainingRuntime or ClusterTrainingRuntime
+	// Kind for the runtime, which must be TrainingRuntime or ClusterTrainingRuntime.
+	// Defaults to the TrainingRuntime.
 	Kind *string `json:"kind,omitempty"`
-
-	// Version for the runtime. For example: v2alpha1
-	Version *string `json:"version,omitempty"`
 }
 
 type TrainJobStatus struct {

--- a/docs/proposals/2170-kubeflow-training-v2/README.md
+++ b/docs/proposals/2170-kubeflow-training-v2/README.md
@@ -301,11 +301,11 @@ type TrainJobSpec struct {
 	Suspend *bool `json:"suspend,omitempty"`
 
 	// ManagedBy is used to indicate the controller or entity that manages a TrainJob.
-	// The value must be either an empty, 'training-operator.kubeflow.org/trainjob-controller' or
+	// The value must be either an empty, 'kubeflow.org/trainjob-controller' or
 	// 'kueue.x-k8s.io/multikueue'.
 	// The built-in TrainJob controller reconciles TrainJob which don't have this
 	// field at all or the field value is the reserved string
-	// 'training-operator.kubeflow.org/trainjob-controller', but delegates reconciling TrainJobs
+	// 'kubeflow.org/trainjob-controller', but delegates reconciling TrainJobs
 	// with a 'kueue.x-k8s.io/multikueue' to the Kueue.
 	//
 	// The value must be a valid domain-prefixed path (e.g. acme.io/foo) -
@@ -1607,7 +1607,7 @@ model parallelizm). For some specific use-cases like MPI or Elastic PyTorch, we 
 ### Allow users to specify arbitrary value in the managedBy field
 
 We can allow users to specify the arbitrary values instead of restricting the `.spec.managedBy` field in the TrainJob
-with an empty, 'training-operator.kubeflow.org/trainjob-controller' or 'kusus.x-k8s.io/multikueue'.
+with an empty, 'kubeflow.org/trainjob-controller' or 'kusus.x-k8s.io/multikueue'.
 
 But, the arbitrary values allow users to specify external or in-house customized training-operator, which means that
 the TrainJobs are reconciled by the controllers without any specification compliance.

--- a/docs/proposals/2170-kubeflow-training-v2/README.md
+++ b/docs/proposals/2170-kubeflow-training-v2/README.md
@@ -327,7 +327,7 @@ type TrainingRuntimeRef struct {
 	APIVersion *string `json:apiVersion,omitempty`
 
 	// Kind for the runtime, which must be TrainingRuntime or ClusterTrainingRuntime.
-	// Defaults to the TrainingRuntime.
+	// Defaults to the ClusterTrainingRuntime.
 	Kind *string `json:"kind,omitempty"`
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I updated the below API definitions for the Training v2 API:

1. `trainingRuntimeRef`
    1. I removed the `namespace` field since we should use the TrainingRuntime deployed in the same namespace with the TrainJob. Otherwise, users should define the ClusterTrainingRuntime instead of the namespace-scoped TrainingRuntime resource.
    2. I renamed the `version` field with `apiVersion` since we are sometimes confused if the version indicates the runtime revision or API version.
2. `managedBy`
    1. I added limitations and restrictions based on discussions in https://github.com/kubeflow/training-operator/issues/2193. The `managedBy` field is acceptable only for either an empty value, "training-operator.kubeflow.org/trainjob-controller" or "kueue.x-k8s.io/multikueue".

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Related: https://github.com/kubeflow/training-operator/issues/2170

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
