### PR TITLE
Fix API Group for Torch Runtime

### DIFF
--- a/manifests/base/runtimes/pretraining/torch_distributed.yaml
+++ b/manifests/base/runtimes/pretraining/torch_distributed.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubeflow.org/v1alpha1
+apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:
   name: torch-distributed


### PR DESCRIPTION
We should use `trainer.kubeflow.org/v1alpha1` as API Group for Torch Distributed Runtime.

/assign @kubeflow/wg-training-leads @astefanutti @Electronic-Waste 