### PR TITLE
Add required RBAC on TrainJob finalizer sub-resources

### DIFF
--- a/manifests/v2/base/rbac/role.yaml
+++ b/manifests/v2/base/rbac/role.yaml
@@ -55,6 +55,7 @@ rules:
 - apiGroups:
   - kubeflow.org
   resources:
+  - trainjobs/finalizers
   - trainjobs/status
   verbs:
   - get

--- a/pkg/controller.v2/trainjob_controller.go
+++ b/pkg/controller.v2/trainjob_controller.go
@@ -68,6 +68,7 @@ func NewTrainJobReconciler(client client.Client, recorder record.EventRecorder, 
 
 // +kubebuilder:rbac:groups=kubeflow.org,resources=trainjobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kubeflow.org,resources=trainjobs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=kubeflow.org,resources=trainjobs/finalizers,verbs=get;update;patch
 
 func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var trainJob kubeflowv2.TrainJob


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds RBAC on TrainJob finalizer sub-resources, that's required for clusters with https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement.

Fixes #2349

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
