### PR TITLE
Fix the group name, keep it consistent with the CRD definition

### DIFF
--- a/sdk_v2/kubeflow/training/constants/constants.py
+++ b/sdk_v2/kubeflow/training/constants/constants.py
@@ -18,7 +18,7 @@ import os
 DEFAULT_TIMEOUT = 120
 
 # Common constants.
-GROUP = "kubeflow.org"
+GROUP = "trainer.kubeflow.org"
 VERSION = "v2alpha1"
 API_VERSION = f"{GROUP}/{VERSION}"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

The CRD defines the GROUP name is "trainer.kubeflow.org",  but in constants.py,  GROUP is still "kubeflow.org".
It will cause an error when using the training client. 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
