### PR TITLE
KEP-2170: Add the apiGroup to the TrainingRuntimeRef

### DIFF
--- a/docs/proposals/2170-kubeflow-training-v2/README.md
+++ b/docs/proposals/2170-kubeflow-training-v2/README.md
@@ -317,13 +317,18 @@ type TrainJobSpec struct {
 }
 
 type TrainingRuntimeRef struct {
-	// Name for the runtime.
+	// Name is the name of the runtime being referenced.
 	// This must indicate the runtime deployed in the same namespace as the TrainJob
 	// when TrainingRuntime is used in the kind.
 	Name string `json:"name"`
 
-	// Kind for the runtime, which must be TrainingRuntime or ClusterTrainingRuntime.
-	// Defaults to the ClusterTrainingRuntime.
+	// APIGroup is the group of the runtime being referenced.
+	// Defaults to 'kubeflow.org'.
+	APIGroup *string `json:"apiGroup,omitempty"`
+
+	// Kind is the kind of the runtime being referenced.
+	// The value must be TrainingRuntime or ClusterTrainingRuntime when the 'kubeflow.org' is used in the apiGroup.
+	// Defaults to the ClusterTrainingRuntime when the 'kubeflow.org' is used in the apiGroup.
 	Kind *string `json:"kind,omitempty"`
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Based on [this discussion](https://github.com/kubeflow/training-operator/pull/2198#discussion_r1707795122), I added the `apiGroup` field to the `.spec.trainingRuntimeRef` in the TrainJob.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Part-of #2170

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
