### PR TITLE
feat: Support debugging webhooks locally

### DIFF
--- a/docs/development/developer_guide.md
+++ b/docs/development/developer_guide.md
@@ -106,6 +106,39 @@ Defaulted container "pytorch" out of: pytorch, init-pytorch (init)
 2024-04-19T19:00:57Z INFO     Train Epoch: 1 [10240/60000 (17%)]	loss=1.1650
 ```
 
+## Running the Operator and Debugging Locally
+
+If you need to develop, test, and debug the Operator on your local machine (such as a Mac) and want to disable webhook validation, you can follow the steps below.
+
+### Configure KUBECONFIG and KUBEFLOW_NAMESPACE
+
+We can configure the Operator to use the configuration available in your kubeconfig to communicate with a K8s cluster. Set your environment:
+
+```sh
+export KUBECONFIG=$(echo ~/.kube/config)
+```
+
+### Create the CRDS
+After the cluster is up, the CRDS should be created on the cluster.
+The CRDS created using `/manifests/overlays/local` will ignore the webhook validation.
+
+```bash
+kubectl apply -k ./manifests/overlays/local
+```
+
+### Run Operator
+
+Now we are ready to run the Operator locally and disable webhook validation, 
+
+```sh
+go run ./cmd/training-operator.v1/main.go -disable-webhook=true
+```
+- `-disable-webhook=true`: This flag disables webhook validation.
+
+
+This way, the Operator will run locally and will not perform any webhook-related operations, making it easier for you to debug.
+
+
 ## Testing changes locally
 
 Now that you confirmed you can spin up an operator locally, you can try to test your local changes to the operator.
@@ -143,6 +176,9 @@ You should be able to see a pod for your training operator running in your names
 ```
 kubectl logs -n kubeflow -l training.kubeflow.org/job-name=pytorch-simple
 ```
+
+
+
 ## Go version
 
 On ubuntu the default go package appears to be gccgo-go which has problems see [issue](https://github.com/golang/go/issues/15429) golang-go package is also really old so install from golang tarballs instead.

--- a/manifests/overlays/local/kustomization.yaml
+++ b/manifests/overlays/local/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- ../../base/
+- namespace.yaml
+images:
+- name: kubeflow/training-operator
+  newName: kubeflow/training-operator
+  newTag: latest
+secretGenerator:
+- name: training-operator-webhook-cert
+  options:
+    disableNameSuffixHash: true
+patches:
+- path: validating_webhook_patch.yaml
+  target:
+    group: admissionregistration.k8s.io
+    kind: ValidatingWebhookConfiguration
+    version: v1

--- a/manifests/overlays/local/namespace.yaml
+++ b/manifests/overlays/local/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeflow

--- a/manifests/overlays/local/validating_webhook_patch.yaml
+++ b/manifests/overlays/local/validating_webhook_patch.yaml
@@ -1,0 +1,13 @@
+---
+- op: replace
+  path: /webhooks/0/failurePolicy
+  value: Ignore
+- op: replace
+  path: /webhooks/1/failurePolicy
+  value: Ignore
+- op: replace
+  path: /webhooks/2/failurePolicy
+  value: Ignore
+- op: replace
+  path: /webhooks/3/failurePolicy
+  value: Ignore


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Add a method for quick local development and debugging, enabling developers to rapidly develop and debug the operator on their local machines, such as a Mac.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2226 

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
