### PR TITLE
Upgrade helm/kind-action to v1.11.0

### DIFF
--- a/.github/workflows/setup-e2e-test/action.yaml
+++ b/.github/workflows/setup-e2e-test/action.yaml
@@ -30,7 +30,7 @@ runs:
         go-version-file: go.mod
 
     - name: Create k8s Kind Cluster
-      uses: helm/kind-action@9fdad0686e6f19fcd572f62516f5e0436f562ee7
+      uses: helm/kind-action@v1.11.0
       with:
         node_image: kindest/node:${{ inputs.kubernetes-version }}
         cluster_name: training-operator-cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

This follows #2332 that required using an unreleased version of helm/kind-action to get #127.

This PR upgrades helm/kind-action to the latest version that has just been released:

https://github.com/helm/kind-action/releases/tag/v1.11.0.

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
