### PR TITLE
KEP-2170: Add Torch Distributed Runtime

### DIFF
--- a/manifests/v2/base/kustomization.yaml
+++ b/manifests/v2/base/kustomization.yaml
@@ -1,9 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-# We can't set namespace in the overlays since we use remote JobSet manifests in the resources.
-namespace: kubeflow-system
-resources:
-  - ./crds
-  - ./rbac
-  - ./webhook
-  - ./manager

--- a/manifests/v2/base/manager/kustomization.yaml
+++ b/manifests/v2/base/manager/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
   - manager.yaml
+# TODO (andreyvelich): Move it to overlays once we copy the JobSet manifests.
+namespace: kubeflow-system

--- a/manifests/v2/base/rbac/kustomization.yaml
+++ b/manifests/v2/base/rbac/kustomization.yaml
@@ -2,3 +2,5 @@ resources:
   - role.yaml
   - role_binding.yaml
   - service_account.yaml
+# TODO (andreyvelich): Move it to overlays once we copy the JobSet manifests.
+namespace: kubeflow-system

--- a/manifests/v2/base/runtimes/pre-training/kustomization.yaml
+++ b/manifests/v2/base/runtimes/pre-training/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - torch-distributed.yaml

--- a/manifests/v2/base/runtimes/pre-training/torch-distributed.yaml
+++ b/manifests/v2/base/runtimes/pre-training/torch-distributed.yaml
@@ -26,8 +26,8 @@ spec:
                         - |
                           echo "Torch Distributed Runtime"
 
-                          echo "Torch Python Package"
-                          pip show torch
-
+                          echo "--------------------------------------"
                           echo "Torch Default Runtime Env"
                           env | grep PET_
+
+                          pip list

--- a/manifests/v2/base/runtimes/pre-training/torch-distributed.yaml
+++ b/manifests/v2/base/runtimes/pre-training/torch-distributed.yaml
@@ -1,0 +1,33 @@
+apiVersion: kubeflow.org/v2alpha1
+kind: ClusterTrainingRuntime
+metadata:
+  name: torch-distributed
+  labels:
+    training.kubeflow.org/phase: pre-training
+spec:
+  mlPolicy:
+    numNodes: 1
+    torch:
+      numProcPerNode: auto
+  template:
+    spec:
+      replicatedJobs:
+        - name: trainer-node
+          template:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: trainer
+                      image: pytorch/pytorch:2.5.0-cuda12.4-cudnn9-runtime
+                      command:
+                        - /bin/bash
+                        - -c
+                        - |
+                          echo "Torch Distributed Runtime"
+
+                          echo "Torch Python Package"
+                          pip show torch
+
+                          echo "Torch Default Runtime Env"
+                          env | grep PET_

--- a/manifests/v2/base/webhook/kustomization.yaml
+++ b/manifests/v2/base/webhook/kustomization.yaml
@@ -10,3 +10,5 @@ patches:
       kind: ValidatingWebhookConfiguration
 configurations:
   - kustomizeconfig.yaml
+# TODO (andreyvelich): Move it to overlays once we copy the JobSet manifests.
+namespace: kubeflow-system

--- a/manifests/v2/overlays/only-manager/kustomization.yaml
+++ b/manifests/v2/overlays/only-manager/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../base/manager
   - ../../base/rbac
   - ../../base/webhook
-  - ../../base/runtimes/pre-training
   # TODO (andreyvelich): JobSet should support kubeflow-system namespace.
   - https://github.com/kubernetes-sigs/jobset/releases/download/v0.6.0/manifests.yaml
 images:

--- a/manifests/v2/overlays/only-manager/namespace.yaml
+++ b/manifests/v2/overlays/only-manager/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeflow-system

--- a/manifests/v2/overlays/only-runtimes/kustomization.yaml
+++ b/manifests/v2/overlays/only-runtimes/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/runtimes/pre-training


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/training-operator/issues/2211

I added Torch distributed runtime and more overlays (only-runtimes, only-manager) as we discussed with @tenzen-y and @deepanker13 offline.
Since it might be useful for GitOps to install everything, only manager, or only runtimes.

/assign  @kubeflow/wg-training-leads @varshaprasad96 @akshaychitneni @helenxie-bit @Electronic-Waste @saileshd1402 @seanlaii

