### PR TITLE
Ensure code generation dependencies are downloaded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 		output:rbac:artifacts:config=manifests/v2/base/rbac \
 		output:webhook:artifacts:config=manifests/v2/base/webhook
 
-generate: controller-gen manifests ## Generate apidoc, sdk and code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+generate: go-mod-download manifests ## Generate apidoc, sdk and code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate/boilerplate.go.txt" paths="./pkg/apis/..."
 	hack/update-codegen.sh
 	hack/python-sdk/gen-sdk.sh
@@ -123,6 +123,10 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 	$(KUSTOMIZE) build manifests/overlays/standalone | kubectl delete -f -
 
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+
+.PHONY: go-mod-download
+go-mod-download:
+	go mod download
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR runs `go mod download` prior to running code generation to ensure the required dependencies are present.

Before:

```
$ sudo rm -rf `go list -m -mod=readonly -f "{{.Dir}}" k8s.io/code-generator`
$ make generate
GOBIN=/workdir/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5
/workdir/bin/controller-gen "crd:generateEmbeddedObjectMeta=true,maxDescLen=400" rbac:roleName=training-operator webhook paths="./pkg/apis/kubeflow.org/v1/..." \
	output:crd:artifacts:config=manifests/base/crds \
	output:rbac:artifacts:config=manifests/base/rbac \
	output:webhook:artifacts:config=manifests/base/webhook
/workdir/bin/controller-gen "crd:generateEmbeddedObjectMeta=true" rbac:roleName=training-operator-v2 webhook \
	paths="./pkg/apis/kubeflow.org/v2alpha1/...;./pkg/controller.v2/...;./pkg/runtime.v2/...;./pkg/webhook.v2/...;./pkg/cert/..." \
	output:crd:artifacts:config=manifests/v2/base/crds \
	output:rbac:artifacts:config=manifests/v2/base/rbac \
	output:webhook:artifacts:config=manifests/v2/base/webhook
/workdir/bin/controller-gen object:headerFile="hack/boilerplate/boilerplate.go.txt" paths="./pkg/apis/..."
hack/update-codegen.sh
hack/update-codegen.sh: line 19: /kube_codegen.sh: No such file or directory
make: *** [Makefile:52: generate] Error 1
```

After:
```
$ sudo rm -rf `go list -m -mod=readonly -f "{{.Dir}}" k8s.io/code-generator`
$ make generate
# OK
```

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
