### PR TITLE
buildx link was broken

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,7 @@ Kubeflow Training Operator is currently at v1.
 ## Requirements
 
 - [Go](https://golang.org/) (1.23 or later)
-- [Docker](https://docs.docker.com/)
-- [Docker](https://docs.docker.com/) (20.10 or later)
-- [Docker Buildx](https://docs.docker.com/build/buildx/) (0.8.0 or later)
+- [Docker](https://docs.docker.com/) (23 or later)
 - [Python](https://www.python.org/) (3.11 or later)
 - [kustomize](https://kustomize.io/) (4.0.5 or later)
 - [Kind](https://kind.sigs.k8s.io/) (0.22.0 or later)


### PR DESCRIPTION
buildx comes by default with docker v23 and newer

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
BuildKit is the default Docker build engine, so both `docker build` and `docker buildx build` use BuildKit to build images. `docker build` is now an alias for the `docker buildx build` command.
BuildKit is the default builder for users on Docker Desktop and Docker Engine v23.0 and later.
https://docs.docker.com/build/buildkit/

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
