### PR TITLE
Nominate @Electronic-Waste as a reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,7 @@ approvers:
   - tenzen-y
   - terrytangyuan
 reviewers:
+  - Electronic-Waste
   - jinchihe
   - kuizhiqing
 emeritus_approvers:


### PR DESCRIPTION
I would like to nominate @Electronic-Waste as a reviewer for Kubeflow Trainer project.

Shao, has done a lot of great contributions to the Kubeflow Trainer V2 project including:
- 163 contributions [in the last year.](https://kubeflow.devstats.cncf.io/d/66/developer-activity-counts-by-companies?orgId=1&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=kubeflow%2Ftraining-operator&var-country_name=All&var-companies=All)
- Helping us with Kubeflow Trainer implementation: https://github.com/kubeflow/training-operator/issues/2170
- Driving the LLM Trainer work: https://github.com/kubeflow/training-operator/pull/2410

Thanks again for all of you great contributions, Shao, and I am looking forward to continue working with you 🎉 

/hold for WG leads review
/assign @kubeflow/wg-training-leads 