### PR TITLE
KEP-2170: Implement TrainJob Reconciler to manage objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ bin/
 /tf-operator
 vendor/
 testbin/*
-dep-crds/
+manifests/external-crds/
 cover.out
 
 # IDEs

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ bin/
 /tf-operator
 vendor/
 testbin/*
+dep-crds/
 cover.out
 
 # IDEs

--- a/Makefile
+++ b/Makefile
@@ -130,11 +130,11 @@ kustomize: ## Download kustomize locally if necessary.
 	GOBIN=$(PROJECT_DIR)/bin go install sigs.k8s.io/kustomize/kustomize/v4@v4.5.7
 
 ## Download external CRDs for the integration testings.
-EXTERNAL_CRDS_DIR ?= $(PROJECT_DIR)/dep-crds
+EXTERNAL_CRDS_DIR ?= $(PROJECT_DIR)/manifests/external-crds
 
 JOBSET_ROOT = $(shell go list -m -mod=readonly -f "{{.Dir}}" sigs.k8s.io/jobset)
 .PHONY: jobset-operator-crd
-jobset-operator-crd: ## Copy the CRDs from the jobset-operator to the dep-crds directory.
+jobset-operator-crd: ## Copy the CRDs from the jobset-operator to the manifests/external-crds directory.
 	mkdir -p $(EXTERNAL_CRDS_DIR)/jobset-operator/
 	cp -f $(JOBSET_ROOT)/config/components/crd/bases/* $(EXTERNAL_CRDS_DIR)/jobset-operator/
 
@@ -142,4 +142,4 @@ SCHEDULER_PLUGINS_ROOT = $(shell go list -m -f "{{.Dir}}" sigs.k8s.io/scheduler-
 .PHONY: scheduler-plugins-crd
 scheduler-plugins-crd:
 	mkdir -p $(EXTERNAL_CRDS_DIR)/scheduler-plugins/
-	cp -f $(SCHEDULER_PLUGINS_ROOT)/manifests/coscheduling/* $(PROJECT_DIR)/dep-crds/scheduler-plugins
+	cp -f $(SCHEDULER_PLUGINS_ROOT)/manifests/coscheduling/* $(EXTERNAL_CRDS_DIR)/scheduler-plugins

--- a/Makefile
+++ b/Makefile
@@ -74,15 +74,16 @@ HAS_SETUP_ENVTEST := $(shell command -v setup-envtest;)
 testall: manifests generate fmt vet golangci-lint test ## Run tests.
 
 test: envtest
-	KUBEBUILDER_ASSETS="$(shell setup-envtest use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell setup-envtest use $(ENVTEST_K8S_VERSION) -p path)" \
+		go test ./pkg/apis/kubeflow.org/v1/... ./pkg/cert/... ./pkg/common/... ./pkg/config/... ./pkg/controller.v1/... ./pkg/core/... ./pkg/util/... ./pkg/webhooks/... -coverprofile cover.out
 
 .PHONY: test-integrationv2
-test-integrationv2: envtest
+test-integrationv2: envtest jobset-operator-crd scheduler-plugins-crd
 	KUBEBUILDER_ASSETS="$(shell setup-envtest use $(ENVTEST_K8S_VERSION) -p path)" go test ./test/... -coverprofile cover.out
 
 .PHONY: testv2
 testv2:
-	go test ./pkg/controller.v2/... ./pkg/runtime.v2/... ./pkg/webhook.v2/... ./pkg/util.v2/... -coverprofile cover.out
+	go test ./pkg/apis/kubeflow.org/v2alpha1/... ./pkg/controller.v2/... ./pkg/runtime.v2/... ./pkg/webhook.v2/... ./pkg/util.v2/... -coverprofile cover.out
 
 envtest:
 ifndef HAS_SETUP_ENVTEST
@@ -127,3 +128,18 @@ controller-gen: ## Download controller-gen locally if necessary.
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
 	GOBIN=$(PROJECT_DIR)/bin go install sigs.k8s.io/kustomize/kustomize/v4@v4.5.7
+
+## Download external CRDs for the integration testings.
+EXTERNAL_CRDS_DIR ?= $(PROJECT_DIR)/dep-crds
+
+JOBSET_ROOT = $(shell go list -m -mod=readonly -f "{{.Dir}}" sigs.k8s.io/jobset)
+.PHONY: jobset-operator-crd
+jobset-operator-crd: ## Copy the CRDs from the jobset-operator to the dep-crds directory.
+	mkdir -p $(EXTERNAL_CRDS_DIR)/jobset-operator/
+	cp -f $(JOBSET_ROOT)/config/components/crd/bases/* $(EXTERNAL_CRDS_DIR)/jobset-operator/
+
+SCHEDULER_PLUGINS_ROOT = $(shell go list -m -f "{{.Dir}}" sigs.k8s.io/scheduler-plugins)
+.PHONY: scheduler-plugins-crd
+scheduler-plugins-crd:
+	mkdir -p $(EXTERNAL_CRDS_DIR)/scheduler-plugins/
+	cp -f $(SCHEDULER_PLUGINS_ROOT)/manifests/coscheduling/* $(PROJECT_DIR)/dep-crds/scheduler-plugins

--- a/pkg/controller.v2/trainjob_controller.go
+++ b/pkg/controller.v2/trainjob_controller.go
@@ -20,10 +20,13 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	kubeflowv2 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1"
 	runtime "github.com/kubeflow/training-operator/pkg/runtime.v2"
@@ -33,13 +36,15 @@ type TrainJobReconciler struct {
 	log      logr.Logger
 	client   client.Client
 	recorder record.EventRecorder
+	runtimes map[string]runtime.Runtime
 }
 
-func NewTrainJobReconciler(client client.Client, recorder record.EventRecorder) *TrainJobReconciler {
+func NewTrainJobReconciler(client client.Client, recorder record.EventRecorder, runs map[string]runtime.Runtime) *TrainJobReconciler {
 	return &TrainJobReconciler{
 		log:      ctrl.Log.WithName("trainjob-controller"),
 		client:   client,
 		recorder: recorder,
+		runtimes: runs,
 	}
 }
 
@@ -49,15 +54,70 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log := ctrl.LoggerFrom(ctx).WithValues("trainJob", klog.KObj(&trainJob))
-	ctrl.LoggerInto(ctx, log)
+	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(2).Info("Reconciling TrainJob")
+	if err := r.createOrUpdateObjs(ctx, &trainJob); err != nil {
+		return ctrl.Result{}, err
+	}
+	// TODO (tenzen-y): Do update the status.
 	return ctrl.Result{}, nil
 }
 
-func (r *TrainJobReconciler) SetupWithManager(mgr ctrl.Manager, runtimes map[string]runtime.Runtime) error {
+func (r *TrainJobReconciler) createOrUpdateObjs(ctx context.Context, trainJob *kubeflowv2.TrainJob) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Controller assumes the runtime existence has already verified in the webhook on TrainJob creation.
+	run := r.runtimes[runtimeRefToGroupKind(trainJob.Spec.RuntimeRef).String()]
+	objs, err := run.NewObjects(ctx, trainJob)
+	if err != nil {
+		return err
+	}
+	for _, obj := range objs {
+		var gvk schema.GroupVersionKind
+		if gvk, err = apiutil.GVKForObject(obj.DeepCopyObject(), r.client.Scheme()); err != nil {
+			return err
+		}
+		logKeysAndValues := []any{
+			"groupVersionKind", gvk.String(),
+			"namespace", obj.GetNamespace(),
+			"name", obj.GetName(),
+		}
+		// TODO (tenzen-y): Ideally, we should use the SSA instead of checking existence.
+		// Non-empty resourceVersion indicates UPDATE operation.
+		var creationErr error
+		var created bool
+		if obj.GetResourceVersion() == "" {
+			creationErr = r.client.Create(ctx, obj)
+			created = creationErr == nil
+		}
+		switch {
+		case created:
+			log.V(5).Info("Succeeded to create object", logKeysAndValues)
+			continue
+		case client.IgnoreAlreadyExists(creationErr) != nil:
+			return creationErr
+		default:
+			// This indicates CREATE operation has not been performed or the object has already existed in the cluster.
+			if err = r.client.Update(ctx, obj); err != nil {
+				return err
+			}
+			log.V(5).Info("Succeeded to update object", logKeysAndValues)
+		}
+	}
+	return nil
+}
+
+func runtimeRefToGroupKind(runtimeRef kubeflowv2.RuntimeRef) schema.GroupKind {
+	return schema.GroupKind{
+		Group: ptr.Deref(runtimeRef.APIGroup, ""),
+		Kind:  ptr.Deref(runtimeRef.Kind, ""),
+	}
+}
+
+func (r *TrainJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	b := ctrl.NewControllerManagedBy(mgr).
 		For(&kubeflowv2.TrainJob{})
-	for _, run := range runtimes {
+	for _, run := range r.runtimes {
 		for _, registrar := range run.EventHandlerRegistrars() {
 			if registrar != nil {
 				b = registrar(b, mgr.GetClient())

--- a/pkg/runtime.v2/core/clustertrainingruntime_test.go
+++ b/pkg/runtime.v2/core/clustertrainingruntime_test.go
@@ -46,6 +46,7 @@ func TestClusterTrainingRuntimeNewObjects(t *testing.T) {
 	}{
 		"succeeded to build JobSet and PodGroup": {
 			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				Suspend(true).
 				UID("uid").
 				RuntimeRef(kubeflowv2.SchemeGroupVersion.WithKind(kubeflowv2.ClusterTrainingRuntimeKind), "test-runtime").
 				Trainer(
@@ -57,7 +58,7 @@ func TestClusterTrainingRuntimeNewObjects(t *testing.T) {
 			clusterTrainingRuntime: baseRuntime.RuntimeSpec(
 				testingutil.MakeTrainingRuntimeSpecWrapper(baseRuntime.Spec).
 					ContainerImage("test:runtime").
-					PodGroupPolicySchedulingTimeout(120).
+					PodGroupPolicyCoschedulingSchedulingTimeout(120).
 					MLPolicyNumNodes(20).
 					ResourceRequests(0, corev1.ResourceList{
 						corev1.ResourceCPU: resource.MustParse("1"),
@@ -69,6 +70,7 @@ func TestClusterTrainingRuntimeNewObjects(t *testing.T) {
 			).Obj(),
 			wantObjs: []client.Object{
 				testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
+					Suspend(true).
 					PodLabel(schedulerpluginsv1alpha1.PodGroupLabel, "test-job").
 					ContainerImage(ptr.To("test:trainjob")).
 					JobCompletionMode(batchv1.IndexedCompletion).

--- a/pkg/runtime.v2/core/trainingruntime_test.go
+++ b/pkg/runtime.v2/core/trainingruntime_test.go
@@ -46,6 +46,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 	}{
 		"succeeded to build JobSet and PodGroup": {
 			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				Suspend(true).
 				UID("uid").
 				RuntimeRef(kubeflowv2.SchemeGroupVersion.WithKind(kubeflowv2.TrainingRuntimeKind), "test-runtime").
 				SpecLabel("conflictLabel", "override").
@@ -62,7 +63,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 				RuntimeSpec(
 					testingutil.MakeTrainingRuntimeSpecWrapper(baseRuntime.Spec).
 						ContainerImage("test:runtime").
-						PodGroupPolicySchedulingTimeout(120).
+						PodGroupPolicyCoschedulingSchedulingTimeout(120).
 						MLPolicyNumNodes(20).
 						ResourceRequests(0, corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("1"),
@@ -74,6 +75,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 				).Obj(),
 			wantObjs: []client.Object{
 				testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
+					Suspend(true).
 					Label("conflictLabel", "override").
 					Annotation("conflictAnnotation", "override").
 					PodLabel(schedulerpluginsv1alpha1.PodGroupLabel, "test-job").

--- a/pkg/runtime.v2/framework/core/framework_test.go
+++ b/pkg/runtime.v2/framework/core/framework_test.go
@@ -334,13 +334,12 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 		ResourceRequests(1, corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("1"),
 			corev1.ResourceMemory: resource.MustParse("2Gi"),
-		}).
-		Clone()
+		})
 	jobSetWithPropagatedTrainJobParams := jobSetBase.
+		Clone().
 		JobCompletionMode(batchv1.IndexedCompletion).
 		ContainerImage(ptr.To("foo:bar")).
-		ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind("TrainJob"), "test-job", "uid").
-		Clone()
+		ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind("TrainJob"), "test-job", "uid")
 
 	cases := map[string]struct {
 		runtimeInfo     *runtime.Info
@@ -361,6 +360,7 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 				Obj(),
 			runtimeInfo: &runtime.Info{
 				Obj: jobSetBase.
+					Clone().
 					Obj(),
 				Policy: runtime.Policy{
 					MLPolicy: &kubeflowv2.MLPolicy{
@@ -403,10 +403,12 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 					ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind("TrainJob"), "test-job", "uid").
 					Obj(),
 				jobSetWithPropagatedTrainJobParams.
+					Clone().
 					Obj(),
 			},
 			wantRuntimeInfo: &runtime.Info{
 				Obj: jobSetWithPropagatedTrainJobParams.
+					Clone().
 					Obj(),
 				Policy: runtime.Policy{
 					MLPolicy: &kubeflowv2.MLPolicy{

--- a/pkg/runtime.v2/framework/plugins/jobset/builder.go
+++ b/pkg/runtime.v2/framework/plugins/jobset/builder.go
@@ -28,12 +28,12 @@ import (
 )
 
 type Builder struct {
-	*jobsetv1alpha2.JobSet
+	jobsetv1alpha2.JobSet
 }
 
 func NewBuilder(objectKey client.ObjectKey, jobSetTemplateSpec kubeflowv2.JobSetTemplateSpec) *Builder {
 	return &Builder{
-		JobSet: &jobsetv1alpha2.JobSet{
+		JobSet: jobsetv1alpha2.JobSet{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: jobsetv1alpha2.SchemeGroupVersion.String(),
 				Kind:       "JobSet",
@@ -76,8 +76,13 @@ func (b *Builder) PodLabels(labels map[string]string) *Builder {
 	return b
 }
 
+func (b *Builder) Suspend(suspend *bool) *Builder {
+	b.Spec.Suspend = suspend
+	return b
+}
+
 // TODO: Need to support all TrainJob fields.
 
 func (b *Builder) Build() *jobsetv1alpha2.JobSet {
-	return b.JobSet
+	return &b.JobSet
 }

--- a/test/integration/controller.v2/trainjob_controller_test.go
+++ b/test/integration/controller.v2/trainjob_controller_test.go
@@ -19,13 +19,19 @@ package controllerv2
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	schedulerpluginsv1alpha1 "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 
 	kubeflowv2 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1"
+	testingutil "github.com/kubeflow/training-operator/pkg/util.v2/testing"
 	"github.com/kubeflow/training-operator/test/integration/framework"
+	"github.com/kubeflow/training-operator/test/util"
 )
 
 var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
@@ -54,22 +60,185 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 	})
 
 	ginkgo.When("Reconciling TrainJob", func() {
+		var (
+			trainJob        *kubeflowv2.TrainJob
+			trainJobKey     client.ObjectKey
+			trainingRuntime *kubeflowv2.TrainingRuntime
+		)
+
 		ginkgo.AfterEach(func() {
 			gomega.Expect(k8sClient.DeleteAllOf(ctx, &kubeflowv2.TrainJob{}, client.InNamespace(ns.Name))).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("Should succeed to create TrainJob", func() {
-			trainJob := &kubeflowv2.TrainJob{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: kubeflowv2.SchemeGroupVersion.String(),
-					Kind:       "TrainJob",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "alpha",
-					Namespace: ns.Name,
-				},
-			}
+		ginkgo.BeforeEach(func() {
+			trainJob = testingutil.MakeTrainJobWrapper(ns.Name, "alpha").
+				Suspend(true).
+				RuntimeRef(kubeflowv2.GroupVersion.WithKind(kubeflowv2.TrainingRuntimeKind), "alpha").
+				SpecLabel("testingKey", "testingVal").
+				SpecAnnotation("testingKey", "testingVal").
+				Trainer(
+					testingutil.MakeTrainJobTrainerWrapper().
+						ContainerImage("trainJob").
+						Obj()).
+				Obj()
+			trainJobKey = client.ObjectKeyFromObject(trainJob)
+			baseRuntime := testingutil.MakeTrainingRuntimeWrapper(ns.Name, "alpha")
+			trainingRuntime = baseRuntime.Clone().
+				RuntimeSpec(
+					testingutil.MakeTrainingRuntimeSpecWrapper(baseRuntime.Clone().Spec).
+						ContainerImage("trainingRuntime").
+						PodGroupPolicyCoscheduling(&kubeflowv2.CoschedulingPodGroupPolicySource{}).
+						MLPolicyNumNodes(100).
+						ResourceRequests(0, corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("5"),
+						}).
+						ResourceRequests(1, corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("10"),
+						}).
+						Obj()).
+				Obj()
+		})
+
+		ginkgo.It("Should succeed to create TrainJob with TrainingRuntime", func() {
+			ginkgo.By("Creating TrainingRuntime and TrainJob")
+			gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
 			gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+
+			ginkgo.By("Checking if appropriately JobSet and PodGroup are created")
+			gomega.Eventually(func(g gomega.Gomega) {
+				jobSet := &jobsetv1alpha2.JobSet{}
+				g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
+				g.Expect(jobSet).Should(gomega.BeComparableTo(
+					testingutil.MakeJobSetWrapper(ns.Name, trainJobKey.Name).
+						Suspend(true).
+						Label("testingKey", "testingVal").
+						Annotation("testingKey", "testingVal").
+						PodLabel(schedulerpluginsv1alpha1.PodGroupLabel, trainJobKey.Name).
+						ContainerImage(ptr.To("trainJob")).
+						JobCompletionMode(batchv1.IndexedCompletion).
+						ResourceRequests(0, corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("5"),
+						}).
+						ResourceRequests(1, corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("10"),
+						}).
+						ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind(kubeflowv2.TrainJobKind), trainJobKey.Name, string(trainJob.UID)).
+						Obj(),
+					util.IgnoreObjectMetadata))
+				pg := &schedulerpluginsv1alpha1.PodGroup{}
+				g.Expect(k8sClient.Get(ctx, trainJobKey, pg)).Should(gomega.Succeed())
+				g.Expect(pg).Should(gomega.BeComparableTo(
+					testingutil.MakeSchedulerPluginsPodGroup(ns.Name, trainJobKey.Name).
+						MinMember(200).
+						MinResources(corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1500"),
+						}).
+						ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind(kubeflowv2.TrainJobKind), trainJobKey.Name, string(trainJob.UID)).
+						Obj(),
+					util.IgnoreObjectMetadata))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("Should succeeded to update JobSet only when TrainJob is suspended", func() {
+			ginkgo.By("Creating TrainingRuntime and suspended TrainJob")
+			gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+
+			ginkgo.By("Checking if JobSet and PodGroup are created")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, trainJobKey, &jobsetv1alpha2.JobSet{})).Should(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, trainJobKey, &schedulerpluginsv1alpha1.PodGroup{})).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Updating suspended TrainJob Trainer image")
+			updatedImageName := "updated-trainer-image"
+			originImageName := *trainJob.Spec.Trainer.Image
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, trainJobKey, trainJob)).Should(gomega.Succeed())
+				trainJob.Spec.Trainer.Image = &updatedImageName
+				g.Expect(k8sClient.Update(ctx, trainJob)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Trainer image should be updated")
+			gomega.Eventually(func(g gomega.Gomega) {
+				jobSet := &jobsetv1alpha2.JobSet{}
+				g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
+				g.Expect(jobSet).Should(gomega.BeComparableTo(
+					testingutil.MakeJobSetWrapper(ns.Name, trainJobKey.Name).
+						Suspend(true).
+						Label("testingKey", "testingVal").
+						Annotation("testingKey", "testingVal").
+						PodLabel(schedulerpluginsv1alpha1.PodGroupLabel, trainJobKey.Name).
+						ContainerImage(&updatedImageName).
+						JobCompletionMode(batchv1.IndexedCompletion).
+						ResourceRequests(0, corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("5"),
+						}).
+						ResourceRequests(1, corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("10"),
+						}).
+						ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind(kubeflowv2.TrainJobKind), trainJobKey.Name, string(trainJob.UID)).
+						Obj(),
+					util.IgnoreObjectMetadata))
+				pg := &schedulerpluginsv1alpha1.PodGroup{}
+				g.Expect(k8sClient.Get(ctx, trainJobKey, pg)).Should(gomega.Succeed())
+				g.Expect(pg).Should(gomega.BeComparableTo(
+					testingutil.MakeSchedulerPluginsPodGroup(ns.Name, trainJobKey.Name).
+						MinMember(200).
+						MinResources(corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1500"),
+						}).
+						ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind(kubeflowv2.TrainJobKind), trainJobKey.Name, string(trainJob.UID)).
+						Obj(),
+					util.IgnoreObjectMetadata))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Unsuspending TrainJob")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, trainJobKey, trainJob)).Should(gomega.Succeed())
+				trainJob.Spec.Suspend = ptr.To(false)
+				g.Expect(k8sClient.Update(ctx, trainJob)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				jobSet := &jobsetv1alpha2.JobSet{}
+				g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
+				g.Expect(ptr.Deref(jobSet.Spec.Suspend, false)).Should(gomega.BeFalse())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Trying to restore trainer image")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, trainJobKey, trainJob)).Should(gomega.Succeed())
+				trainJob.Spec.Trainer.Image = &originImageName
+				g.Expect(k8sClient.Update(ctx, trainJob)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Checking if JobSet keep having updated image")
+			gomega.Consistently(func(g gomega.Gomega) {
+				jobSet := &jobsetv1alpha2.JobSet{}
+				g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
+				for _, rJob := range jobSet.Spec.ReplicatedJobs {
+					g.Expect(rJob.Template.Spec.Template.Spec.Containers[0].Image).Should(gomega.Equal(updatedImageName))
+				}
+			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Trying to re-suspend TrainJob and restore trainer image")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, trainJobKey, trainJob))
+				trainJob.Spec.Suspend = ptr.To(true)
+				trainJob.Spec.Trainer.Image = &originImageName
+				g.Expect(k8sClient.Update(ctx, trainJob)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Checking if JobSet image is restored")
+			gomega.Eventually(func(g gomega.Gomega) {
+				jobSet := &jobsetv1alpha2.JobSet{}
+				g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
+				g.Expect(jobSet.Spec.Suspend).ShouldNot(gomega.BeNil())
+				g.Expect(*jobSet.Spec.Suspend).Should(gomega.BeTrue())
+				for _, rJob := range jobSet.Spec.ReplicatedJobs {
+					g.Expect(rJob.Template.Spec.Template.Spec.Containers[0].Image).Should(gomega.Equal(originImageName))
+				}
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
 

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -36,6 +36,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	schedulerpluginsv1alpha1 "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 
 	kubeflowv2 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1"
 	controllerv2 "github.com/kubeflow/training-operator/pkg/controller.v2"
@@ -52,7 +54,11 @@ func (f *Framework) Init() *rest.Config {
 	log.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter), zap.UseDevMode(true)))
 	ginkgo.By("bootstrapping test environment")
 	f.testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "manifests", "v2", "base", "crds")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "manifests", "v2", "base", "crds"),
+			filepath.Join("..", "..", "..", "dep-crds", "scheduler-plugins", "crd.yaml"),
+			filepath.Join("..", "..", "..", "dep-crds", "jobset-operator"),
+		},
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "manifests", "v2", "base", "webhook")},
 		},
@@ -67,8 +73,8 @@ func (f *Framework) Init() *rest.Config {
 func (f *Framework) RunManager(cfg *rest.Config) (context.Context, client.Client) {
 	webhookInstallOpts := &f.testEnv.WebhookInstallOptions
 	gomega.ExpectWithOffset(1, kubeflowv2.AddToScheme(scheme.Scheme)).NotTo(gomega.HaveOccurred())
-
-	// +kubebuilder:scaffold:scheme
+	gomega.ExpectWithOffset(1, jobsetv1alpha2.AddToScheme(scheme.Scheme)).NotTo(gomega.HaveOccurred())
+	gomega.ExpectWithOffset(1, schedulerpluginsv1alpha1.AddToScheme(scheme.Scheme)).NotTo(gomega.HaveOccurred())
 
 	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -56,8 +56,8 @@ func (f *Framework) Init() *rest.Config {
 	f.testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "..", "manifests", "v2", "base", "crds"),
-			filepath.Join("..", "..", "..", "dep-crds", "scheduler-plugins", "crd.yaml"),
-			filepath.Join("..", "..", "..", "dep-crds", "jobset-operator"),
+			filepath.Join("..", "..", "..", "manifests", "external-crds", "scheduler-plugins", "crd.yaml"),
+			filepath.Join("..", "..", "..", "manifests", "external-crds", "jobset-operator"),
 		},
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "manifests", "v2", "base", "webhook")},

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -14,21 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllerv2
+package util
 
 import (
-	ctrl "sigs.k8s.io/controller-runtime"
-
-	runtime "github.com/kubeflow/training-operator/pkg/runtime.v2"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
 )
 
-func SetupControllers(mgr ctrl.Manager, runtimes map[string]runtime.Runtime) (string, error) {
-	if err := NewTrainJobReconciler(
-		mgr.GetClient(),
-		mgr.GetEventRecorderFor("training-operator-trainjob-controller"),
-		runtimes,
-	).SetupWithManager(mgr); err != nil {
-		return "TrainJob", err
+const (
+	Timeout            = 5 * time.Second
+	ConsistentDuration = time.Second
+	Interval           = time.Millisecond * 250
+)
+
+var (
+	IgnoreObjectMetadata = cmp.Options{
+		cmpopts.IgnoreTypes(metav1.TypeMeta{}),
+		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "UID", "ResourceVersion", "Generation", "CreationTimestamp", "ManagedFields"),
 	}
-	return "", nil
-}
+)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I implemented the object creation and update in the TrainJob reconciler.
I will implement the TrainJob status operation in a follow-up PR.

Additionally, I restricted the directories in `make test` so that we can perform tests only for the v1 APIs and controllers.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Part-of #2207 
Relates to #2170

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
