### PR TITLE
fix restart policy bug in mpi job UpdateJobConditions

### DIFF
--- a/pkg/controller.v1/mpi/mpijob_controller.go
+++ b/pkg/controller.v1/mpi/mpijob_controller.go
@@ -597,7 +597,7 @@ func (jc *MPIJobReconciler) UpdateJobStatus(job interface{}, replicas map[kubefl
 			}
 		}
 		if failed > 0 {
-			if spec.RestartPolicy == kubeflowv1.RestartPolicyExitCode {
+			if spec.RestartPolicy != kubeflowv1.RestartPolicyNever {
 				msg := fmt.Sprintf("MPIJob %s is restarting because %d %s replica(s) failed.", mpiJob.Name, failed, rtype)
 				jc.Recorder.Event(mpiJob, corev1.EventTypeWarning, commonutil.NewReason(kubeflowv1.MPIJobKind, commonutil.JobRestartingReason), msg)
 				commonutil.UpdateJobConditions(jobStatus, kubeflowv1.JobRestarting, corev1.ConditionTrue, commonutil.NewReason(kubeflowv1.MPIJobKind, commonutil.JobRestartingReason), msg)


### PR DESCRIPTION
What this PR does / why we need it:
This PR fixes an issue in the MPIJob controller logic related to the handling of failed replicas. Specifically, the condition for determining the restart policy was incorrect.

Previously, the code used:
if spec.RestartPolicy **== kubeflowv1.RestartPolicyExitCode**
This condition was problematic because it failed to handle cases where the restart policy should be based on other valid configurations. The incorrect logic could lead to unexpected behavior, such as jobs failing instead of restarting.

The updated code uses:
if spec.RestartPolicy **!= kubeflowv1.RestartPolicyNever**
This ensures that jobs are restarted appropriately unless explicitly configured not to restart, aligning the behavior with the intended design and user expectations.