### PR TITLE
Bump Training Python SDK to 1.8.1 version

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -33,7 +33,7 @@ REQUIRES = [
 
 setuptools.setup(
     name="kubeflow-training",
-    version="1.8.0",
+    version="1.8.1",
     author="Kubeflow Authors",
     author_email="hejinchi@cn.ibm.com",
     license="Apache License Version 2.0",


### PR DESCRIPTION
Updating Training Python SDK to the 1.8.1 version.

/assign @kubeflow/wg-training-leads