### PR TITLE
Pin Gloo repository in JAX Dockerfile to a specific commit

### DIFF
--- a/examples/jax/cpu-demo/Dockerfile
+++ b/examples/jax/cpu-demo/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN git clone https://github.com/facebookincubator/gloo.git \
     && cd gloo \
+    && git checkout 43b7acbf372cdce14075f3526e39153b7e433b53 \
     && mkdir build \
     && cd build \
     && cmake ../ \


### PR DESCRIPTION
Pin the Gloo repository to a specific commit in the JAX Dockerfile to prevent build failures caused by a recent bug introduced in the Gloo codebase. By locking the version of Gloo to a known working commit, we ensure that the JAX build remains stable and functional until the issue is resolved upstream.

The build failure occurs when compiling the `gloo/transport/tcp/buffer.cc` file due to an undefined `__NR_gettid` constant, which was introduced after the pinned commit.

**Related Issue/Context:**
- Gloo GitHub Commit: https://github.com/facebookincubator/gloo/commit/43b7acbf372cdce14075f3526e39153b7e433b53
- JAX Example Image build failure: https://github.com/kubeflow/training-operator/actions/runs/11864108924/job/33066900230?pr=2328


Thanks to @andreyvelich for reporting the issue.
