### PR TITLE
Release Training Operator Image for v1.9.0-rc.0

### DIFF
--- a/manifests/overlays/kubeflow/kustomization.yaml
+++ b/manifests/overlays/kubeflow/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - kubeflow-training-roles.yaml
 images:
   - name: kubeflow/training-operator
-    newTag: "latest"
+    newTag: v1-1155249
 # TODO (tenzen-y): Once we support cert-manager, we need to remove this secret generation.
 # REF: https://github.com/kubeflow/training-operator/issues/2049
 secretGenerator:

--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - namespace.yaml
 images:
   - name: kubeflow/training-operator
-    newTag: "latest"
+    newTag: v1-1155249
 secretGenerator:
   - name: training-operator-webhook-cert
     options:


### PR DESCRIPTION
Part of: https://github.com/kubeflow/training-operator/issues/2169
I updated image tag for `v1.9.0-rc.0` release.

/assign @kubeflow/wg-training-leads 