### PR TITLE
KEP-2170: Implement JobSet, PlainML, and Torch Plugins

### DIFF
--- a/pkg/apis/kubeflow.org/v2alpha1/trainingruntime_types.go
+++ b/pkg/apis/kubeflow.org/v2alpha1/trainingruntime_types.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	// TrainingRuntimeKind is the GroupVersionKind Kind name for the TrainingRuntime.
+	// TrainingRuntimeKind is the Kind name for the TrainingRuntime.
 	TrainingRuntimeKind string = "TrainingRuntime"
-	// ClusterTrainingRuntimeKind is the GroupVersionKind Kind name for the ClusterTrainingRuntime.
+	// ClusterTrainingRuntimeKind is the Kind name for the ClusterTrainingRuntime.
 	ClusterTrainingRuntimeKind string = "ClusterTrainingRuntime"
 )
 

--- a/pkg/apis/kubeflow.org/v2alpha1/trainjob_types.go
+++ b/pkg/apis/kubeflow.org/v2alpha1/trainjob_types.go
@@ -22,6 +22,7 @@ import (
 )
 
 const (
+	// TrainJobKind is the Kind name for the TrainJob.
 	TrainJobKind string = "TrainJob"
 )
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,22 @@
+package constants
+
+const (
+
+	// JobSetKind is the Kind name for the JobSet.
+	JobSetKind string = "JobSet"
+
+	// JobTrainerNode is the Job name for the trainer node.
+	JobTrainerNode string = "trainer-node"
+
+	// ContainerTrainer is the container name for the trainer.
+	ContainerTrainer string = "trainer"
+
+	// JobInitializer is the Job name for the initializer.
+	JobInitializer string = "initializer"
+
+	// ContainerModelInitializer is the container name for the model initializer.
+	ContainerModelInitializer string = "model-initializer"
+
+	// ContainerDatasetInitializer is the container name for the dataset initializer.
+	ContainerDatasetInitializer string = "dataset-initializer"
+)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -5,6 +5,9 @@ const (
 	// JobSetKind is the Kind name for the JobSet.
 	JobSetKind string = "JobSet"
 
+	// PodGroupKind is the Kind name for the PodGroup.
+	PodGroupKind string = "PodGroup"
+
 	// JobTrainerNode is the Job name for the trainer node.
 	JobTrainerNode string = "trainer-node"
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -5,14 +5,17 @@ const (
 	// JobSetKind is the Kind name for the JobSet.
 	JobSetKind string = "JobSet"
 
-	// PodGroupKind is the Kind name for the PodGroup.
-	PodGroupKind string = "PodGroup"
+	// JobCompletionIndexFieldPath is the field path for the Job completion annotation.
+	JobCompletionIndexFieldPath string = "metadata.annotations['batch.kubernetes.io/job-completion-index']"
 
 	// JobTrainerNode is the Job name for the trainer node.
 	JobTrainerNode string = "trainer-node"
 
 	// ContainerTrainer is the container name for the trainer.
 	ContainerTrainer string = "trainer"
+
+	// ContainerTrainerPort is the default port for the trainer nodes communication.
+	ContainerTrainerPort int32 = 29500
 
 	// JobInitializer is the Job name for the initializer.
 	JobInitializer string = "initializer"
@@ -23,11 +26,23 @@ const (
 	// ContainerDatasetInitializer is the container name for the dataset initializer.
 	ContainerDatasetInitializer string = "dataset-initializer"
 
+	// PodGroupKind is the Kind name for the PodGroup.
+	PodGroupKind string = "PodGroup"
+
 	// Distributed envs for torchrun.
 	// Ref: https://github.com/pytorch/pytorch/blob/3a0d0885171376ed610c8175a19ba40411fc6f3f/torch/distributed/argparse_util.py#L45
-	// Number of training nodes.
+	// TorchEnvNumNodes is the env name for the number of training nodes.
 	TorchEnvNumNodes string = "PET_NNODES"
 
-	// Number of procs (e.g. GPUs) per node.
+	// TorchEnvNumProcPerNode is the env name for the number of procs per node (e.g. number of GPUs per Pod).
 	TorchEnvNumProcPerNode string = "PET_NPROC_PER_NODE"
+
+	// TorchEnvNodeRank is the env name of the node RANK
+	TorchEnvNodeRank string = "PET_NODE_RANK"
+
+	// TorchEnvMasterAddr is the env name for the master node address.
+	TorchEnvMasterAddr string = "PET_MASTER_ADDR"
+
+	// TorchEnvMasterPort is the env name for the master node port.
+	TorchEnvMasterPort string = "PET_MASTER_PORT"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -5,7 +5,7 @@ const (
 	// JobSetKind is the Kind name for the JobSet.
 	JobSetKind string = "JobSet"
 
-	// JobCompletionIndexFieldPath is the field path for the Job completion annotation.
+	// JobCompletionIndexFieldPath is the field path for the Job completion index annotation.
 	JobCompletionIndexFieldPath string = "metadata.annotations['batch.kubernetes.io/job-completion-index']"
 
 	// JobTrainerNode is the Job name for the trainer node.
@@ -37,7 +37,7 @@ const (
 	// TorchEnvNumProcPerNode is the env name for the number of procs per node (e.g. number of GPUs per Pod).
 	TorchEnvNumProcPerNode string = "PET_NPROC_PER_NODE"
 
-	// TorchEnvNodeRank is the env name of the node RANK
+	// TorchEnvNodeRank is the env name for the node RANK
 	TorchEnvNodeRank string = "PET_NODE_RANK"
 
 	// TorchEnvMasterAddr is the env name for the master node address.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -22,4 +22,12 @@ const (
 
 	// ContainerDatasetInitializer is the container name for the dataset initializer.
 	ContainerDatasetInitializer string = "dataset-initializer"
+
+	// Distributed envs for torchrun.
+	// Ref: https://github.com/pytorch/pytorch/blob/3a0d0885171376ed610c8175a19ba40411fc6f3f/torch/distributed/argparse_util.py#L45
+	// Number of training nodes.
+	TorchEnvNumNodes string = "PET_NNODES"
+
+	// Number of procs (e.g. GPUs) per node.
+	TorchEnvNumProcPerNode string = "PET_NPROC_PER_NODE"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -52,5 +52,5 @@ const (
 
 var (
 	// JobCompletionIndexFieldPath is the field path for the Job completion index annotation.
-	JobCompletionIndexFieldPath string = fmt.Sprintf("metadata.annotations['%v']", batchv1.JobCompletionIndexAnnotation)
+	JobCompletionIndexFieldPath string = fmt.Sprintf("metadata.annotations['%s']", batchv1.JobCompletionIndexAnnotation)
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -8,6 +8,9 @@ import (
 
 const (
 
+	// DefaultJobReplicas is the default value for the ReplicatedJob replicas.
+	DefaultJobReplicas = 1
+
 	// JobSetKind is the Kind name for the JobSet.
 	JobSetKind string = "JobSet"
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,12 +1,15 @@
 package constants
 
+import (
+	"fmt"
+
+	batchv1 "k8s.io/api/batch/v1"
+)
+
 const (
 
 	// JobSetKind is the Kind name for the JobSet.
 	JobSetKind string = "JobSet"
-
-	// JobCompletionIndexFieldPath is the field path for the Job completion index annotation.
-	JobCompletionIndexFieldPath string = "metadata.annotations['batch.kubernetes.io/job-completion-index']"
 
 	// JobTrainerNode is the Job name for the trainer node.
 	JobTrainerNode string = "trainer-node"
@@ -45,4 +48,9 @@ const (
 
 	// TorchEnvMasterPort is the env name for the master node port.
 	TorchEnvMasterPort string = "PET_MASTER_PORT"
+)
+
+var (
+	// JobCompletionIndexFieldPath is the field path for the Job completion index annotation.
+	JobCompletionIndexFieldPath string = fmt.Sprintf("metadata.annotations['%v']", batchv1.JobCompletionIndexAnnotation)
 )

--- a/pkg/runtime.v2/core/clustertrainingruntime_test.go
+++ b/pkg/runtime.v2/core/clustertrainingruntime_test.go
@@ -22,11 +22,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	schedulerpluginsv1alpha1 "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 
@@ -72,18 +70,17 @@ func TestClusterTrainingRuntimeNewObjects(t *testing.T) {
 				testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
 					Suspend(true).
 					PodLabel(schedulerpluginsv1alpha1.PodGroupLabel, "test-job").
-					ContainerImage(ptr.To("test:trainjob")).
-					JobCompletionMode(batchv1.IndexedCompletion).
+					ContainerImage("test:trainjob").
 					ResourceRequests(0, corev1.ResourceList{
 						corev1.ResourceCPU: resource.MustParse("1"),
 					}).
 					ResourceRequests(1, corev1.ResourceList{
 						corev1.ResourceCPU: resource.MustParse("2"),
 					}).
-					ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind("TrainJob"), "test-job", "uid").
+					ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind(kubeflowv2.TrainJobKind), "test-job", "uid").
 					Obj(),
 				testingutil.MakeSchedulerPluginsPodGroup(metav1.NamespaceDefault, "test-job").
-					ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind("TrainJob"), "test-job", "uid").
+					ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind(kubeflowv2.TrainJobKind), "test-job", "uid").
 					MinMember(40).
 					SchedulingTimeout(120).
 					MinResources(corev1.ResourceList{

--- a/pkg/runtime.v2/core/trainingruntime.go
+++ b/pkg/runtime.v2/core/trainingruntime.go
@@ -119,7 +119,7 @@ func (r *TrainingRuntime) buildObjects(
 		return nil, err
 	}
 
-	return r.framework.RunComponentBuilderPlugins(ctx, info, trainJob, jobSetTemplateSpec.Spec)
+	return r.framework.RunComponentBuilderPlugins(ctx, jobSetTemplateSpec.Spec, info, trainJob)
 }
 
 func (r *TrainingRuntime) EventHandlerRegistrars() []runtime.ReconcilerBuilder {

--- a/pkg/runtime.v2/core/trainingruntime.go
+++ b/pkg/runtime.v2/core/trainingruntime.go
@@ -101,6 +101,8 @@ func (r *TrainingRuntime) buildObjects(
 	opts := []runtime.InfoOption{
 		runtime.WithLabels(propagationLabels),
 		runtime.WithAnnotations(propagationAnnotations),
+		runtime.WithMLPolicy(mlPolicy),
+		runtime.WithPodGroupPolicy(podGroupPolicy),
 	}
 
 	for _, rJob := range jobSetTemplateSpec.Spec.ReplicatedJobs {
@@ -110,11 +112,11 @@ func (r *TrainingRuntime) buildObjects(
 
 	info := runtime.NewInfo(opts...)
 
-	if err := r.framework.RunEnforceMLPolicyPlugins(info, trainJob, mlPolicy); err != nil {
+	if err := r.framework.RunEnforceMLPolicyPlugins(info, trainJob); err != nil {
 		return nil, err
 	}
 
-	if err := r.framework.RunEnforcePodGroupPolicyPlugins(info, trainJob, podGroupPolicy); err != nil {
+	if err := r.framework.RunEnforcePodGroupPolicyPlugins(info, trainJob); err != nil {
 		return nil, err
 	}
 

--- a/pkg/runtime.v2/core/trainingruntime.go
+++ b/pkg/runtime.v2/core/trainingruntime.go
@@ -121,7 +121,7 @@ func (r *TrainingRuntime) buildObjects(
 	}
 
 	jobSetTemplate := jobsetv1alpha2.JobSet{
-		Spec: *jobSetTemplateSpec.Spec.DeepCopy(),
+		Spec: jobSetTemplateSpec.Spec,
 	}
 
 	return r.framework.RunComponentBuilderPlugins(ctx, jobSetTemplate.DeepCopy(), info, trainJob)

--- a/pkg/runtime.v2/core/trainingruntime.go
+++ b/pkg/runtime.v2/core/trainingruntime.go
@@ -114,8 +114,7 @@ func (r *TrainingRuntime) buildObjects(
 		return nil, err
 	}
 
-	err := r.framework.RunEnforcePodGroupPolicyPlugins(info, trainJob, podGroupPolicy)
-	if err != nil {
+	if err := r.framework.RunEnforcePodGroupPolicyPlugins(info, trainJob, podGroupPolicy); err != nil {
 		return nil, err
 	}
 

--- a/pkg/runtime.v2/core/trainingruntime.go
+++ b/pkg/runtime.v2/core/trainingruntime.go
@@ -104,6 +104,7 @@ func (r *TrainingRuntime) buildObjects(
 		runtime.WithPodGroupPolicy(podGroupPolicy),
 	}
 	for _, rJob := range jobSetTemplateSpec.Spec.ReplicatedJobs {
+		// By default every ReplicatedJob has only 1 replica.
 		opts = append(opts, runtime.WithPodSpecReplicas(rJob.Name, 1, rJob.Template.Spec.Template.Spec))
 	}
 

--- a/pkg/runtime.v2/core/trainingruntime.go
+++ b/pkg/runtime.v2/core/trainingruntime.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	kubeflowv2 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1"
 	runtime "github.com/kubeflow/training-operator/pkg/runtime.v2"
@@ -119,7 +120,11 @@ func (r *TrainingRuntime) buildObjects(
 		return nil, err
 	}
 
-	return r.framework.RunComponentBuilderPlugins(ctx, jobSetTemplateSpec.Spec, info, trainJob)
+	jobSetTemplate := jobsetv1alpha2.JobSet{
+		Spec: *jobSetTemplateSpec.Spec.DeepCopy(),
+	}
+
+	return r.framework.RunComponentBuilderPlugins(ctx, jobSetTemplate.DeepCopy(), info, trainJob)
 }
 
 func (r *TrainingRuntime) EventHandlerRegistrars() []runtime.ReconcilerBuilder {

--- a/pkg/runtime.v2/core/trainingruntime.go
+++ b/pkg/runtime.v2/core/trainingruntime.go
@@ -101,9 +101,8 @@ func (r *TrainingRuntime) buildObjects(
 	opts := []runtime.InfoOption{
 		runtime.WithLabels(propagationLabels),
 		runtime.WithAnnotations(propagationAnnotations),
-		runtime.WithMLPolicy(mlPolicy),
-		runtime.WithPodGroupPolicy(podGroupPolicy),
 	}
+
 	for _, rJob := range jobSetTemplateSpec.Spec.ReplicatedJobs {
 		// By default every ReplicatedJob has only 1 replica.
 		opts = append(opts, runtime.WithPodSpecReplicas(rJob.Name, 1, rJob.Template.Spec.Template.Spec))
@@ -111,11 +110,11 @@ func (r *TrainingRuntime) buildObjects(
 
 	info := runtime.NewInfo(opts...)
 
-	if err := r.framework.RunEnforceMLPolicyPlugins(info, trainJob); err != nil {
+	if err := r.framework.RunEnforceMLPolicyPlugins(info, trainJob, mlPolicy); err != nil {
 		return nil, err
 	}
 
-	err := r.framework.RunEnforcePodGroupPolicyPlugins(info, trainJob)
+	err := r.framework.RunEnforcePodGroupPolicyPlugins(info, trainJob, podGroupPolicy)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/runtime.v2/core/trainingruntime_test.go
+++ b/pkg/runtime.v2/core/trainingruntime_test.go
@@ -199,7 +199,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							},
 							{
 								Name:  constants.TorchEnvMasterAddr,
-								Value: fmt.Sprintf("test-job-%v-0-0.test-job", constants.JobTrainerNode),
+								Value: fmt.Sprintf("test-job-%s-0-0.test-job", constants.JobTrainerNode),
 							},
 							{
 								Name:  constants.TorchEnvMasterPort,
@@ -284,7 +284,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							},
 							{
 								Name:  constants.TorchEnvMasterAddr,
-								Value: fmt.Sprintf("test-job-%v-0-0.test-job", constants.JobTrainerNode),
+								Value: fmt.Sprintf("test-job-%s-0-0.test-job", constants.JobTrainerNode),
 							},
 							{
 								Name:  constants.TorchEnvMasterPort,

--- a/pkg/runtime.v2/core/trainingruntime_test.go
+++ b/pkg/runtime.v2/core/trainingruntime_test.go
@@ -86,6 +86,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind(kubeflowv2.TrainJobKind), "test-job", "uid").
 					MinMember(31). // 31 replicas = 30 Trainer nodes + 1 Initializer.
 					MinResources(corev1.ResourceList{
+						// TODO (andreyvelich): Create helper function to calculate PodGroup resources in the unit tests.
 						corev1.ResourceCPU: resource.MustParse("31"), // Every replica has 1 CPU = 31 CPUs in total.
 					}).
 					SchedulingTimeout(120).

--- a/pkg/runtime.v2/core/trainingruntime_test.go
+++ b/pkg/runtime.v2/core/trainingruntime_test.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -34,7 +35,6 @@ import (
 )
 
 func TestTrainingRuntimeNewObjects(t *testing.T) {
-
 	resRequests := corev1.ResourceList{
 		corev1.ResourceCPU: resource.MustParse("1"),
 	}
@@ -178,6 +178,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 				testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
 					NumNodes(30).
 					ContainerTrainer("test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					ContainerTrainerPorts([]corev1.ContainerPort{{ContainerPort: constants.ContainerTrainerPort}}).
 					ContainerTrainerEnv(
 						[]corev1.EnvVar{
 							{
@@ -187,6 +188,22 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							{
 								Name:  constants.TorchEnvNumProcPerNode,
 								Value: "3",
+							},
+							{
+								Name: constants.TorchEnvNodeRank,
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: constants.JobCompletionIndexFieldPath,
+									},
+								},
+							},
+							{
+								Name:  constants.TorchEnvMasterAddr,
+								Value: fmt.Sprintf("test-job-%v-0-0.%v", constants.JobTrainerNode, constants.ContainerTrainer),
+							},
+							{
+								Name:  constants.TorchEnvMasterPort,
+								Value: fmt.Sprintf("%d", constants.ContainerTrainerPort),
 							},
 						},
 					).
@@ -238,6 +255,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 				testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
 					NumNodes(100).
 					ContainerTrainer("test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
+					ContainerTrainerPorts([]corev1.ContainerPort{{ContainerPort: constants.ContainerTrainerPort}}).
 					ContainerTrainerEnv(
 						[]corev1.EnvVar{
 							{
@@ -247,6 +265,22 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							{
 								Name:  constants.TorchEnvNumProcPerNode,
 								Value: "auto",
+							},
+							{
+								Name: constants.TorchEnvNodeRank,
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: constants.JobCompletionIndexFieldPath,
+									},
+								},
+							},
+							{
+								Name:  constants.TorchEnvMasterAddr,
+								Value: fmt.Sprintf("test-job-%v-0-0.%v", constants.JobTrainerNode, constants.ContainerTrainer),
+							},
+							{
+								Name:  constants.TorchEnvMasterPort,
+								Value: fmt.Sprintf("%d", constants.ContainerTrainerPort),
 							},
 							{
 								Name:  "TRAIN_JOB",

--- a/pkg/runtime.v2/core/trainingruntime_test.go
+++ b/pkg/runtime.v2/core/trainingruntime_test.go
@@ -22,11 +22,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	schedulerpluginsv1alpha1 "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 
@@ -79,18 +77,17 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					Label("conflictLabel", "override").
 					Annotation("conflictAnnotation", "override").
 					PodLabel(schedulerpluginsv1alpha1.PodGroupLabel, "test-job").
-					ContainerImage(ptr.To("test:trainjob")).
-					JobCompletionMode(batchv1.IndexedCompletion).
+					ContainerImage("test:trainjob").
 					ResourceRequests(0, corev1.ResourceList{
 						corev1.ResourceCPU: resource.MustParse("1"),
 					}).
 					ResourceRequests(1, corev1.ResourceList{
 						corev1.ResourceCPU: resource.MustParse("2"),
 					}).
-					ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind("TrainJob"), "test-job", "uid").
+					ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind(kubeflowv2.TrainJobKind), "test-job", "uid").
 					Obj(),
 				testingutil.MakeSchedulerPluginsPodGroup(metav1.NamespaceDefault, "test-job").
-					ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind("TrainJob"), "test-job", "uid").
+					ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind(kubeflowv2.TrainJobKind), "test-job", "uid").
 					MinMember(40).
 					SchedulingTimeout(120).
 					MinResources(corev1.ResourceList{

--- a/pkg/runtime.v2/core/trainingruntime_test.go
+++ b/pkg/runtime.v2/core/trainingruntime_test.go
@@ -46,7 +46,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 		wantObjs        []client.Object
 		wantError       error
 	}{
-		// Test cases for PlainML MLPolicy.
+		// Test cases for the PlainML MLPolicy.
 		"succeeded to build PodGroup and JobSet with NumNodes from the TrainJob and container from Runtime.": {
 			trainingRuntime: testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "test-runtime").
 				Label("conflictLabel", "overridden").
@@ -156,7 +156,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					Obj(),
 			},
 		},
-		// Test cases for Torch MLPolicy.
+		// Test cases for the Torch MLPolicy.
 		"succeeded to build JobSet with Torch values from the TrainJob": {
 			trainingRuntime: testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "test-runtime").RuntimeSpec(
 				testingutil.MakeTrainingRuntimeSpecWrapper(testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "test-runtime").Spec).
@@ -199,7 +199,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							},
 							{
 								Name:  constants.TorchEnvMasterAddr,
-								Value: fmt.Sprintf("test-job-%v-0-0.%v", constants.JobTrainerNode, constants.ContainerTrainer),
+								Value: fmt.Sprintf("test-job-%v-0-0.test-job", constants.JobTrainerNode),
 							},
 							{
 								Name:  constants.TorchEnvMasterPort,
@@ -259,6 +259,14 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					ContainerTrainerEnv(
 						[]corev1.EnvVar{
 							{
+								Name:  "TRAIN_JOB",
+								Value: "override",
+							},
+							{
+								Name:  "TRAIN_JOB_CUSTOM",
+								Value: "test:trainjob",
+							},
+							{
 								Name:  constants.TorchEnvNumNodes,
 								Value: "100",
 							},
@@ -276,19 +284,11 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							},
 							{
 								Name:  constants.TorchEnvMasterAddr,
-								Value: fmt.Sprintf("test-job-%v-0-0.%v", constants.JobTrainerNode, constants.ContainerTrainer),
+								Value: fmt.Sprintf("test-job-%v-0-0.test-job", constants.JobTrainerNode),
 							},
 							{
 								Name:  constants.TorchEnvMasterPort,
 								Value: fmt.Sprintf("%d", constants.ContainerTrainerPort),
-							},
-							{
-								Name:  "TRAIN_JOB",
-								Value: "override",
-							},
-							{
-								Name:  "TRAIN_JOB_CUSTOM",
-								Value: "test:trainjob",
 							},
 							{
 								Name:  "RUNTIME",

--- a/pkg/runtime.v2/framework/core/framework.go
+++ b/pkg/runtime.v2/framework/core/framework.go
@@ -71,18 +71,18 @@ func New(ctx context.Context, c client.Client, r fwkplugins.Registry, indexer cl
 	return f, nil
 }
 
-func (f *Framework) RunEnforceMLPolicyPlugins(info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeMLPolicy *kubeflowv2.MLPolicy) error {
+func (f *Framework) RunEnforceMLPolicyPlugins(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error {
 	for _, plugin := range f.enforceMLPlugins {
-		if err := plugin.EnforceMLPolicy(info, trainJob, runtimeMLPolicy); err != nil {
+		if err := plugin.EnforceMLPolicy(info, trainJob); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (f *Framework) RunEnforcePodGroupPolicyPlugins(info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimePodGroupPolicy *kubeflowv2.PodGroupPolicy) error {
+func (f *Framework) RunEnforcePodGroupPolicyPlugins(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error {
 	for _, plugin := range f.enforcePodGroupPolicyPlugins {
-		if err := plugin.EnforcePodGroupPolicy(info, trainJob, runtimePodGroupPolicy); err != nil {
+		if err := plugin.EnforcePodGroupPolicy(info, trainJob); err != nil {
 			return err
 		}
 	}

--- a/pkg/runtime.v2/framework/core/framework.go
+++ b/pkg/runtime.v2/framework/core/framework.go
@@ -104,10 +104,10 @@ func (f *Framework) RunCustomValidationPlugins(oldObj, newObj *kubeflowv2.TrainJ
 	return aggregatedWarnings, aggregatedErrors
 }
 
-func (f *Framework) RunComponentBuilderPlugins(ctx context.Context, info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeJobTemplateSpec interface{}) ([]client.Object, error) {
+func (f *Framework) RunComponentBuilderPlugins(ctx context.Context, runtimeJobTemplateSpec interface{}, info *runtime.Info, trainJob *kubeflowv2.TrainJob) ([]client.Object, error) {
 	var objs []client.Object
 	for _, plugin := range f.componentBuilderPlugins {
-		obj, err := plugin.Build(ctx, info, trainJob, runtimeJobTemplateSpec)
+		obj, err := plugin.Build(ctx, runtimeJobTemplateSpec, info, trainJob)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/runtime.v2/framework/core/framework.go
+++ b/pkg/runtime.v2/framework/core/framework.go
@@ -104,10 +104,10 @@ func (f *Framework) RunCustomValidationPlugins(oldObj, newObj *kubeflowv2.TrainJ
 	return aggregatedWarnings, aggregatedErrors
 }
 
-func (f *Framework) RunComponentBuilderPlugins(ctx context.Context, runtimeJobTemplateSpec interface{}, info *runtime.Info, trainJob *kubeflowv2.TrainJob) ([]client.Object, error) {
+func (f *Framework) RunComponentBuilderPlugins(ctx context.Context, runtimeJobTemplate client.Object, info *runtime.Info, trainJob *kubeflowv2.TrainJob) ([]client.Object, error) {
 	var objs []client.Object
 	for _, plugin := range f.componentBuilderPlugins {
-		obj, err := plugin.Build(ctx, runtimeJobTemplateSpec, info, trainJob)
+		obj, err := plugin.Build(ctx, runtimeJobTemplate, info, trainJob)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/runtime.v2/framework/core/framework.go
+++ b/pkg/runtime.v2/framework/core/framework.go
@@ -71,18 +71,18 @@ func New(ctx context.Context, c client.Client, r fwkplugins.Registry, indexer cl
 	return f, nil
 }
 
-func (f *Framework) RunEnforceMLPolicyPlugins(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error {
+func (f *Framework) RunEnforceMLPolicyPlugins(info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeMLPolicy *kubeflowv2.MLPolicy) error {
 	for _, plugin := range f.enforceMLPlugins {
-		if err := plugin.EnforceMLPolicy(info, trainJob); err != nil {
+		if err := plugin.EnforceMLPolicy(info, trainJob, runtimeMLPolicy); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (f *Framework) RunEnforcePodGroupPolicyPlugins(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error {
+func (f *Framework) RunEnforcePodGroupPolicyPlugins(info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimePodGroupPolicy *kubeflowv2.PodGroupPolicy) error {
 	for _, plugin := range f.enforcePodGroupPolicyPlugins {
-		if err := plugin.EnforcePodGroupPolicy(info, trainJob); err != nil {
+		if err := plugin.EnforcePodGroupPolicy(info, trainJob, runtimePodGroupPolicy); err != nil {
 			return err
 		}
 	}

--- a/pkg/runtime.v2/framework/core/framework.go
+++ b/pkg/runtime.v2/framework/core/framework.go
@@ -71,18 +71,18 @@ func New(ctx context.Context, c client.Client, r fwkplugins.Registry, indexer cl
 	return f, nil
 }
 
-func (f *Framework) RunEnforceMLPolicyPlugins(info *runtime.Info) error {
+func (f *Framework) RunEnforceMLPolicyPlugins(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error {
 	for _, plugin := range f.enforceMLPlugins {
-		if err := plugin.EnforceMLPolicy(info); err != nil {
+		if err := plugin.EnforceMLPolicy(info, trainJob); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (f *Framework) RunEnforcePodGroupPolicyPlugins(trainJob *kubeflowv2.TrainJob, info *runtime.Info) error {
+func (f *Framework) RunEnforcePodGroupPolicyPlugins(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error {
 	for _, plugin := range f.enforcePodGroupPolicyPlugins {
-		if err := plugin.EnforcePodGroupPolicy(trainJob, info); err != nil {
+		if err := plugin.EnforcePodGroupPolicy(info, trainJob); err != nil {
 			return err
 		}
 	}
@@ -104,10 +104,10 @@ func (f *Framework) RunCustomValidationPlugins(oldObj, newObj *kubeflowv2.TrainJ
 	return aggregatedWarnings, aggregatedErrors
 }
 
-func (f *Framework) RunComponentBuilderPlugins(ctx context.Context, info *runtime.Info, trainJob *kubeflowv2.TrainJob) ([]client.Object, error) {
+func (f *Framework) RunComponentBuilderPlugins(ctx context.Context, info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeJobTemplateSpec interface{}) ([]client.Object, error) {
 	var objs []client.Object
 	for _, plugin := range f.componentBuilderPlugins {
-		obj, err := plugin.Build(ctx, info, trainJob)
+		obj, err := plugin.Build(ctx, info, trainJob, runtimeJobTemplateSpec)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/runtime.v2/framework/core/framework_test.go
+++ b/pkg/runtime.v2/framework/core/framework_test.go
@@ -375,17 +375,17 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		registry               fwkplugins.Registry
-		runtimeJobTemplateSpec interface{}
-		runtimeInfo            *runtime.Info
-		trainJob               *kubeflowv2.TrainJob
-		wantRuntimeInfo        *runtime.Info
-		wantObjs               []client.Object
-		wantError              error
+		registry           fwkplugins.Registry
+		runtimeJobTemplate client.Object
+		runtimeInfo        *runtime.Info
+		trainJob           *kubeflowv2.TrainJob
+		wantRuntimeInfo    *runtime.Info
+		wantObjs           []client.Object
+		wantError          error
 	}{
 		"succeeded to build PodGroup and JobSet with NumNodes from TrainJob": {
-			registry:               fwkplugins.NewRegistry(),
-			runtimeJobTemplateSpec: testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").Spec,
+			registry:           fwkplugins.NewRegistry(),
+			runtimeJobTemplate: testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").DeepCopy(),
 			runtimeInfo: &runtime.Info{
 				Policy: runtime.Policy{
 					MLPolicy: &kubeflowv2.MLPolicy{
@@ -484,7 +484,7 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 			if err = fwk.RunEnforceMLPolicyPlugins(tc.runtimeInfo, tc.trainJob); err != nil {
 				t.Fatal(err)
 			}
-			objs, err := fwk.RunComponentBuilderPlugins(ctx, tc.runtimeJobTemplateSpec, tc.runtimeInfo, tc.trainJob)
+			objs, err := fwk.RunComponentBuilderPlugins(ctx, tc.runtimeJobTemplate, tc.runtimeInfo, tc.trainJob)
 			if diff := cmp.Diff(tc.wantError, err, cmpopts.EquateErrors()); len(diff) != 0 {
 				t.Errorf("Unexpected errors (-want,+got):\n%s", diff)
 			}

--- a/pkg/runtime.v2/framework/interface.go
+++ b/pkg/runtime.v2/framework/interface.go
@@ -38,12 +38,12 @@ type WatchExtensionPlugin interface {
 
 type EnforcePodGroupPolicyPlugin interface {
 	Plugin
-	EnforcePodGroupPolicy(trainJob *kubeflowv2.TrainJob, info *runtime.Info) error
+	EnforcePodGroupPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error
 }
 
 type EnforceMLPolicyPlugin interface {
 	Plugin
-	EnforceMLPolicy(info *runtime.Info) error
+	EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error
 }
 
 type CustomValidationPlugin interface {
@@ -53,5 +53,5 @@ type CustomValidationPlugin interface {
 
 type ComponentBuilderPlugin interface {
 	Plugin
-	Build(ctx context.Context, info *runtime.Info, trainJob *kubeflowv2.TrainJob) (client.Object, error)
+	Build(ctx context.Context, info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeJobTemplateSpec interface{}) (client.Object, error)
 }

--- a/pkg/runtime.v2/framework/interface.go
+++ b/pkg/runtime.v2/framework/interface.go
@@ -53,5 +53,5 @@ type CustomValidationPlugin interface {
 
 type ComponentBuilderPlugin interface {
 	Plugin
-	Build(ctx context.Context, runtimeJobTemplateSpec interface{}, info *runtime.Info, trainJob *kubeflowv2.TrainJob) (client.Object, error)
+	Build(ctx context.Context, runtimeJobTemplate client.Object, info *runtime.Info, trainJob *kubeflowv2.TrainJob) (client.Object, error)
 }

--- a/pkg/runtime.v2/framework/interface.go
+++ b/pkg/runtime.v2/framework/interface.go
@@ -53,5 +53,5 @@ type CustomValidationPlugin interface {
 
 type ComponentBuilderPlugin interface {
 	Plugin
-	Build(ctx context.Context, info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeJobTemplateSpec interface{}) (client.Object, error)
+	Build(ctx context.Context, runtimeJobTemplateSpec interface{}, info *runtime.Info, trainJob *kubeflowv2.TrainJob) (client.Object, error)
 }

--- a/pkg/runtime.v2/framework/interface.go
+++ b/pkg/runtime.v2/framework/interface.go
@@ -38,12 +38,12 @@ type WatchExtensionPlugin interface {
 
 type EnforcePodGroupPolicyPlugin interface {
 	Plugin
-	EnforcePodGroupPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimePodGroupPolicy *kubeflowv2.PodGroupPolicy) error
+	EnforcePodGroupPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error
 }
 
 type EnforceMLPolicyPlugin interface {
 	Plugin
-	EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeMLPolicy *kubeflowv2.MLPolicy) error
+	EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error
 }
 
 type CustomValidationPlugin interface {

--- a/pkg/runtime.v2/framework/interface.go
+++ b/pkg/runtime.v2/framework/interface.go
@@ -38,12 +38,12 @@ type WatchExtensionPlugin interface {
 
 type EnforcePodGroupPolicyPlugin interface {
 	Plugin
-	EnforcePodGroupPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error
+	EnforcePodGroupPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimePodGroupPolicy *kubeflowv2.PodGroupPolicy) error
 }
 
 type EnforceMLPolicyPlugin interface {
 	Plugin
-	EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error
+	EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeMLPolicy *kubeflowv2.MLPolicy) error
 }
 
 type CustomValidationPlugin interface {

--- a/pkg/runtime.v2/framework/plugins/coscheduling/coscheduling.go
+++ b/pkg/runtime.v2/framework/plugins/coscheduling/coscheduling.go
@@ -99,7 +99,7 @@ func (c *CoScheduling) EnforcePodGroupPolicy(info *runtime.Info, trainJob *kubef
 	return nil
 }
 
-func (c *CoScheduling) Build(ctx context.Context, runtimeJobTemplateSpec interface{}, info *runtime.Info, trainJob *kubeflowv2.TrainJob) (client.Object, error) {
+func (c *CoScheduling) Build(ctx context.Context, runtimeJobTemplate client.Object, info *runtime.Info, trainJob *kubeflowv2.TrainJob) (client.Object, error) {
 	if info == nil || info.PodGroupPolicy == nil || info.PodGroupPolicy.Coscheduling == nil || trainJob == nil {
 		return nil, nil
 	}

--- a/pkg/runtime.v2/framework/plugins/coscheduling/coscheduling.go
+++ b/pkg/runtime.v2/framework/plugins/coscheduling/coscheduling.go
@@ -43,6 +43,7 @@ import (
 	schedulerpluginsv1alpha1 "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 
 	kubeflowv2 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1"
+	"github.com/kubeflow/training-operator/pkg/constants"
 	runtime "github.com/kubeflow/training-operator/pkg/runtime.v2"
 	"github.com/kubeflow/training-operator/pkg/runtime.v2/framework"
 	runtimeindexer "github.com/kubeflow/training-operator/pkg/runtime.v2/indexer"
@@ -98,7 +99,7 @@ func (c *CoScheduling) EnforcePodGroupPolicy(info *runtime.Info, trainJob *kubef
 	return nil
 }
 
-func (c *CoScheduling) Build(ctx context.Context, info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeJobTemplateSpec interface{}) (client.Object, error) {
+func (c *CoScheduling) Build(ctx context.Context, runtimeJobTemplateSpec interface{}, info *runtime.Info, trainJob *kubeflowv2.TrainJob) (client.Object, error) {
 	if info == nil || info.PodGroupPolicy == nil || info.PodGroupPolicy.Coscheduling == nil || trainJob == nil {
 		return nil, nil
 	}
@@ -117,7 +118,7 @@ func (c *CoScheduling) Build(ctx context.Context, info *runtime.Info, trainJob *
 	newPG := &schedulerpluginsv1alpha1.PodGroup{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: schedulerpluginsv1alpha1.SchemeGroupVersion.String(),
-			Kind:       "PodGroup",
+			Kind:       constants.PodGroupKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      trainJob.Name,

--- a/pkg/runtime.v2/framework/plugins/coscheduling/coscheduling.go
+++ b/pkg/runtime.v2/framework/plugins/coscheduling/coscheduling.go
@@ -88,19 +88,18 @@ func (c *CoScheduling) Name() string {
 	return Name
 }
 
-func (c *CoScheduling) EnforcePodGroupPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimePodGroupPolicy *kubeflowv2.PodGroupPolicy) error {
-	if info == nil || trainJob == nil || runtimePodGroupPolicy == nil || runtimePodGroupPolicy.Coscheduling == nil {
+func (c *CoScheduling) EnforcePodGroupPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error {
+	if info == nil || info.RuntimePolicy.PodGroupPolicy == nil || trainJob == nil {
 		return nil
 	}
 
 	info.Scheduler.PodLabels = make(map[string]string, 1)
 	info.Scheduler.PodLabels[schedulerpluginsv1alpha1.PodGroupLabel] = trainJob.Name
-	info.Scheduler.ScheduleTimeoutSeconds = runtimePodGroupPolicy.Coscheduling.ScheduleTimeoutSeconds
 	return nil
 }
 
 func (c *CoScheduling) Build(ctx context.Context, runtimeJobTemplate client.Object, info *runtime.Info, trainJob *kubeflowv2.TrainJob) (client.Object, error) {
-	if info == nil || info.Scheduler == nil || info.Scheduler.ScheduleTimeoutSeconds == nil || trainJob == nil {
+	if info == nil || info.RuntimePolicy.PodGroupPolicy == nil || info.RuntimePolicy.PodGroupPolicy.Coscheduling == nil || trainJob == nil {
 		return nil, nil
 	}
 
@@ -125,7 +124,7 @@ func (c *CoScheduling) Build(ctx context.Context, runtimeJobTemplate client.Obje
 			Namespace: trainJob.Namespace,
 		},
 		Spec: schedulerpluginsv1alpha1.PodGroupSpec{
-			ScheduleTimeoutSeconds: info.Scheduler.ScheduleTimeoutSeconds,
+			ScheduleTimeoutSeconds: info.RuntimePolicy.PodGroupPolicy.Coscheduling.ScheduleTimeoutSeconds,
 			MinMember:              totalMembers,
 			MinResources:           totalResources,
 		},

--- a/pkg/runtime.v2/framework/plugins/coscheduling/coscheduling.go
+++ b/pkg/runtime.v2/framework/plugins/coscheduling/coscheduling.go
@@ -87,7 +87,7 @@ func (c *CoScheduling) Name() string {
 	return Name
 }
 
-func (c *CoScheduling) EnforcePodGroupPolicy(trainJob *kubeflowv2.TrainJob, info *runtime.Info) error {
+func (c *CoScheduling) EnforcePodGroupPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error {
 	if info == nil || info.PodGroupPolicy == nil || trainJob == nil {
 		return nil
 	}
@@ -98,7 +98,7 @@ func (c *CoScheduling) EnforcePodGroupPolicy(trainJob *kubeflowv2.TrainJob, info
 	return nil
 }
 
-func (c *CoScheduling) Build(ctx context.Context, info *runtime.Info, trainJob *kubeflowv2.TrainJob) (client.Object, error) {
+func (c *CoScheduling) Build(ctx context.Context, info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeJobTemplateSpec interface{}) (client.Object, error) {
 	if info == nil || info.PodGroupPolicy == nil || info.PodGroupPolicy.Coscheduling == nil || trainJob == nil {
 		return nil, nil
 	}

--- a/pkg/runtime.v2/framework/plugins/coscheduling/coscheduling.go
+++ b/pkg/runtime.v2/framework/plugins/coscheduling/coscheduling.go
@@ -93,7 +93,9 @@ func (c *CoScheduling) EnforcePodGroupPolicy(info *runtime.Info, trainJob *kubef
 		return nil
 	}
 
-	info.Scheduler.PodLabels = make(map[string]string, 1)
+	if info.Scheduler.PodLabels == nil {
+		info.Scheduler.PodLabels = make(map[string]string, 1)
+	}
 	info.Scheduler.PodLabels[schedulerpluginsv1alpha1.PodGroupLabel] = trainJob.Name
 	return nil
 }

--- a/pkg/runtime.v2/framework/plugins/jobset/builder.go
+++ b/pkg/runtime.v2/framework/plugins/jobset/builder.go
@@ -20,6 +20,7 @@ import (
 	"maps"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
@@ -79,14 +80,14 @@ func (b *Builder) Trainer(info *runtime.Info, trainJob *kubeflowv2.TrainJob) *Bu
 					// Update values from the Info object.
 					if info.Trainer.Env != nil {
 						// Update JobSet envs from the Info.
-						envNames := make(map[string]bool, len(info.Trainer.Env))
+						envNames := sets.New[string]()
 						for _, env := range info.Trainer.Env {
-							envNames[env.Name] = true
+							envNames.Insert(env.Name)
 						}
 						trainerEnvs := info.Trainer.Env
 						// Info envs take precedence over TrainingRuntime envs.
 						for _, env := range container.Env {
-							if _, ok := envNames[env.Name]; !ok {
+							if !envNames.Has(env.Name) {
 								trainerEnvs = append(trainerEnvs, env)
 							}
 						}

--- a/pkg/runtime.v2/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime.v2/framework/plugins/jobset/jobset.go
@@ -68,8 +68,8 @@ func (j *JobSet) Name() string {
 	return Name
 }
 
-func (j *JobSet) Build(ctx context.Context, info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeJobTemplateSpec interface{}) (client.Object, error) {
-	if info == nil || trainJob == nil || runtimeJobTemplateSpec == nil {
+func (j *JobSet) Build(ctx context.Context, runtimeJobTemplateSpec interface{}, info *runtime.Info, trainJob *kubeflowv2.TrainJob) (client.Object, error) {
+	if runtimeJobTemplateSpec == nil || info == nil || trainJob == nil {
 		return nil, fmt.Errorf("runtime info or object is missing")
 	}
 

--- a/pkg/runtime.v2/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime.v2/framework/plugins/jobset/jobset.go
@@ -75,7 +75,7 @@ func (j *JobSet) Build(ctx context.Context, runtimeJobTemplateSpec interface{}, 
 
 	raw, ok := runtimeJobTemplateSpec.(jobsetv1alpha2.JobSetSpec)
 	if !ok {
-		return nil, fmt.Errorf("failed to cast runtime Job template for JobSetSpec")
+		return nil, nil
 	}
 
 	var jobSetBuilder *Builder

--- a/pkg/runtime.v2/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime.v2/framework/plugins/jobset/jobset.go
@@ -68,12 +68,12 @@ func (j *JobSet) Name() string {
 	return Name
 }
 
-func (j *JobSet) Build(ctx context.Context, runtimeJobTemplateSpec interface{}, info *runtime.Info, trainJob *kubeflowv2.TrainJob) (client.Object, error) {
-	if runtimeJobTemplateSpec == nil || info == nil || trainJob == nil {
+func (j *JobSet) Build(ctx context.Context, runtimeJobTemplate client.Object, info *runtime.Info, trainJob *kubeflowv2.TrainJob) (client.Object, error) {
+	if runtimeJobTemplate == nil || info == nil || trainJob == nil {
 		return nil, fmt.Errorf("runtime info or object is missing")
 	}
 
-	raw, ok := runtimeJobTemplateSpec.(jobsetv1alpha2.JobSetSpec)
+	raw, ok := runtimeJobTemplate.(*jobsetv1alpha2.JobSet)
 	if !ok {
 		return nil, nil
 	}
@@ -89,7 +89,7 @@ func (j *JobSet) Build(ctx context.Context, runtimeJobTemplateSpec interface{}, 
 				Labels:      info.Labels,
 				Annotations: info.Annotations,
 			},
-			Spec: raw,
+			Spec: raw.Spec,
 		})
 		oldJobSet = nil
 	} else {
@@ -100,6 +100,7 @@ func (j *JobSet) Build(ctx context.Context, runtimeJobTemplateSpec interface{}, 
 
 	// TODO (andreyvelich): add support for model and dataset initializers.
 	// TODO (andreyvelich): Add support for the PodSpecOverride.
+	// TODO (andreyvelich): Refactor the builder with wrappers for PodSpec.
 	jobSet := jobSetBuilder.
 		Trainer(info, trainJob).
 		PodLabels(info.PodLabels).

--- a/pkg/runtime.v2/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime.v2/framework/plugins/jobset/jobset.go
@@ -36,6 +36,7 @@ import (
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	kubeflowv2 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1"
+	"github.com/kubeflow/training-operator/pkg/constants"
 	runtime "github.com/kubeflow/training-operator/pkg/runtime.v2"
 	"github.com/kubeflow/training-operator/pkg/runtime.v2/framework"
 )
@@ -50,7 +51,7 @@ type JobSet struct {
 var _ framework.WatchExtensionPlugin = (*JobSet)(nil)
 var _ framework.ComponentBuilderPlugin = (*JobSet)(nil)
 
-const Name = "JobSet"
+const Name = constants.JobSetKind
 
 //+kubebuilder:rbac:groups=jobset.x-k8s.io,resources=jobsets,verbs=get;list;watch;create
 
@@ -59,7 +60,7 @@ func New(ctx context.Context, c client.Client, _ client.FieldIndexer) (framework
 		client:     c,
 		restMapper: c.RESTMapper(),
 		scheme:     c.Scheme(),
-		logger:     ctrl.LoggerFrom(ctx).WithValues("pluginName", "JobSet"),
+		logger:     ctrl.LoggerFrom(ctx).WithValues("pluginName", constants.JobSetKind),
 	}, nil
 }
 
@@ -126,7 +127,7 @@ func jobSetIsSuspended(jobSet *jobsetv1alpha2.JobSet) bool {
 
 func (j *JobSet) ReconcilerBuilders() []runtime.ReconcilerBuilder {
 	if _, err := j.restMapper.RESTMapping(
-		schema.GroupKind{Group: jobsetv1alpha2.GroupVersion.Group, Kind: "JobSet"},
+		schema.GroupKind{Group: jobsetv1alpha2.GroupVersion.Group, Kind: constants.JobSetKind},
 		jobsetv1alpha2.SchemeGroupVersion.Version,
 	); err != nil {
 		// TODO (tenzen-y): After we provide the Configuration API, we should return errors based on the enabled plugins.

--- a/pkg/runtime.v2/framework/plugins/mpi/mpi.go
+++ b/pkg/runtime.v2/framework/plugins/mpi/mpi.go
@@ -47,8 +47,8 @@ func (m *MPI) Name() string {
 	return Name
 }
 
-func (m *MPI) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeMLPolicy *kubeflowv2.MLPolicy) error {
-	if info == nil || runtimeMLPolicy == nil || runtimeMLPolicy.MPI == nil {
+func (m *MPI) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error {
+	if info == nil || info.RuntimePolicy.MLPolicy == nil || info.RuntimePolicy.MLPolicy.MPI == nil {
 		return nil
 	}
 	// TODO: Need to implement main logic.

--- a/pkg/runtime.v2/framework/plugins/mpi/mpi.go
+++ b/pkg/runtime.v2/framework/plugins/mpi/mpi.go
@@ -47,7 +47,7 @@ func (m *MPI) Name() string {
 	return Name
 }
 
-func (m *MPI) EnforceMLPolicy(info *runtime.Info) error {
+func (m *MPI) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error {
 	if info == nil || info.MLPolicy == nil || info.MLPolicy.MPI == nil {
 		return nil
 	}

--- a/pkg/runtime.v2/framework/plugins/mpi/mpi.go
+++ b/pkg/runtime.v2/framework/plugins/mpi/mpi.go
@@ -47,8 +47,8 @@ func (m *MPI) Name() string {
 	return Name
 }
 
-func (m *MPI) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error {
-	if info == nil || info.MLPolicy == nil || info.MLPolicy.MPI == nil {
+func (m *MPI) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeMLPolicy *kubeflowv2.MLPolicy) error {
+	if info == nil || runtimeMLPolicy == nil || runtimeMLPolicy.MPI == nil {
 		return nil
 	}
 	// TODO: Need to implement main logic.

--- a/pkg/runtime.v2/framework/plugins/plainml/plainml.go
+++ b/pkg/runtime.v2/framework/plugins/plainml/plainml.go
@@ -55,9 +55,8 @@ func (p *PlainML) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.Train
 
 	// Add envs from the TrainJob.
 	if trainJob.Spec.Trainer != nil {
-		info.Trainer.Env = make(map[string]string, len(trainJob.Spec.Trainer.Env))
 		for _, env := range trainJob.Spec.Trainer.Env {
-			info.Trainer.Env[env.Name] = env.Value
+			info.Trainer.Env = append(info.Trainer.Env, env)
 		}
 	}
 

--- a/pkg/runtime.v2/framework/plugins/plainml/plainml.go
+++ b/pkg/runtime.v2/framework/plugins/plainml/plainml.go
@@ -53,6 +53,14 @@ func (p *PlainML) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.Train
 	}
 	info.Trainer.NumNodes = numNodes
 
+	// Add envs from the TrainJob.
+	if trainJob.Spec.Trainer != nil {
+		info.Trainer.Env = make(map[string]string, len(trainJob.Spec.Trainer.Env))
+		for _, env := range trainJob.Spec.Trainer.Env {
+			info.Trainer.Env[env.Name] = env.Value
+		}
+	}
+
 	// Update total Pod requests for the PodGroupPolicy plugin.
 	for rName := range info.TotalRequests {
 		// For other Jobs like the Initializer, replica is always equal to 1.

--- a/pkg/runtime.v2/framework/plugins/plainml/plainml.go
+++ b/pkg/runtime.v2/framework/plugins/plainml/plainml.go
@@ -56,6 +56,7 @@ func (p *PlainML) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.Train
 	// Update total Pod requests for the PodGroupPolicy plugin.
 	for rName := range info.TotalRequests {
 		// For other Jobs like the Initializer, replica is always equal to 1.
+		// TODO (andreyvelich): Add support for total requests from the TrainJob's ResourcesPerNode.
 		if rName == constants.JobTrainerNode {
 			info.TotalRequests[rName] = runtime.TotalResourceRequest{
 				Replicas:    *numNodes,

--- a/pkg/runtime.v2/framework/plugins/plainml/plainml.go
+++ b/pkg/runtime.v2/framework/plugins/plainml/plainml.go
@@ -55,9 +55,7 @@ func (p *PlainML) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.Train
 
 	// Add envs from the TrainJob.
 	if trainJob.Spec.Trainer != nil {
-		for _, env := range trainJob.Spec.Trainer.Env {
-			info.Trainer.Env = append(info.Trainer.Env, env)
-		}
+		info.Trainer.Env = append(info.Trainer.Env, trainJob.Spec.Trainer.Env...)
 	}
 
 	// Update total Pod requests for the PodGroupPolicy plugin.

--- a/pkg/runtime.v2/framework/plugins/plainml/plainml.go
+++ b/pkg/runtime.v2/framework/plugins/plainml/plainml.go
@@ -42,13 +42,14 @@ func (p *PlainML) Name() string {
 	return Name
 }
 
-func (p *PlainML) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeMLPolicy *kubeflowv2.MLPolicy) error {
-	if info == nil || runtimeMLPolicy == nil || runtimeMLPolicy.Torch != nil || runtimeMLPolicy.MPI != nil {
+func (p *PlainML) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error {
+	if info == nil || info.RuntimePolicy.MLPolicy == nil || info.RuntimePolicy.MLPolicy.Torch != nil || info.RuntimePolicy.MLPolicy.MPI != nil {
 		return nil
 	}
 
 	// TrainJob contains the actual information for the number of nodes.
-	numNodes := runtimeMLPolicy.NumNodes
+	numNodes := info.RuntimePolicy.MLPolicy.NumNodes
+
 	if trainJob.Spec.Trainer != nil && trainJob.Spec.Trainer.NumNodes != nil {
 		numNodes = trainJob.Spec.Trainer.NumNodes
 	}

--- a/pkg/runtime.v2/framework/plugins/plainml/plainml.go
+++ b/pkg/runtime.v2/framework/plugins/plainml/plainml.go
@@ -66,7 +66,7 @@ func (p *PlainML) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.Train
 		// TODO (andreyvelich): Add support for total requests from the TrainJob's ResourcesPerNode.
 		if rName == constants.JobTrainerNode {
 			info.Scheduler.TotalRequests[rName] = runtime.TotalResourceRequest{
-				Replicas:    ptr.Deref(numNodes, 1),
+				Replicas:    ptr.Deref(numNodes, constants.DefaultJobReplicas),
 				PodRequests: info.TotalRequests[rName].PodRequests,
 			}
 		}

--- a/pkg/runtime.v2/framework/plugins/plainml/plainml.go
+++ b/pkg/runtime.v2/framework/plugins/plainml/plainml.go
@@ -19,6 +19,7 @@ package plainml
 import (
 	"context"
 
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kubeflowv2 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1"
@@ -64,7 +65,7 @@ func (p *PlainML) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.Train
 		// TODO (andreyvelich): Add support for total requests from the TrainJob's ResourcesPerNode.
 		if rName == constants.JobTrainerNode {
 			info.TotalRequests[rName] = runtime.TotalResourceRequest{
-				Replicas:    *numNodes,
+				Replicas:    ptr.Deref(numNodes, 1),
 				PodRequests: info.TotalRequests[rName].PodRequests,
 			}
 		}

--- a/pkg/runtime.v2/framework/plugins/plainml/plainml.go
+++ b/pkg/runtime.v2/framework/plugins/plainml/plainml.go
@@ -48,12 +48,14 @@ func (p *PlainML) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.Train
 
 	// TrainJob contains the actual information for the number of nodes.
 	numNodes := info.MLPolicy.NumNodes
-	if trainJob.Spec.Trainer.NumNodes != nil {
+	if trainJob.Spec.Trainer != nil && trainJob.Spec.Trainer.NumNodes != nil {
 		numNodes = trainJob.Spec.Trainer.NumNodes
 	}
+	info.Trainer.NumNodes = numNodes
 
+	// Update total Pod requests for the PodGroupPolicy plugin.
 	for rName := range info.TotalRequests {
-		// For other Jobs replica is always equal to 1.
+		// For other Jobs like the Initializer, replica is always equal to 1.
 		if rName == constants.JobTrainerNode {
 			info.TotalRequests[rName] = runtime.TotalResourceRequest{
 				Replicas:    *numNodes,
@@ -61,8 +63,6 @@ func (p *PlainML) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.Train
 			}
 		}
 	}
-
-	info.Trainer.NumNodes = *numNodes
 
 	return nil
 }

--- a/pkg/runtime.v2/framework/plugins/plainml/plainml.go
+++ b/pkg/runtime.v2/framework/plugins/plainml/plainml.go
@@ -42,13 +42,13 @@ func (p *PlainML) Name() string {
 	return Name
 }
 
-func (p *PlainML) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error {
-	if info == nil || info.MLPolicy == nil || info.MLPolicy.Torch != nil || info.MLPolicy.MPI != nil {
+func (p *PlainML) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeMLPolicy *kubeflowv2.MLPolicy) error {
+	if info == nil || runtimeMLPolicy == nil || runtimeMLPolicy.Torch != nil || runtimeMLPolicy.MPI != nil {
 		return nil
 	}
 
 	// TrainJob contains the actual information for the number of nodes.
-	numNodes := info.MLPolicy.NumNodes
+	numNodes := runtimeMLPolicy.NumNodes
 	if trainJob.Spec.Trainer != nil && trainJob.Spec.Trainer.NumNodes != nil {
 		numNodes = trainJob.Spec.Trainer.NumNodes
 	}
@@ -64,7 +64,7 @@ func (p *PlainML) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.Train
 		// For other Jobs like the Initializer, replica is always equal to 1.
 		// TODO (andreyvelich): Add support for total requests from the TrainJob's ResourcesPerNode.
 		if rName == constants.JobTrainerNode {
-			info.TotalRequests[rName] = runtime.TotalResourceRequest{
+			info.Scheduler.TotalRequests[rName] = runtime.TotalResourceRequest{
 				Replicas:    ptr.Deref(numNodes, 1),
 				PodRequests: info.TotalRequests[rName].PodRequests,
 			}

--- a/pkg/runtime.v2/framework/plugins/torch/torch.go
+++ b/pkg/runtime.v2/framework/plugins/torch/torch.go
@@ -125,7 +125,7 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJo
 		// TODO (andreyvelich): Add support for total requests from the TrainJob's ResourcesPerNode.
 		if rName == constants.JobTrainerNode {
 			info.TotalRequests[rName] = runtime.TotalResourceRequest{
-				Replicas:    ptr.Deref(numNodes, 1),
+				Replicas:    ptr.Deref(numNodes, constants.DefaultJobReplicas),
 				PodRequests: info.TotalRequests[rName].PodRequests,
 			}
 		}

--- a/pkg/runtime.v2/framework/plugins/torch/torch.go
+++ b/pkg/runtime.v2/framework/plugins/torch/torch.go
@@ -49,19 +49,19 @@ func (t *Torch) Name() string {
 }
 
 // TODO (andreyvelich): Add support for PyTorch elastic when JobSet supports Elastic Jobs.
-func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error {
-	if info == nil || info.MLPolicy == nil || info.MLPolicy.Torch == nil {
+func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeMLPolicy *kubeflowv2.MLPolicy) error {
+	if info == nil || runtimeMLPolicy == nil || runtimeMLPolicy.Torch == nil {
 		return nil
 	}
 
 	// TrainJob contains the actual information for the Trainer.
-	numNodes := info.MLPolicy.NumNodes
+	numNodes := runtimeMLPolicy.NumNodes
 	if trainJob.Spec.Trainer != nil && trainJob.Spec.Trainer.NumNodes != nil {
 		numNodes = trainJob.Spec.Trainer.NumNodes
 	}
 	info.Trainer.NumNodes = numNodes
 
-	numProcPerNode := info.MLPolicy.Torch.NumProcPerNode
+	numProcPerNode := runtimeMLPolicy.Torch.NumProcPerNode
 	if trainJob.Spec.Trainer != nil && trainJob.Spec.Trainer.NumProcPerNode != nil {
 		numProcPerNode = trainJob.Spec.Trainer.NumProcPerNode
 	}

--- a/pkg/runtime.v2/framework/plugins/torch/torch.go
+++ b/pkg/runtime.v2/framework/plugins/torch/torch.go
@@ -43,7 +43,7 @@ func (t *Torch) Name() string {
 	return Name
 }
 
-func (t *Torch) EnforceMLPolicy(info *runtime.Info) error {
+func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error {
 	if info == nil || info.MLPolicy == nil || info.MLPolicy.Torch == nil {
 		return nil
 	}

--- a/pkg/runtime.v2/framework/plugins/torch/torch.go
+++ b/pkg/runtime.v2/framework/plugins/torch/torch.go
@@ -69,6 +69,8 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJo
 	// Update envs for Info object.
 	// Add PyTorch distributed "PET_" values for torchrun
 	// TODO (andreyvelich): Add validation to check that TrainJob doesn't have "PET_" envs.
+	// TODO (andreyvelich): We should validate that envs from different plugins don't conflict with each other.
+	// Ref: https://github.com/kubeflow/training-operator/pull/2308#discussion_r1823229940
 	infoEnvs := []corev1.EnvVar{
 		{
 			Name:  constants.TorchEnvNumNodes,

--- a/pkg/runtime.v2/framework/plugins/torch/torch.go
+++ b/pkg/runtime.v2/framework/plugins/torch/torch.go
@@ -49,19 +49,19 @@ func (t *Torch) Name() string {
 }
 
 // TODO (andreyvelich): Add support for PyTorch elastic when JobSet supports Elastic Jobs.
-func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob, runtimeMLPolicy *kubeflowv2.MLPolicy) error {
-	if info == nil || runtimeMLPolicy == nil || runtimeMLPolicy.Torch == nil {
+func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *kubeflowv2.TrainJob) error {
+	if info == nil || info.RuntimePolicy.MLPolicy == nil || info.RuntimePolicy.MLPolicy.Torch == nil {
 		return nil
 	}
 
 	// TrainJob contains the actual information for the Trainer.
-	numNodes := runtimeMLPolicy.NumNodes
+	numNodes := info.RuntimePolicy.MLPolicy.NumNodes
 	if trainJob.Spec.Trainer != nil && trainJob.Spec.Trainer.NumNodes != nil {
 		numNodes = trainJob.Spec.Trainer.NumNodes
 	}
 	info.Trainer.NumNodes = numNodes
 
-	numProcPerNode := runtimeMLPolicy.Torch.NumProcPerNode
+	numProcPerNode := info.RuntimePolicy.MLPolicy.Torch.NumProcPerNode
 	if trainJob.Spec.Trainer != nil && trainJob.Spec.Trainer.NumProcPerNode != nil {
 		numProcPerNode = trainJob.Spec.Trainer.NumProcPerNode
 	}

--- a/pkg/runtime.v2/runtime.go
+++ b/pkg/runtime.v2/runtime.go
@@ -41,7 +41,7 @@ type Info struct {
 }
 
 type Trainer struct {
-	NumNodes int32
+	NumNodes *int32
 }
 
 type Policy struct {

--- a/pkg/runtime.v2/runtime.go
+++ b/pkg/runtime.v2/runtime.go
@@ -31,8 +31,9 @@ type Info struct {
 }
 
 type Trainer struct {
-	// TODO (andreyvelich): Add more parameters.
-	NumNodes      *int32
+	NumNodes *int32
+	// TODO (andreyvelich). Potentially, we can use map for env and sort it to improve code.
+	// Context: https://github.com/kubeflow/training-operator/pull/2308#discussion_r1823267183
 	Env           []corev1.EnvVar
 	ContainerPort *corev1.ContainerPort
 }

--- a/pkg/runtime.v2/runtime.go
+++ b/pkg/runtime.v2/runtime.go
@@ -17,18 +17,12 @@ limitations under the License.
 package runtimev2
 
 import (
-	"errors"
 	"maps"
 
 	corev1 "k8s.io/api/core/v1"
 	kueuelr "sigs.k8s.io/kueue/pkg/util/limitrange"
 
 	kubeflowv2 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1"
-)
-
-var (
-	errorDifferentGVK  = errors.New("the GroupVersionKinds are different between old and new objects")
-	errorObjectsAreNil = errors.New("old or new objects are nil")
 )
 
 type Info struct {

--- a/pkg/runtime.v2/runtime.go
+++ b/pkg/runtime.v2/runtime.go
@@ -36,8 +36,9 @@ type Info struct {
 
 type Trainer struct {
 	// TODO (andreyvelich): Add more parameters.
-	NumNodes *int32
-	Env      map[string]string
+	NumNodes      *int32
+	Env           []corev1.EnvVar
+	ContainerPort *corev1.ContainerPort
 }
 
 type Policy struct {

--- a/pkg/runtime.v2/runtime.go
+++ b/pkg/runtime.v2/runtime.go
@@ -41,6 +41,7 @@ type Info struct {
 }
 
 type Trainer struct {
+	// TODO (andreyvelich): Add more parameters.
 	NumNodes *int32
 }
 

--- a/pkg/runtime.v2/runtime.go
+++ b/pkg/runtime.v2/runtime.go
@@ -37,6 +37,7 @@ type Info struct {
 type Trainer struct {
 	// TODO (andreyvelich): Add more parameters.
 	NumNodes *int32
+	Env      map[string]string
 }
 
 type Policy struct {

--- a/pkg/runtime.v2/runtime_test.go
+++ b/pkg/runtime.v2/runtime_test.go
@@ -30,8 +30,6 @@ import (
 )
 
 func TestNewInfo(t *testing.T) {
-	// jobSetBase := testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
-	// 	Clone()
 
 	cases := map[string]struct {
 		infoOpts []InfoOption

--- a/pkg/util.v2/testing/wrapper.go
+++ b/pkg/util.v2/testing/wrapper.go
@@ -118,6 +118,19 @@ func (j *JobSetWrapper) ContainerTrainer(image string, command []string, args []
 	return j
 }
 
+func (j *JobSetWrapper) ContainerTrainerPorts(ports []corev1.ContainerPort) *JobSetWrapper {
+	for i, rJob := range j.Spec.ReplicatedJobs {
+		if rJob.Name == constants.JobTrainerNode {
+			for k, container := range rJob.Template.Spec.Template.Spec.Containers {
+				if container.Name == constants.ContainerTrainer {
+					j.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.Containers[k].Ports = ports
+				}
+			}
+		}
+	}
+	return j
+}
+
 func (j *JobSetWrapper) ContainerTrainerEnv(env []corev1.EnvVar) *JobSetWrapper {
 	for i, rJob := range j.Spec.ReplicatedJobs {
 		if rJob.Name == constants.JobTrainerNode {

--- a/test/integration/controller.v2/trainjob_controller_test.go
+++ b/test/integration/controller.v2/trainjob_controller_test.go
@@ -95,7 +95,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 						NumNodes(100).
 						ContainerTrainer("test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 						ContainerDatasetModelInitializer("test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
-						PodGroupPolicyCoscheduling(&kubeflowv2.CoschedulingPodGroupPolicySource{}).
+						PodGroupPolicyCoscheduling(&kubeflowv2.CoschedulingPodGroupPolicySource{ScheduleTimeoutSeconds: ptr.To[int32](100)}).
 						Obj()).
 				Obj()
 		})
@@ -131,6 +131,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 							corev1.ResourceCPU:    resource.MustParse("101"), // 1 CPU and 4Gi per replica.
 							corev1.ResourceMemory: resource.MustParse("404Gi"),
 						}).
+						SchedulingTimeout(100).
 						ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind(kubeflowv2.TrainJobKind), trainJobKey.Name, string(trainJob.UID)).
 						Obj(),
 					util.IgnoreObjectMetadata))
@@ -183,6 +184,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 							corev1.ResourceCPU:    resource.MustParse("101"), // 1 CPU and 4Gi per 101 replica.
 							corev1.ResourceMemory: resource.MustParse("404Gi"),
 						}).
+						SchedulingTimeout(100).
 						ControllerReference(kubeflowv2.SchemeGroupVersion.WithKind(kubeflowv2.TrainJobKind), trainJobKey.Name, string(trainJob.UID)).
 						Obj(),
 					util.IgnoreObjectMetadata))

--- a/test/integration/webhook.v2/clustertrainingruntime_test.go
+++ b/test/integration/webhook.v2/clustertrainingruntime_test.go
@@ -68,7 +68,6 @@ var _ = ginkgo.Describe("ClusterTrainingRuntime Webhook", ginkgo.Ordered, func()
 					return baseRuntime.
 						RuntimeSpec(
 							testingutil.MakeTrainingRuntimeSpecWrapper(baseRuntime.Spec).
-								Replicas(1).
 								Obj()).
 						Obj()
 				}),

--- a/test/integration/webhook.v2/trainingruntime_test.go
+++ b/test/integration/webhook.v2/trainingruntime_test.go
@@ -65,11 +65,10 @@ var _ = ginkgo.Describe("TrainingRuntime Webhook", ginkgo.Ordered, func() {
 		},
 			ginkgo.Entry("Should succeed to create TrainingRuntime",
 				func() *kubeflowv2.TrainingRuntime {
-					baseRuntime := testingutil.MakeTrainingRuntimeWrapper(ns.Name, trainingRuntimeName).Clone()
+					baseRuntime := testingutil.MakeTrainingRuntimeWrapper(ns.Name, trainingRuntimeName)
 					return baseRuntime.
 						RuntimeSpec(
 							testingutil.MakeTrainingRuntimeSpecWrapper(baseRuntime.Spec).
-								Replicas(1).
 								Obj()).
 						Obj()
 				}),


### PR DESCRIPTION
Part of: https://github.com/kubeflow/training-operator/issues/2290.

I implemented JobSet and PlainML plugins, and I was able to submit our first TrainJob and ClusterTrainingRuntime 🎉 

<details><summary>Working ClusterTrainingRuntime</summary>

    apiVersion: kubeflow.org/v2alpha1
    kind: ClusterTrainingRuntime
    metadata:
      name: first-runtime
    spec:
      mlPolicy:
        numNodes: 5
      template:
        spec:
          replicatedJobs:
            - name: trainer-node
              template:
                spec:
                  template:
                    spec:
                      containers:
                        - name: trainer
                          image: python:alpine3.20
                          command:
                            - "/bin/sh"
                            - -c
                            - "echo 'Hello From Training Runtime'"
    ---
    apiVersion: kubeflow.org/v2alpha1
    kind: TrainJob
    metadata:
      name: first-job
    spec:
      runtimeRef:
        name: first-runtime
        kind: ClusterTrainingRuntime
        apiGroup: kubeflow.org
      trainer:
        numNodes: 2
</details>

A few details:
- We discussed with @tenzen-y that Info object doesn't need to have Obj class, since we can directly pass the JobTemplateSpec into `RunComponentBuilderPlugins()` API.
- I added the Trainer struct in Info object which represents values combined from MLPolicy and TrainJob. Those values will be inserted into JobSet.
- [x] I need to update the unit tests in this PR.
- [x] I need to implement torch plugin.
- [x] I need to implement env variables enforcement.


/assign @kubeflow/wg-training-leads @varshaprasad96 @akshaychitneni @deepanker13 @helenxie-bit @Electronic-Waste @saileshd1402 @kannon92 @kuizhiqing @shravan-achar