### PR TITLE
Upgrade jobset SDK version to v0.7.3

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dependencies = [
     "kubernetes>=27.2.0",
-    "jobset @ git+https://github.com/kubernetes-sigs/jobset.git@v0.6.0#subdirectory=sdk/python",
+    "jobset @ git+https://github.com/kubernetes-sigs/jobset.git@v0.7.3#subdirectory=sdk/python",
 ]
 
 [project.urls]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Since we use jobset v0.7.3 in the manifest:

https://github.com/kubeflow/trainer/blob/0b765d6e0d44fe12aa8e740c2dbfe2ecd04a6d10/manifests/third-party/jobset/kustomization.yaml#L1-L6

We'd better upgrade the jobset SDK version to v0.7.3 as well.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
