### PR TITLE
[SDK] Minor fix in wait_for_job_conditions with job_kind python training API

### DIFF
--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -909,7 +909,7 @@ class TrainingClient(object):
             )
 
             # Get Job conditions.
-            conditions = self.get_job_conditions(job=job, timeout=timeout)
+            conditions = self.get_job_conditions(job=job, timeout=timeout, job_kind=job_kind)
             if len(conditions) > 0:
                 status_logger(
                     name,

--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -909,7 +909,9 @@ class TrainingClient(object):
             )
 
             # Get Job conditions.
-            conditions = self.get_job_conditions(job=job, timeout=timeout, job_kind=job_kind)
+            conditions = self.get_job_conditions(
+                job=job, timeout=timeout, job_kind=job_kind
+            )
             if len(conditions) > 0:
                 status_logger(
                     name,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR fixes a minor bug in the wait_for_job_conditions function of the python training SDK

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing

**Bug**
- Encountered this bug when testing the [create-tfjob.ipynb](https://github.com/kubeflow/training-operator/blob/da11d1116c29322c481d0b8f174df8d6f05004aa/examples/tensorflow/image-classification/create-tfjob.ipynb#L315) notebook example
- When `job_kind` (which is not PyTorch job kind) is passed in `wait_for_job_conditions` the SDK throws a ValueError.
Example code:
`TrainingClient(namespace=namespace).wait_for_job_conditions(name, job_kind=constants.TFJOB_KIND)`

Error:
```
ValueError: Job must be one of these types: KubeflowOrgV1PyTorchJob ('KubeflowOrgV1TFJob', 'KubeflowOrgV1PyTorchJob', 'KubeflowOrgV1XGBoostJob', 'KubeflowOrgV1MPIJob', 'KubeflowOrgV1PaddleJob', 'KubeflowOrgV1JAXJob')
```

**Fix**
- When [wait_for_job_conditions](https://github.com/kubeflow/training-operator/blob/da11d1116c29322c481d0b8f174df8d6f05004aa/sdk/python/kubeflow/training/api/training_client.py#L854) calls the [get_job_conditions](https://github.com/kubeflow/training-operator/blob/da11d1116c29322c481d0b8f174df8d6f05004aa/sdk/python/kubeflow/training/api/training_client.py#L613) function, since job_kind is not passed, it takes the default value of `PyTorchJob` [from here](https://github.com/kubeflow/training-operator/blob/da11d1116c29322c481d0b8f174df8d6f05004aa/sdk/python/kubeflow/training/api/training_client.py#L649) which leads to the error.