### PR TITLE
KEP-2170: Add TrainJob conditions

### DIFF
--- a/api.v2/openapi-spec/swagger.json
+++ b/api.v2/openapi-spec/swagger.json
@@ -610,7 +610,13 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1.Condition"
-          }
+          },
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
         },
         "jobsStatus": {
           "description": "JobsStatus tracks the child Jobs in TrainJob.",

--- a/hack/violation_exception_v2alpha1.list
+++ b/hack/violation_exception_v2alpha1.list
@@ -13,7 +13,6 @@ API rule violation: list_type_missing,github.com/kubeflow/training-operator/pkg/
 API rule violation: list_type_missing,github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1,PodSpecOverride,Volumes
 API rule violation: list_type_missing,github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1,TorchElasticPolicy,Metrics
 API rule violation: list_type_missing,github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1,TrainJobSpec,PodSpecOverrides
-API rule violation: list_type_missing,github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1,TrainJobStatus,Conditions
 API rule violation: list_type_missing,github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1,TrainJobStatus,JobsStatus
 API rule violation: list_type_missing,github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1,Trainer,Args
 API rule violation: list_type_missing,github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1,Trainer,Command

--- a/manifests/v2/base/crds/kubeflow.org_trainjobs.yaml
+++ b/manifests/v2/base/crds/kubeflow.org_trainjobs.yaml
@@ -3055,6 +3055,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               jobsStatus:
                 description: JobsStatus tracks the child Jobs in TrainJob.
                 items:

--- a/pkg/apis/kubeflow.org/v2alpha1/openapi_generated.go
+++ b/pkg/apis/kubeflow.org/v2alpha1/openapi_generated.go
@@ -1110,6 +1110,16 @@ func schema_pkg_apis_kubefloworg_v2alpha1_TrainJobStatus(ref common.ReferenceCal
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"type",
+								},
+								"x-kubernetes-list-type":       "map",
+								"x-kubernetes-patch-merge-key": "type",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Conditions for the TrainJob.",
 							Type:        []string{"array"},

--- a/pkg/apis/kubeflow.org/v2alpha1/trainjob_types.go
+++ b/pkg/apis/kubeflow.org/v2alpha1/trainjob_types.go
@@ -48,6 +48,43 @@ type TrainJob struct {
 	Status TrainJobStatus `json:"status,omitempty"`
 }
 
+const (
+	// TrainJobSuspended means the TrainJob is suspended.
+	TrainJobSuspended string = "Suspended"
+
+	// TrainJobComplete means that the TrainJob has completed its execution.
+	TrainJobComplete string = "Complete"
+
+	// TrainJobFailed means that the actual jobs have failed its execution.
+	TrainJobFailed string = "Failed"
+
+	// TrainJobCreated means that the actual jobs creation has succeeded.
+	TrainJobCreated string = "Created"
+)
+
+const (
+	// TrainJobSuspendedReason is the "Suspended" condition reason.
+	// When the TrainJob is suspended, this is added.
+	TrainJobSuspendedReason string = "Suspended"
+
+	// TrainJobResumedReason is the "Suspended" condition reason.
+	// When the TrainJob suspension is changed from True to False, this is added.
+	TrainJobResumedReason string = "Resumed"
+
+	// TrainJobJobsCreationSucceededReason is the "Created" condition reason.
+	// When the creating objects succeeded after building succeeded, this is added.
+	TrainJobJobsCreationSucceededReason string = "JobsCreationSucceeded"
+
+	// TrainJobJobsBuildFailedReason is the "Created" condition reason.
+	// When the building objects based on the TrainJob and the specified runtime failed,
+	// this is added.
+	TrainJobJobsBuildFailedReason string = "JobsBuildFailed"
+
+	// TrainJobJobsCreationFailedReason is the "Created" condition reason.
+	// When the creating objects failed even though building succeeded, this is added.
+	TrainJobJobsCreationFailedReason string = "JobsCreationFailed"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +resource:path=trainjobs
 
@@ -269,7 +306,13 @@ type ContainerOverride struct {
 // TrainJobStatus represents the current status of TrainJob.
 type TrainJobStatus struct {
 	// Conditions for the TrainJob.
-	Conditions []metav1.Condition `json:"conditions,omitempty"`
+	//
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
 	// JobsStatus tracks the child Jobs in TrainJob.
 	JobsStatus []JobStatus `json:"jobsStatus,omitempty"`

--- a/pkg/apis/kubeflow.org/v2alpha1/trainjob_types.go
+++ b/pkg/apis/kubeflow.org/v2alpha1/trainjob_types.go
@@ -49,7 +49,7 @@ type TrainJob struct {
 }
 
 const (
-	// TrainJobSuspended means the TrainJob is suspended.
+	// TrainJobSuspended means that TrainJob is suspended.
 	TrainJobSuspended string = "Suspended"
 
 	// TrainJobComplete means that the TrainJob has completed its execution.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -51,6 +51,26 @@ const (
 
 	// TorchEnvMasterPort is the env name for the master node port.
 	TorchEnvMasterPort string = "PET_MASTER_PORT"
+
+	// TrainJobJobsCreationSucceededMessage is status condition message for the
+	// {"type": "Created", "status": "True", "reason": "JobsCreationSucceeded"} condition.
+	TrainJobJobsCreationSucceededMessage = "Succeeded to create Jobs"
+
+	// TrainJobJobsBuildFailedMessage is status condition message for the
+	// {"type": "Created", "status": "True", "reason": "JobsBuildFailed"} condition.
+	TrainJobJobsBuildFailedMessage = "Failed to build Jobs"
+
+	// TrainJobJobsCreationFailedMessage is status condition message for the
+	// {"type": "Created", "status": "True", "reason": "JobsCreationFailed"} condition.
+	TrainJobJobsCreationFailedMessage = "Failed to create Jobs"
+
+	// TrainJobSuspendedMessage is status condition message for the
+	// {"type": "Suspended", "status": "True", "reason": "Suspended"} condition.
+	TrainJobSuspendedMessage = "TrainJob is suspended"
+
+	// TrainJobResumedMessage is status condition message for the
+	// {"type": "Suspended", "status": "True", "reason": "Resumed"} condition.
+	TrainJobResumedMessage = "TrainJob is resumed"
 )
 
 var (

--- a/pkg/runtime.v2/core/clustertrainingruntime.go
+++ b/pkg/runtime.v2/core/clustertrainingruntime.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,6 +58,10 @@ func (r *ClusterTrainingRuntime) NewObjects(ctx context.Context, trainJob *kubef
 		return nil, fmt.Errorf("%w: %w", errorNotFoundSpecifiedClusterTrainingRuntime, err)
 	}
 	return r.buildObjects(ctx, trainJob, clTrainingRuntime.Spec.Template, clTrainingRuntime.Spec.MLPolicy, clTrainingRuntime.Spec.PodGroupPolicy)
+}
+
+func (r *ClusterTrainingRuntime) TerminalCondition(ctx context.Context, trainJob *kubeflowv2.TrainJob) (*metav1.Condition, error) {
+	return r.TrainingRuntime.TerminalCondition(ctx, trainJob)
 }
 
 func (r *ClusterTrainingRuntime) EventHandlerRegistrars() []runtime.ReconcilerBuilder {

--- a/pkg/runtime.v2/core/trainingruntime.go
+++ b/pkg/runtime.v2/core/trainingruntime.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -125,6 +126,10 @@ func (r *TrainingRuntime) buildObjects(
 	}
 
 	return r.framework.RunComponentBuilderPlugins(ctx, jobSetTemplate.DeepCopy(), info, trainJob)
+}
+
+func (r *TrainingRuntime) TerminalCondition(ctx context.Context, trainJob *kubeflowv2.TrainJob) (*metav1.Condition, error) {
+	return r.framework.RunTerminalConditionPlugins(ctx, trainJob)
 }
 
 func (r *TrainingRuntime) EventHandlerRegistrars() []runtime.ReconcilerBuilder {

--- a/pkg/runtime.v2/framework/core/framework_test.go
+++ b/pkg/runtime.v2/framework/core/framework_test.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -612,7 +611,7 @@ func TestTerminalConditionPlugins(t *testing.T) {
 				Obj(),
 			wantCondition: &metav1.Condition{
 				Type:    kubeflowv2.TrainJobComplete,
-				Reason:  fmt.Sprintf("%sDueTo%s", jobsetv1alpha2.JobSetCompleted, jobsetconsts.AllJobsCompletedReason),
+				Reason:  jobsetconsts.AllJobsCompletedReason,
 				Message: jobsetconsts.AllJobsCompletedMessage,
 				Status:  metav1.ConditionTrue,
 			},
@@ -631,7 +630,7 @@ func TestTerminalConditionPlugins(t *testing.T) {
 				Obj(),
 			wantCondition: &metav1.Condition{
 				Type:    kubeflowv2.TrainJobFailed,
-				Reason:  fmt.Sprintf("%sDueTo%s", jobsetv1alpha2.JobSetFailed, jobsetconsts.FailedJobsReason),
+				Reason:  jobsetconsts.FailedJobsReason,
 				Message: jobsetconsts.FailedJobsMessage,
 				Status:  metav1.ConditionTrue,
 			},

--- a/pkg/runtime.v2/framework/interface.go
+++ b/pkg/runtime.v2/framework/interface.go
@@ -19,6 +19,7 @@ package framework
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -54,4 +55,9 @@ type CustomValidationPlugin interface {
 type ComponentBuilderPlugin interface {
 	Plugin
 	Build(ctx context.Context, runtimeJobTemplate client.Object, info *runtime.Info, trainJob *kubeflowv2.TrainJob) (client.Object, error)
+}
+
+type TerminalConditionPlugin interface {
+	Plugin
+	TerminalCondition(ctx context.Context, trainJob *kubeflowv2.TrainJob) (*metav1.Condition, error)
 }

--- a/pkg/runtime.v2/framework/plugins/coscheduling/coscheduling.go
+++ b/pkg/runtime.v2/framework/plugins/coscheduling/coscheduling.go
@@ -100,7 +100,7 @@ func (c *CoScheduling) EnforcePodGroupPolicy(info *runtime.Info, trainJob *kubef
 	return nil
 }
 
-func (c *CoScheduling) Build(ctx context.Context, runtimeJobTemplate client.Object, info *runtime.Info, trainJob *kubeflowv2.TrainJob) (client.Object, error) {
+func (c *CoScheduling) Build(ctx context.Context, _ client.Object, info *runtime.Info, trainJob *kubeflowv2.TrainJob) (client.Object, error) {
 	if info == nil || info.RuntimePolicy.PodGroupPolicy == nil || info.RuntimePolicy.PodGroupPolicy.Coscheduling == nil || trainJob == nil {
 		return nil, nil
 	}

--- a/pkg/runtime.v2/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime.v2/framework/plugins/jobset/jobset.go
@@ -133,12 +133,10 @@ func (j *JobSet) TerminalCondition(ctx context.Context, trainJob *kubeflowv2.Tra
 		return nil, err
 	}
 	if completed := meta.FindStatusCondition(jobSet.Status.Conditions, string(jobsetv1alpha2.JobSetCompleted)); completed != nil && completed.Status == metav1.ConditionTrue {
-		completed.Reason = fmt.Sprintf("%sDueTo%s", completed.Type, completed.Reason)
 		completed.Type = kubeflowv2.TrainJobComplete
 		return completed, nil
 	}
 	if failed := meta.FindStatusCondition(jobSet.Status.Conditions, string(jobsetv1alpha2.JobSetFailed)); failed != nil && failed.Status == metav1.ConditionTrue {
-		failed.Reason = fmt.Sprintf("%sDueTo%s", failed.Type, failed.Reason)
 		failed.Type = kubeflowv2.TrainJobFailed
 		return failed, nil
 	}

--- a/pkg/runtime.v2/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime.v2/framework/plugins/jobset/jobset.go
@@ -50,6 +50,7 @@ type JobSet struct {
 
 var _ framework.WatchExtensionPlugin = (*JobSet)(nil)
 var _ framework.ComponentBuilderPlugin = (*JobSet)(nil)
+var _ framework.TerminalConditionPlugin = (*JobSet)(nil)
 
 const Name = constants.JobSetKind
 
@@ -124,6 +125,24 @@ func needsCreateOrUpdate(old, new *jobsetv1alpha2.JobSet, trainJobIsSuspended bo
 
 func jobSetIsSuspended(jobSet *jobsetv1alpha2.JobSet) bool {
 	return ptr.Deref(jobSet.Spec.Suspend, false)
+}
+
+func (j *JobSet) TerminalCondition(ctx context.Context, trainJob *kubeflowv2.TrainJob) (*metav1.Condition, error) {
+	jobSet := &jobsetv1alpha2.JobSet{}
+	if err := j.client.Get(ctx, client.ObjectKeyFromObject(trainJob), jobSet); err != nil {
+		return nil, err
+	}
+	if completed := meta.FindStatusCondition(jobSet.Status.Conditions, string(jobsetv1alpha2.JobSetCompleted)); completed != nil && completed.Status == metav1.ConditionTrue {
+		completed.Reason = fmt.Sprintf("%sDueTo%s", completed.Type, completed.Reason)
+		completed.Type = kubeflowv2.TrainJobComplete
+		return completed, nil
+	}
+	if failed := meta.FindStatusCondition(jobSet.Status.Conditions, string(jobsetv1alpha2.JobSetFailed)); failed != nil && failed.Status == metav1.ConditionTrue {
+		failed.Reason = fmt.Sprintf("%sDueTo%s", failed.Type, failed.Reason)
+		failed.Type = kubeflowv2.TrainJobFailed
+		return failed, nil
+	}
+	return nil, nil
 }
 
 func (j *JobSet) ReconcilerBuilders() []runtime.ReconcilerBuilder {

--- a/pkg/runtime.v2/interface.go
+++ b/pkg/runtime.v2/interface.go
@@ -19,6 +19,7 @@ package runtimev2
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,6 +32,7 @@ type ReconcilerBuilder func(*builder.Builder, client.Client) *builder.Builder
 
 type Runtime interface {
 	NewObjects(ctx context.Context, trainJob *kubeflowv2.TrainJob) ([]client.Object, error)
+	TerminalCondition(ctx context.Context, trainJob *kubeflowv2.TrainJob) (*metav1.Condition, error)
 	EventHandlerRegistrars() []ReconcilerBuilder
 	ValidateObjects(ctx context.Context, old, new *kubeflowv2.TrainJob) (admission.Warnings, field.ErrorList)
 }

--- a/pkg/util.v2/testing/wrapper.go
+++ b/pkg/util.v2/testing/wrapper.go
@@ -282,6 +282,13 @@ func (j *JobSetWrapper) Annotation(key, value string) *JobSetWrapper {
 	return j
 }
 
+func (j *JobSetWrapper) Conditions(conditions ...metav1.Condition) *JobSetWrapper {
+	if len(conditions) != 0 {
+		j.Status.Conditions = append(j.Status.Conditions, conditions...)
+	}
+	return j
+}
+
 func (j *JobSetWrapper) Obj() *jobsetv1alpha2.JobSet {
 	return &j.JobSet
 }

--- a/test/integration/controller.v2/trainjob_controller_test.go
+++ b/test/integration/controller.v2/trainjob_controller_test.go
@@ -355,13 +355,13 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 						Type:    kubeflowv2.TrainJobSuspended,
 						Status:  metav1.ConditionTrue,
 						Reason:  kubeflowv2.TrainJobSuspendedReason,
-						Message: "TrainJob is suspended",
+						Message: constants.TrainJobSuspendedMessage,
 					},
 					{
 						Type:    kubeflowv2.TrainJobCreated,
 						Status:  metav1.ConditionTrue,
 						Reason:  kubeflowv2.TrainJobJobsCreationSucceededReason,
-						Message: "Succeeded to create Jobs",
+						Message: constants.TrainJobJobsCreationSucceededMessage,
 					},
 				}, util.IgnoreConditions))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -378,13 +378,13 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 						Type:    kubeflowv2.TrainJobSuspended,
 						Status:  metav1.ConditionFalse,
 						Reason:  kubeflowv2.TrainJobResumedReason,
-						Message: "TrainJob is resumed",
+						Message: constants.TrainJobResumedMessage,
 					},
 					{
 						Type:    kubeflowv2.TrainJobCreated,
 						Status:  metav1.ConditionTrue,
 						Reason:  kubeflowv2.TrainJobJobsCreationSucceededReason,
-						Message: "Succeeded to create Jobs",
+						Message: constants.TrainJobJobsCreationSucceededMessage,
 					},
 				}, util.IgnoreConditions))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -411,13 +411,13 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 						Type:    kubeflowv2.TrainJobSuspended,
 						Status:  metav1.ConditionFalse,
 						Reason:  kubeflowv2.TrainJobResumedReason,
-						Message: "TrainJob is resumed",
+						Message: constants.TrainJobResumedMessage,
 					},
 					{
 						Type:    kubeflowv2.TrainJobCreated,
 						Status:  metav1.ConditionTrue,
 						Reason:  kubeflowv2.TrainJobJobsCreationSucceededReason,
-						Message: "Succeeded to create Jobs",
+						Message: constants.TrainJobJobsCreationSucceededMessage,
 					},
 					{
 						Type:    kubeflowv2.TrainJobComplete,
@@ -470,13 +470,13 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 						Type:    kubeflowv2.TrainJobSuspended,
 						Status:  metav1.ConditionFalse,
 						Reason:  kubeflowv2.TrainJobResumedReason,
-						Message: "TrainJob is resumed",
+						Message: constants.TrainJobResumedMessage,
 					},
 					{
 						Type:    kubeflowv2.TrainJobCreated,
 						Status:  metav1.ConditionTrue,
 						Reason:  kubeflowv2.TrainJobJobsCreationSucceededReason,
-						Message: "Succeeded to create Jobs",
+						Message: constants.TrainJobJobsCreationSucceededMessage,
 					},
 					{
 						Type:    kubeflowv2.TrainJobFailed,

--- a/test/integration/controller.v2/trainjob_controller_test.go
+++ b/test/integration/controller.v2/trainjob_controller_test.go
@@ -422,7 +422,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 					{
 						Type:    kubeflowv2.TrainJobComplete,
 						Status:  metav1.ConditionTrue,
-						Reason:  fmt.Sprintf("%sDueTo%s", jobsetv1alpha2.JobSetCompleted, jobsetconsts.AllJobsCompletedReason),
+						Reason:  jobsetconsts.AllJobsCompletedReason,
 						Message: jobsetconsts.AllJobsCompletedMessage,
 					},
 				}, util.IgnoreConditions))
@@ -481,7 +481,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 					{
 						Type:    kubeflowv2.TrainJobFailed,
 						Status:  metav1.ConditionTrue,
-						Reason:  fmt.Sprintf("%sDueTo%s", jobsetv1alpha2.JobSetFailed, jobsetconsts.FailedJobsReason),
+						Reason:  jobsetconsts.FailedJobsReason,
 						Message: jobsetconsts.FailedJobsMessage,
 					},
 				}, util.IgnoreConditions))

--- a/test/integration/controller.v2/trainjob_controller_test.go
+++ b/test/integration/controller.v2/trainjob_controller_test.go
@@ -22,12 +22,14 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	jobsetconsts "sigs.k8s.io/jobset/pkg/constants"
 	schedulerpluginsv1alpha1 "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 
 	kubeflowv2 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v2alpha1"
@@ -330,6 +332,159 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 						Obj(),
 					util.IgnoreObjectMetadata))
 
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("Should succeeded to reconcile TrainJob conditions with Complete condition", func() {
+			ginkgo.By("Creating TrainingRuntime and suspended TrainJob")
+			gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+
+			ginkgo.By("Checking if JobSet and PodGroup are created")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, trainJobKey, &jobsetv1alpha2.JobSet{})).Should(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, trainJobKey, &schedulerpluginsv1alpha1.PodGroup{})).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Checking if TrainJob has Suspended and Created conditions")
+			gomega.Eventually(func(g gomega.Gomega) {
+				gotTrainJob := &kubeflowv2.TrainJob{}
+				g.Expect(k8sClient.Get(ctx, trainJobKey, gotTrainJob)).Should(gomega.Succeed())
+				g.Expect(gotTrainJob.Status.Conditions).Should(gomega.BeComparableTo([]metav1.Condition{
+					{
+						Type:    kubeflowv2.TrainJobSuspended,
+						Status:  metav1.ConditionTrue,
+						Reason:  kubeflowv2.TrainJobSuspendedReason,
+						Message: "TrainJob is suspended",
+					},
+					{
+						Type:    kubeflowv2.TrainJobCreated,
+						Status:  metav1.ConditionTrue,
+						Reason:  kubeflowv2.TrainJobJobsCreationSucceededReason,
+						Message: "Succeeded to create Jobs",
+					},
+				}, util.IgnoreConditions))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Checking if the TrainJob has Resumed and Created conditions after unsuspended")
+			gomega.Eventually(func(g gomega.Gomega) {
+				gotTrainJob := &kubeflowv2.TrainJob{}
+				g.Expect(k8sClient.Get(ctx, trainJobKey, gotTrainJob)).Should(gomega.Succeed())
+				gotTrainJob.Spec.Suspend = ptr.To(false)
+				g.Expect(k8sClient.Update(ctx, gotTrainJob)).Should(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, trainJobKey, gotTrainJob)).Should(gomega.Succeed())
+				g.Expect(gotTrainJob.Status.Conditions).Should(gomega.BeComparableTo([]metav1.Condition{
+					{
+						Type:    kubeflowv2.TrainJobSuspended,
+						Status:  metav1.ConditionFalse,
+						Reason:  kubeflowv2.TrainJobResumedReason,
+						Message: "TrainJob is resumed",
+					},
+					{
+						Type:    kubeflowv2.TrainJobCreated,
+						Status:  metav1.ConditionTrue,
+						Reason:  kubeflowv2.TrainJobJobsCreationSucceededReason,
+						Message: "Succeeded to create Jobs",
+					},
+				}, util.IgnoreConditions))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Updating the JobSet condition with Completed")
+			gomega.Eventually(func(g gomega.Gomega) {
+				jobSet := &jobsetv1alpha2.JobSet{}
+				g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
+				meta.SetStatusCondition(&jobSet.Status.Conditions, metav1.Condition{
+					Type:    string(jobsetv1alpha2.JobSetCompleted),
+					Reason:  jobsetconsts.AllJobsCompletedReason,
+					Message: jobsetconsts.AllJobsCompletedMessage,
+					Status:  metav1.ConditionTrue,
+				})
+				g.Expect(k8sClient.Status().Update(ctx, jobSet)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Checking if the TranJob has Resumed, Created, and Completed conditions")
+			gomega.Eventually(func(g gomega.Gomega) {
+				gotTrainJob := &kubeflowv2.TrainJob{}
+				g.Expect(k8sClient.Get(ctx, trainJobKey, gotTrainJob)).Should(gomega.Succeed())
+				g.Expect(gotTrainJob.Status.Conditions).Should(gomega.BeComparableTo([]metav1.Condition{
+					{
+						Type:    kubeflowv2.TrainJobSuspended,
+						Status:  metav1.ConditionFalse,
+						Reason:  kubeflowv2.TrainJobResumedReason,
+						Message: "TrainJob is resumed",
+					},
+					{
+						Type:    kubeflowv2.TrainJobCreated,
+						Status:  metav1.ConditionTrue,
+						Reason:  kubeflowv2.TrainJobJobsCreationSucceededReason,
+						Message: "Succeeded to create Jobs",
+					},
+					{
+						Type:    kubeflowv2.TrainJobComplete,
+						Status:  metav1.ConditionTrue,
+						Reason:  fmt.Sprintf("%sDueTo%s", jobsetv1alpha2.JobSetCompleted, jobsetconsts.AllJobsCompletedReason),
+						Message: jobsetconsts.AllJobsCompletedMessage,
+					},
+				}, util.IgnoreConditions))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("Should succeeded to reconcile TrainJob conditions with Failed condition", func() {
+			ginkgo.By("Creating TrainingRuntime and suspended TrainJob")
+			gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+
+			ginkgo.By("Checking if JobSet and PodGroup are created")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, trainJobKey, &jobsetv1alpha2.JobSet{})).Should(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, trainJobKey, &schedulerpluginsv1alpha1.PodGroup{})).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Unsuspending the TrainJob")
+			gomega.Eventually(func(g gomega.Gomega) {
+				gotTrainJob := &kubeflowv2.TrainJob{}
+				g.Expect(k8sClient.Get(ctx, trainJobKey, gotTrainJob)).Should(gomega.Succeed())
+				gotTrainJob.Spec.Suspend = ptr.To(false)
+				g.Expect(k8sClient.Update(ctx, gotTrainJob)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Updating the JobSet condition with Failed")
+			gomega.Eventually(func(g gomega.Gomega) {
+				jobSet := &jobsetv1alpha2.JobSet{}
+				g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
+				meta.SetStatusCondition(&jobSet.Status.Conditions, metav1.Condition{
+					Type:    string(jobsetv1alpha2.JobSetFailed),
+					Reason:  jobsetconsts.FailedJobsReason,
+					Message: jobsetconsts.FailedJobsMessage,
+					Status:  metav1.ConditionTrue,
+				})
+				g.Expect(k8sClient.Status().Update(ctx, jobSet)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Checking if the TranJob has Resumed, Created, and Failed conditions")
+			gomega.Eventually(func(g gomega.Gomega) {
+				gotTrainJob := &kubeflowv2.TrainJob{}
+				g.Expect(k8sClient.Get(ctx, trainJobKey, gotTrainJob)).Should(gomega.Succeed())
+				g.Expect(gotTrainJob.Status.Conditions).Should(gomega.BeComparableTo([]metav1.Condition{
+					{
+						Type:    kubeflowv2.TrainJobSuspended,
+						Status:  metav1.ConditionFalse,
+						Reason:  kubeflowv2.TrainJobResumedReason,
+						Message: "TrainJob is resumed",
+					},
+					{
+						Type:    kubeflowv2.TrainJobCreated,
+						Status:  metav1.ConditionTrue,
+						Reason:  kubeflowv2.TrainJobJobsCreationSucceededReason,
+						Message: "Succeeded to create Jobs",
+					},
+					{
+						Type:    kubeflowv2.TrainJobFailed,
+						Status:  metav1.ConditionTrue,
+						Reason:  fmt.Sprintf("%sDueTo%s", jobsetv1alpha2.JobSetFailed, jobsetconsts.FailedJobsReason),
+						Message: jobsetconsts.FailedJobsMessage,
+					},
+				}, util.IgnoreConditions))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -26,12 +26,12 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -51,7 +51,7 @@ type Framework struct {
 }
 
 func (f *Framework) Init() *rest.Config {
-	log.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter), zap.UseDevMode(true)))
+	ctrl.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter), zap.Level(zapcore.Level(-5)), zap.UseDevMode(true)))
 	ginkgo.By("bootstrapping test environment")
 	f.testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -34,4 +34,7 @@ var (
 		cmpopts.IgnoreTypes(metav1.TypeMeta{}),
 		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "UID", "ResourceVersion", "Generation", "CreationTimestamp", "ManagedFields"),
 	}
+	IgnoreConditions = cmp.Options{
+		cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime", "ObservedGeneration"),
+	}
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I implemented the TrainJob condition mechanism based on https://github.com/kubeflow/training-operator/tree/master/docs/proposals/2170-kubeflow-training-v2#state-transition

However, the current implementation depends on the JobSet status.conditions as opposed to the status.terminalState since the terminalState was introduced in JobSet v0.6, then the JobSet depends on the K8s lib. After we upgrade the training-operator dep version to 1.30 in https://github.com/kubeflow/training-operator/pull/2299, we can rely on the termonalState.

So, after we upgrade the K8s libs to 1.30, we can revisit the JobSet status.terminalState.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Part-of: https://github.com/kubeflow/training-operator/issues/2207
Relates to #2170 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
