### PR TITLE
Add release branch to the image push trigger

### DIFF
--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -39,20 +39,20 @@ jobs:
         uses: ./.github/workflows/free-up-disk-space
 
       - name: Docker Login
-        # Trigger workflow only for kubeflow/training-operator repository with specific branch (master, v.*-branch) or tag (v.*).
+        # Trigger workflow only for kubeflow/training-operator repository with specific branch (master, v.*-branch, release-*) or tag (v.*).
         if: >-
           github.repository == 'kubeflow/training-operator' &&
-          (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/v') && endsWith(github.ref, '-branch')) || startsWith(github.ref, 'refs/tags/v'))
+          (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/v') && endsWith(github.ref, '-branch')) || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/tags/v'))
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Publish Component ${{ inputs.component-name }}
-        # Trigger workflow only for kubeflow/training-operator repository with specific branch (master, v.*-branch) or tag (v.*).
+        # Trigger workflow only for kubeflow/training-operator repository with specific branch (master, v.*-branch, release-*) or tag (v.*).
         if: >-
           github.repository == 'kubeflow/training-operator' &&
-          (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/v') && endsWith(github.ref, '-branch')) || startsWith(github.ref, 'refs/tags/v'))
+          (github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/v') && endsWith(github.ref, '-branch')) || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/tags/v'))
         id: publish
         uses: ./.github/workflows/template-publish-image
         with:


### PR DESCRIPTION
Since we decided to use `release-` branch, we need to update the image push trigger in our CI.

/assign @kubeflow/wg-training-leads 