### PR TITLE
Fix TrainJob status comparison and update

### DIFF
--- a/pkg/controller.v2/trainjob_controller.go
+++ b/pkg/controller.v2/trainjob_controller.go
@@ -95,7 +95,7 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if terminalCondErr := setTerminalCondition(ctx, runtime, &trainJob); terminalCondErr != nil {
 		return ctrl.Result{}, errors.Join(err, terminalCondErr)
 	}
-	if !equality.Semantic.DeepEqual(&trainJob, originStatus) {
+	if !equality.Semantic.DeepEqual(&trainJob.Status, originStatus) {
 		return ctrl.Result{}, errors.Join(err, r.client.Status().Update(ctx, &trainJob))
 	}
 	return ctrl.Result{}, err


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

This PR fixes the comparison that compares the TrainJob status state and fixes some flakes in the tests.

Fixes #2354.

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
