### PR TITLE
Ignore cache exporting errors in the image building workflows

### DIFF
--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -53,4 +53,4 @@ runs:
         push: ${{ inputs.push }}
         tags: ${{ steps.meta.outputs.tags }}
         cache-from: type=gha
-        cache-to: type=gha
+        cache-to: type=gha,ignore-error=true


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
We often manually restart CI jobs due to cache exporting errors like

```
#14 [7/8] RUN mkdir -p /root/deepspeed_data
#14 DONE 0.1s

#15 exporting to GitHub Actions Cache
#15 preparing build cache for export
#15 preparing build cache for export 607.8s done
#15 ERROR: maximum timeout reached
------
 > exporting to GitHub Actions Cache:
------
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
ERROR: failed to solve: maximum timeout reached
Error: buildx failed with: ERROR: failed to solve: maximum timeout reached
```

https://github.com/kubeflow/training-operator/actions/runs/11731087630/job/32680387684#step:6:1362

So, we ignore the cache exporting errors by https://docs.docker.com/build/cache/backends/gha/#synopsis

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
