### PR TITLE
Use env variable for the pytorch init-container image in case of usin…

### DIFF
--- a/cmd/training-operator.v1/main.go
+++ b/cmd/training-operator.v1/main.go
@@ -98,7 +98,7 @@ func main() {
 
 	// PyTorch related flags
 	flag.StringVar(&config.Config.PyTorchInitContainerImage, "pytorch-init-container-image",
-		config.PyTorchInitContainerImageDefault, "The image for pytorch init container")
+		config.GetPytorchInitContainerImage(), "The image for pytorch init container")
 	flag.StringVar(&config.Config.PyTorchInitContainerTemplateFile, "pytorch-init-container-template-file",
 		config.PyTorchInitContainerTemplateFileDefault, "The template file for pytorch init container")
 	flag.IntVar(&config.Config.PyTorchInitContainerMaxTries, "pytorch-init-container-max-tries",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,10 @@
 
 package config
 
+import (
+	"os"
+)
+
 // Config is the global configuration for the training operator.
 var Config struct {
 	PyTorchInitContainerTemplateFile string
@@ -26,6 +30,8 @@ const (
 	// PyTorchInitContainerImageDefault is the default image for the pytorch
 	// init container.
 	PyTorchInitContainerImageDefault = "alpine:3.10"
+	// PyTorchInitContainerImageEnvVar is the environment variable to provide init container image explicitly for the pytorch
+	PyTorchInitContainerImageEnvVar = "PYTORCH_INIT_CONTAINER_IMAGE"
 	// PyTorchInitContainerTemplateFileDefault is the default template file for
 	// the pytorch init container.
 	PyTorchInitContainerTemplateFileDefault = "/etc/config/initContainer.yaml"
@@ -34,3 +40,11 @@ const (
 	// MPIKubectlDeliveryImageDefault is the default image for launcher pod in MPIJob init container.
 	MPIKubectlDeliveryImageDefault = "kubeflow/kubectl-delivery:latest"
 )
+
+func GetPytorchInitContainerImage() string {
+	// Use image specified in the PYTORCH_INIT_CONTAINER_IMAGE environment variable if provided, otherwise use default PyTorchInitContainerImageDefault
+	if v, ok := os.LookupEnv(PyTorchInitContainerImageEnvVar); ok {
+		return v
+	}
+	return PyTorchInitContainerImageDefault
+}

--- a/pkg/controller.v1/pytorch/initcontainer_test.go
+++ b/pkg/controller.v1/pytorch/initcontainer_test.go
@@ -31,7 +31,7 @@ func TestInitContainer(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	defer ginkgo.GinkgoRecover()
 
-	config.Config.PyTorchInitContainerImage = config.PyTorchInitContainerImageDefault
+	config.Config.PyTorchInitContainerImage = config.GetPytorchInitContainerImage()
 	config.Config.PyTorchInitContainerTemplateFile = config.PyTorchInitContainerTemplateFileDefault
 	config.Config.PyTorchInitContainerMaxTries = config.PyTorchInitContainerMaxTriesDefault
 

--- a/pkg/controller.v1/pytorch/pytorchjob_controller_suite_test.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller_suite_test.go
@@ -82,7 +82,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Set default config.
-	config.Config.PyTorchInitContainerImage = config.PyTorchInitContainerImageDefault
+	config.Config.PyTorchInitContainerImage = config.GetPytorchInitContainerImage()
 	config.Config.PyTorchInitContainerTemplateFile = config.PyTorchInitContainerTemplateFileDefault
 
 	//+kubebuilder:scaffold:scheme


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

- In Disconnected environment, the images with tags/digests are supported but use of image digest is more preferred because of immutability, consistency and security.
- The update suggested in this PR allows to pass a pytorch init container image using an environment variable which allows to use the image with digest  to be used in case of disconnected environment.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

- Added provision to use environment variable for the pytorch init container image in case of using other image reference or same image with digest in case of disconnected environment.

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
