### PR TITLE
KEP-2170: Strictly verify the CRD marker validation and defaulting in the integration testings

### DIFF
--- a/docs/proposals/2170-kubeflow-training-v2/README.md
+++ b/docs/proposals/2170-kubeflow-training-v2/README.md
@@ -281,6 +281,8 @@ type TrainJob struct {
 
 type TrainJobSpec struct {
 	// Reference to the training runtime.
+	// The field is immutable.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="runtimeRef is immutable"
 	RuntimeRef RuntimeRef `json:"runtimeRef"`
 
 	// Configuration of the desired trainer.

--- a/manifests/v2/base/crds/kubeflow.org_trainjobs.yaml
+++ b/manifests/v2/base/crds/kubeflow.org_trainjobs.yaml
@@ -2747,7 +2747,9 @@ spec:
                   type: object
                 type: array
               runtimeRef:
-                description: Reference to the training runtime.
+                description: |-
+                  Reference to the training runtime.
+                  The field is immutable.
                 properties:
                   apiGroup:
                     default: kubeflow.org
@@ -2770,6 +2772,9 @@ spec:
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: runtimeRef is immutable
+                  rule: self == oldSelf
               suspend:
                 default: false
                 description: |-

--- a/pkg/apis/kubeflow.org/v2alpha1/openapi_generated.go
+++ b/pkg/apis/kubeflow.org/v2alpha1/openapi_generated.go
@@ -1010,7 +1010,7 @@ func schema_pkg_apis_kubefloworg_v2alpha1_TrainJobSpec(ref common.ReferenceCallb
 				Properties: map[string]spec.Schema{
 					"runtimeRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Reference to the training runtime.",
+							Description: "Reference to the training runtime. The field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1.RuntimeRef"),
 						},

--- a/pkg/apis/kubeflow.org/v2alpha1/trainjob_types.go
+++ b/pkg/apis/kubeflow.org/v2alpha1/trainjob_types.go
@@ -66,6 +66,8 @@ type TrainJobList struct {
 // TrainJobSpec represents specification of the desired TrainJob.
 type TrainJobSpec struct {
 	// Reference to the training runtime.
+	// The field is immutable.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="runtimeRef is immutable"
 	RuntimeRef RuntimeRef `json:"runtimeRef"`
 
 	// Configuration of the desired trainer.

--- a/pkg/util.v2/testing/errormatcher.go
+++ b/pkg/util.v2/testing/errormatcher.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2024 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func BeNotFoundError() types.GomegaMatcher {
+	return BeAPIError(NotFoundError)
+}
+
+func BeForbiddenError() types.GomegaMatcher {
+	return BeAPIError(ForbiddenError)
+}
+
+func BeInvalidError() types.GomegaMatcher {
+	return BeAPIError(InvalidError)
+}
+
+type errorMatcher int
+
+const (
+	NotFoundError errorMatcher = iota
+	ForbiddenError
+	InvalidError
+)
+
+func (em errorMatcher) String() string {
+	return []string{"NotFoundError", "ForbiddenError", "InvalidError"}[em]
+}
+
+type apiError func(error) bool
+
+func (em errorMatcher) isAPIError(err error) bool {
+	return []apiError{apierrors.IsNotFound, apierrors.IsForbidden, apierrors.IsInvalid}[em](err)
+}
+
+type isErrorMatch struct {
+	name errorMatcher
+}
+
+func BeAPIError(name errorMatcher) types.GomegaMatcher {
+	return &isErrorMatch{
+		name: name,
+	}
+}
+
+func (matcher *isErrorMatch) Match(actual interface{}) (success bool, err error) {
+	err, ok := actual.(error)
+	if !ok {
+		return false, fmt.Errorf("%s expects an error", matcher.name.String())
+	}
+
+	return err != nil && matcher.name.isAPIError(err), nil
+}
+
+func (matcher *isErrorMatch) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "to be a %s", matcher.name.String())
+}
+
+func (matcher *isErrorMatch) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to be %s", matcher.name.String())
+}

--- a/pkg/util.v2/testing/wrapper.go
+++ b/pkg/util.v2/testing/wrapper.go
@@ -236,16 +236,26 @@ func (t *TrainJobWrapper) SpecAnnotation(key, value string) *TrainJobWrapper {
 }
 
 func (t *TrainJobWrapper) RuntimeRef(gvk schema.GroupVersionKind, name string) *TrainJobWrapper {
-	t.Spec.RuntimeRef = kubeflowv2.RuntimeRef{
-		APIGroup: &gvk.Group,
-		Kind:     &gvk.Kind,
-		Name:     name,
+	runtimeRef := kubeflowv2.RuntimeRef{
+		Name: name,
 	}
+	if gvk.Group != "" {
+		runtimeRef.APIGroup = &gvk.Group
+	}
+	if gvk.Kind != "" {
+		runtimeRef.Kind = &gvk.Kind
+	}
+	t.Spec.RuntimeRef = runtimeRef
 	return t
 }
 
 func (t *TrainJobWrapper) Trainer(trainer *kubeflowv2.Trainer) *TrainJobWrapper {
 	t.Spec.Trainer = trainer
+	return t
+}
+
+func (t *TrainJobWrapper) ManagedBy(m string) *TrainJobWrapper {
+	t.Spec.ManagedBy = &m
 	return t
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I refactored the CRD marker integration testing so that we could more strictly verify the expected behavior.
Additionally, I made the `.spec.runtimeRef` field as immutable field to reduce unexpected errors when actual Jobs are built.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2293
Relates to #2170

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
