### PR TITLE
Fix Kustomize patchesStrategicMerge deprecation warning

### DIFF
--- a/manifests/v2/third-party/jobset/kustomization.yaml
+++ b/manifests/v2/third-party/jobset/kustomization.yaml
@@ -13,6 +13,16 @@ configMapGenerator:
       disableNameSuffixHash: true
 
 # Add required patches.
-patchesStrategicMerge:
-  - patches/jobset_remove_namespace.yaml # Remove namespace from the JobSet release manifests.
-  - patches/jobset_config_patch.yaml # Add custom manager config to the JobSet.
+patches:
+  # Remove namespace from the JobSet release manifests.
+  - path: patches/jobset_remove_namespace.yaml
+    target:
+      group: ""
+      version: v1
+      kind: Namespace
+  # Add custom manager config to the JobSet.
+  - path: patches/jobset_config_patch.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

A follow up of #2388 to fix the following warning when installing the v2 operator:

```
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.

Fixed fields:
  patchesJson6902 -> patches
  patchesStrategicMerge -> patches
  commonLabels -> labels
```

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
