### PR TITLE
KEP-2170: Add the TrainJob state transition design

### DIFF
--- a/docs/proposals/2170-kubeflow-training-v2/README.md
+++ b/docs/proposals/2170-kubeflow-training-v2/README.md
@@ -283,8 +283,8 @@ const (
 	// TrainJobSuspended means the TrainJob is suspended.
 	TrainJobSuspended string = "Suspended"
 
-	// TrainJobCompleted means that the TrainJob has completed its execution.
-	TrainJobCompleted string = "Completed"
+	// TrainJobComplete means that the TrainJob has completed its execution.
+	TrainJobComplete string = "Complete"
 
 	// TrainJobFailed means that the actual jobs have failed its execution.
 	TrainJobFailed string = "Failed"
@@ -958,7 +958,7 @@ spec:
 In this section, we're explaining the TrainJob state transition (`.status.conditions`).
 The basic TrainJob state machine is the below.
 Especially, if we specify the TrainingRuntime or ClusterTrainingRuntime as a runtime,
-the TrainJob terminal condition (`Failed` or `Completed`) is decided based on the JobSet terminal state (`status.terminalState`)
+the TrainJob terminal condition (`Failed` or `Complete`) is decided based on the JobSet terminal state (`status.terminalState`)
 instead of computing from JobSet conditions.
 
 ```mermaid
@@ -986,8 +986,8 @@ stateDiagram-v2
     Failed=True --> [*]
 
     #COMPLETION
-    terminal_choice --> Completed=True: Actual Jobs (e.g., JobSet) completed.
-    Completed=True --> [*]
+    terminal_choice --> Complete=True: Actual Jobs (e.g., JobSet) completed.
+    Complete=True --> [*]
 ```
 
 In the above state transition, the `Created=False` will happen in the following situations and

--- a/docs/proposals/2170-kubeflow-training-v2/README.md
+++ b/docs/proposals/2170-kubeflow-training-v2/README.md
@@ -283,7 +283,7 @@ const (
 	// TrainJobSuspended means the TrainJob is suspended.
 	TrainJobSuspended string = "Suspended"
 
-	// TrainJobCompleted means that the actual jobs have completed its execution.
+	// TrainJobCompleted means that the TrainJob has completed its execution.
 	TrainJobCompleted string = "Completed"
 
 	// TrainJobFailed means that the actual jobs have failed its execution.

--- a/docs/proposals/2170-kubeflow-training-v2/README.md
+++ b/docs/proposals/2170-kubeflow-training-v2/README.md
@@ -990,6 +990,12 @@ stateDiagram-v2
     Completed=True --> [*]
 ```
 
+In the above state transition, the `Created=False` will happen in the following situations and
+those different situations can be identified by the condition reasons (`.status.conditions.[type="Created"].reason`).
+
+- `JobsBuildFailed`: When the TrainJob controller failed to construct objects (resources) using the [runtime framework interfaces](../../../pkg/runtime.v2/framework/interface.go)
+- `JobsCreationFailed`: When the TrainJob controller succeeded to construct objects, but it failed to deploy objects to the cluster.
+
 Additionally, we extend the [runtime framework interfaces](../../../pkg/runtime.v2/framework/interface.go)
 to allow each plugin to propagate the arbitrary conditions to the TrainJob.
 

--- a/docs/proposals/2170-kubeflow-training-v2/README.md
+++ b/docs/proposals/2170-kubeflow-training-v2/README.md
@@ -956,12 +956,10 @@ spec:
 ### State Transition
 
 In this section, we're explaining the TrainJob state transition (`.status.conditions`).
-The basic TrainJob state machine is the below, but the TrainJob has actual Jobs state as well.
-This means that If the TrainJob specifies the TrainingRuntime, the TrainJob has JobSet conditions as well,
-but actual Jobs states are added prefix like `JobSetCompleted`.
-
-Especially, if we specify the TrainingRuntime as a runtime, the TrainJob terminal condition (`Failed` or `Completed`) is decided
-based on the JobSet terminal state (`status.terminalState`) instead of computing from JobSet conditions.
+The basic TrainJob state machine is the below.
+Especially, if we specify the TrainingRuntime or ClusterTrainingRuntime as a runtime,
+the TrainJob terminal condition (`Failed` or `Completed`) is decided based on the JobSet terminal state (`status.terminalState`)
+instead of computing from JobSet conditions.
 
 ```mermaid
 stateDiagram-v2
@@ -992,25 +990,8 @@ stateDiagram-v2
     Completed=True --> [*]
 ```
 
-Hence, when we specify the JobSet as a runtime, after the TrainJob completed,
-we can see the TrainJob pseudo state in the following:
-
-```yaml
-[...]
-status:
-  conditions:
-  - type: Created
-    status: true
-  - type: Suspended
-    status: false
-  - type: JobSetSuspended
-    status: false
-  - type: JobSetCompleted
-    status: true
-  - type: Completed
-    status: true
-[...]
-```
+Additionally, we extend the [runtime framework interfaces](../../../pkg/runtime.v2/framework/interface.go)
+to allow each plugin to propagate the arbitrary conditions to the TrainJob.
 
 ## The Training Runtime API
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I added the TrainJob state machine design.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Part-of #2207
Relates to: #2170 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
