### PR TITLE
Validate pytorchjob workers are configured when elasticpolicy is configured

### DIFF
--- a/pkg/webhooks/pytorch/pytorchjob_webhook.go
+++ b/pkg/webhooks/pytorch/pytorchjob_webhook.go
@@ -94,13 +94,10 @@ func validateSpec(spec trainingoperator.PyTorchJobSpec) (admission.Warnings, fie
 	var allErrs field.ErrorList
 	var warnings admission.Warnings
 	if spec.ElasticPolicy != nil {
-		workerReplicaSpec, ok := spec.PyTorchReplicaSpecs[trainingoperator.PyTorchJobReplicaTypeWorker]
-		workerPath := specPath.Child("pytorchReplicaSpecs").Child("Worker")
+		_, ok := spec.PyTorchReplicaSpecs[trainingoperator.PyTorchJobReplicaTypeWorker]
+		workerPath := pytorchReplicaSpecPath.Key(string(trainingoperator.PyTorchJobReplicaTypeWorker))
 		if !ok {
 			allErrs = append(allErrs, field.Required(workerPath, "must be configured if elastic policy is used"))
-		} else if workerReplicaSpec.Replicas != nil && int(*workerReplicaSpec.Replicas) < 1 {
-			workerReplicasPath := workerPath.Child("replicas")
-			allErrs = append(allErrs, field.Forbidden(workerReplicasPath, "must be at least 1 worker if elastic policy is used"))
 		}
 		if spec.ElasticPolicy.NProcPerNode != nil {
 			elasticNProcPerNodePath := specPath.Child("elasticPolicy").Child("nProcPerNode")
@@ -156,6 +153,8 @@ func validatePyTorchReplicaSpecs(rSpecs map[trainingoperator.ReplicaType]*traini
 			if rSpec.Replicas == nil || int(*rSpec.Replicas) != 1 {
 				allErrs = append(allErrs, field.Forbidden(rolePath.Child("replicas"), "must be 1"))
 			}
+		} else if rSpec.Replicas != nil && int(*rSpec.Replicas) < 1 {
+			allErrs = append(allErrs, field.Forbidden(rolePath.Child("replicas"), "must be at least 1"))
 		}
 	}
 	return allErrs

--- a/pkg/webhooks/pytorch/pytorchjob_webhook.go
+++ b/pkg/webhooks/pytorch/pytorchjob_webhook.go
@@ -100,7 +100,7 @@ func validateSpec(spec trainingoperator.PyTorchJobSpec) (admission.Warnings, fie
 			allErrs = append(allErrs, field.Required(workerPath, "must be configured if elastic policy is used"))
 		} else if workerReplicaSpec.Replicas != nil && int(*workerReplicaSpec.Replicas) < 1 {
 			workerReplicasPath := workerPath.Child("replicas")
-			allErrs = append(allErrs, field.Forbidden(workerReplicasPath, "must be at least 1 if elastic policy is used"))
+			allErrs = append(allErrs, field.Forbidden(workerReplicasPath, "must be at least 1 worker if elastic policy is used"))
 		}
 		if spec.ElasticPolicy.NProcPerNode != nil {
 			elasticNProcPerNodePath := specPath.Child("elasticPolicy").Child("nProcPerNode")

--- a/pkg/webhooks/pytorch/pytorchjob_webhook_test.go
+++ b/pkg/webhooks/pytorch/pytorchjob_webhook_test.go
@@ -88,6 +88,9 @@ func TestValidateV1PyTorchJob(t *testing.T) {
 					RunPolicy: trainingoperator.RunPolicy{
 						ManagedBy: ptr.To(trainingoperator.KubeflowJobsController),
 					},
+					ElasticPolicy: &trainingoperator.ElasticPolicy{
+						RDZVBackend: ptr.To(trainingoperator.BackendC10D),
+					},
 					PyTorchReplicaSpecs: validPyTorchReplicaSpecs,
 				},
 			},
@@ -247,6 +250,19 @@ func TestValidateV1PyTorchJob(t *testing.T) {
 								},
 							},
 						},
+						trainingoperator.PyTorchJobReplicaTypeWorker: {
+							Replicas: ptr.To[int32](1),
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  "pytorch",
+											Image: "gcr.io/kubeflow-ci/pytorch-dist-mnist_test:1.0",
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -267,6 +283,19 @@ func TestValidateV1PyTorchJob(t *testing.T) {
 					},
 					PyTorchReplicaSpecs: map[trainingoperator.ReplicaType]*trainingoperator.ReplicaSpec{
 						trainingoperator.PyTorchJobReplicaTypeMaster: {
+							Replicas: ptr.To[int32](1),
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  "pytorch",
+											Image: "gcr.io/kubeflow-ci/pytorch-dist-mnist_test:1.0",
+										},
+									},
+								},
+							},
+						},
+						trainingoperator.PyTorchJobReplicaTypeWorker: {
 							Replicas: ptr.To[int32](1),
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
@@ -333,6 +362,62 @@ func TestValidateV1PyTorchJob(t *testing.T) {
 			},
 			wantErr: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "runPolicy", "managedBy"), trainingoperator.MultiKueueController, apivalidation.FieldImmutableErrorMsg),
+			},
+		},
+		"attempt to configure elasticPolicy when no worker is configured": {
+			pytorchJob: &trainingoperator.PyTorchJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: trainingoperator.PyTorchJobSpec{
+					ElasticPolicy: &trainingoperator.ElasticPolicy{},
+					PyTorchReplicaSpecs: map[trainingoperator.ReplicaType]*trainingoperator.ReplicaSpec{
+						trainingoperator.PyTorchJobReplicaTypeMaster: {
+							Replicas: ptr.To[int32](1),
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  "pytorch",
+											Image: "gcr.io/kubeflow-ci/pytorch-dist-mnist_test:1.0",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				field.Required(field.NewPath("spec", "pytorchReplicaSpecs", "Worker"), "must be configured if elastic policy is used"),
+			},
+		},
+		"attempt to configure elasticPolicy when worker replicas is 0": {
+			pytorchJob: &trainingoperator.PyTorchJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: trainingoperator.PyTorchJobSpec{
+					ElasticPolicy: &trainingoperator.ElasticPolicy{},
+					PyTorchReplicaSpecs: map[trainingoperator.ReplicaType]*trainingoperator.ReplicaSpec{
+						trainingoperator.PyTorchJobReplicaTypeWorker: {
+							Replicas: ptr.To[int32](0),
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  "pytorch",
+											Image: "gcr.io/kubeflow-ci/pytorch-dist-mnist_test:1.0",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "pytorchReplicaSpecs", "Worker", "replicas"), "must be at least 1 if elastic policy is used"),
 			},
 		},
 	}

--- a/pkg/webhooks/pytorch/pytorchjob_webhook_test.go
+++ b/pkg/webhooks/pytorch/pytorchjob_webhook_test.go
@@ -389,10 +389,10 @@ func TestValidateV1PyTorchJob(t *testing.T) {
 				},
 			},
 			wantErr: field.ErrorList{
-				field.Required(field.NewPath("spec", "pytorchReplicaSpecs", "Worker"), "must be configured if elastic policy is used"),
+				field.Required(pytorchReplicaSpecPath.Key(string(trainingoperator.PyTorchJobReplicaTypeWorker)), ""),
 			},
 		},
-		"attempt to configure elasticPolicy when worker replicas is 0": {
+		"attempt to configure worker with 0 replicas": {
 			pytorchJob: &trainingoperator.PyTorchJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
@@ -417,7 +417,7 @@ func TestValidateV1PyTorchJob(t *testing.T) {
 				},
 			},
 			wantErr: field.ErrorList{
-				field.Forbidden(field.NewPath("spec", "pytorchReplicaSpecs", "Worker", "replicas"), "must be at least 1 if elastic policy is used"),
+				field.Forbidden(pytorchReplicaSpecPath.Key(string(trainingoperator.PyTorchJobReplicaTypeWorker)).Child("replicas"), ""),
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a check in the Pytorchjob validating webhook to ensure that if a user configures an elastic policy that they have defined a worker spec. Previously defining an elastic policy with no worker spec was resulting in a nil pointer exception on [this line](https://github.com/kubeflow/training-operator/blob/master/pkg/apis/kubeflow.org/v1/pytorch_defaults.go#L49). Additionally, we added validation to ensure that the worker spec defines at least one replica.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2278

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
