### PR TITLE
[SDK] Training Client Conditions related unit tests

### DIFF
--- a/sdk/python/kubeflow/training/api/training_client_test.py
+++ b/sdk/python/kubeflow/training/api/training_client_test.py
@@ -631,6 +631,65 @@ test_data_get_job_conditions = [
 ]
 
 
+test_data_is_job_created = [
+    (
+        "valid flow with default namespace and default timeout",
+        {"name": TEST_NAME},
+        False,  # Default created Job condition is Succeded
+    ),
+    (
+        "valid flow with job that is created",
+        {"name": TEST_NAME, "namespace": CREATED},
+        True,
+    ),
+    (
+        "valid flow with all parameters set",
+        {
+            "name": TEST_NAME,
+            "namespace": CREATED,
+            "job": create_job(),
+            "job_kind": constants.PYTORCHJOB_KIND,
+            "timeout": 120,
+        },
+        True,
+    ),
+    (
+        "invalid flow with default namespace and a Job that doesn't exist",
+        {"name": TEST_NAME, "job_kind": constants.TFJOB_KIND},
+        RuntimeError,
+    ),
+    (
+        "invalid flow incorrect parameter",
+        {"name": TEST_NAME, "test": "example"},
+        TypeError,
+    ),
+    (
+        "invalid flow withincorrect value",
+        {"name": TEST_NAME, "job_kind": "FailJob"},
+        ValueError,
+    ),
+    (
+        "runtime error case",
+        {
+            "name": TEST_NAME,
+            "namespace": "runtime",
+            "job_kind": constants.PYTORCHJOB_KIND,
+        },
+        RuntimeError,
+    ),
+    (
+        "invalid flow with timeout error",
+        {"name": TEST_NAME, "namespace": TIMEOUT},
+        TimeoutError,
+    ),
+    (
+        "invalid flow with runtime error",
+        {"name": TEST_NAME, "namespace": RUNTIME},
+        RuntimeError,
+    ),
+]
+
+
 @pytest.fixture
 def training_client():
     with patch(
@@ -793,6 +852,25 @@ def test_get_job_conditions(training_client, test_name, kwargs, expected_output)
         assert expected_output == generate_job_with_status(
             create_job(), namespace=kwargs.get("namespace")
         )
+    except Exception as e:
+        assert type(e) is expected_output
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize("test_name,kwargs,expected_output", test_data_is_job_created)
+def test_is_job_created(training_client, test_name, kwargs, expected_output):
+    """
+    test is_job_created function of training client
+    """
+    print("Executing test: ", test_name)
+
+    try:
+        training_client.is_job_created(**kwargs)
+        if kwargs.get("namespace") is not (CREATED or RUNTIME or TIMEOUT):
+            assert expected_output is False
+        else:
+            assert expected_output is True
     except Exception as e:
         assert type(e) is expected_output
 

--- a/sdk/python/kubeflow/training/api/training_client_test.py
+++ b/sdk/python/kubeflow/training/api/training_client_test.py
@@ -808,6 +808,65 @@ test_data_is_job_restarting = [
 ]
 
 
+test_data_is_job_failed = [
+    (
+        "valid flow with default namespace and default timeout",
+        {"name": TEST_NAME},
+        False,  # Default created Job condition is Succeded
+    ),
+    (
+        "valid flow with job that is failed",
+        {"name": TEST_NAME, "namespace": FAILED},
+        True,
+    ),
+    (
+        "valid flow with all parameters set",
+        {
+            "name": TEST_NAME,
+            "namespace": FAILED,
+            "job": create_job(),
+            "job_kind": constants.PYTORCHJOB_KIND,
+            "timeout": 120,
+        },
+        True,
+    ),
+    (
+        "invalid flow with default namespace and a Job that doesn't exist",
+        {"name": TEST_NAME, "job_kind": constants.TFJOB_KIND},
+        RuntimeError,
+    ),
+    (
+        "invalid flow incorrect parameter",
+        {"name": TEST_NAME, "test": "example"},
+        TypeError,
+    ),
+    (
+        "invalid flow withincorrect value",
+        {"name": TEST_NAME, "job_kind": "FailJob"},
+        ValueError,
+    ),
+    (
+        "runtime error case",
+        {
+            "name": TEST_NAME,
+            "namespace": "runtime",
+            "job_kind": constants.PYTORCHJOB_KIND,
+        },
+        RuntimeError,
+    ),
+    (
+        "invalid flow with timeout error",
+        {"name": TEST_NAME, "namespace": TIMEOUT},
+        TimeoutError,
+    ),
+    (
+        "invalid flow with runtime error",
+        {"name": TEST_NAME, "namespace": RUNTIME},
+        RuntimeError,
+    ),
+]
+
+
 @pytest.fixture
 def training_client():
     with patch(
@@ -1026,6 +1085,25 @@ def test_is_job_restarting(training_client, test_name, kwargs, expected_output):
     try:
         training_client.is_job_restarting(**kwargs)
         if kwargs.get("namespace") is not (RESTARTING or RUNTIME or TIMEOUT):
+            assert expected_output is False
+        else:
+            assert expected_output is True
+    except Exception as e:
+        assert type(e) is expected_output
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize("test_name,kwargs,expected_output", test_data_is_job_failed)
+def test_is_job_failed(training_client, test_name, kwargs, expected_output):
+    """
+    test is_is_job_failed function of training client
+    """
+    print("Executing test: ", test_name)
+
+    try:
+        training_client.is_job_failed(**kwargs)
+        if kwargs.get("namespace") is not (FAILED or RUNTIME or TIMEOUT):
             assert expected_output is False
         else:
             assert expected_output is True


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->
**What this PR does / why we need it**:
The following unit tests are added with this PR. 
* get_job_conditions
* is_job_created
* is_job_running
* is_job_restarting
* is_job_failed
* is_job_succeeded

You can verify each unit test with the following command substituting `<test_name>` for one of the tests above.
```
pytest -v sdk/python/kubeflow/training/api/training_client_test.py -k <test_name>
```
**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Related to #2161

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
