### PR TITLE
fix(sdk): resolve errors in deserialization

### DIFF
--- a/hack/python-sdk/gen-sdk.sh
+++ b/hack/python-sdk/gen-sdk.sh
@@ -66,5 +66,6 @@ else
 fi
 
 # Kubeflow models must have Kubernetes models to perform serialization.
-printf "\n# Import JobSet models for the serialization. It imports the Kubernetes models.\n" >>${SDK_OUTPUT_PATH}/kubeflow/trainer/models/__init__.py
+printf "\n# Import Kubernetes and JobSet models for the serialization. \n" >>${SDK_OUTPUT_PATH}/kubeflow/trainer/models/__init__.py
+printf "from kubernetes.client import *\n" >>${SDK_OUTPUT_PATH}/kubeflow/trainer/models/__init__.py
 printf "from jobset.models import *\n" >>${SDK_OUTPUT_PATH}/kubeflow/trainer/models/__init__.py

--- a/hack/python-sdk/swagger_config.json
+++ b/hack/python-sdk/swagger_config.json
@@ -2,7 +2,7 @@
   "packageName": "kubeflow.trainer",
   "typeMappings": {
     "K8sIoApiAutoscalingV2MetricSpec": "V2MetricSpec",
-    "K8sIoApimachineryPkgUtilIntstrIntOrString": "Union[int, str]",
+    "K8sIoApimachineryPkgUtilIntstrIntOrString": "object",
     "V1Time": "datetime"
   }
 }

--- a/hack/python-sdk/swagger_config.json
+++ b/hack/python-sdk/swagger_config.json
@@ -1,6 +1,8 @@
 {
   "packageName": "kubeflow.trainer",
   "typeMappings": {
+    "K8sIoApiAutoscalingV2MetricSpec": "V2MetricSpec",
+    "K8sIoApimachineryPkgUtilIntstrIntOrString": "Union[int, str]",
     "V1Time": "datetime"
   }
 }

--- a/sdk/docs/TrainerV1alpha1TorchElasticPolicy.md
+++ b/sdk/docs/TrainerV1alpha1TorchElasticPolicy.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **max_nodes** | **int** | Upper limit for the number of nodes to which training job can scale up. | [optional] 
 **max_restarts** | **int** | How many times the training job can be restarted. This value is inserted into the &#x60;--max-restarts&#x60; argument of the &#x60;torchrun&#x60; CLI and the &#x60;.spec.failurePolicy.maxRestarts&#x60; parameter of the training Job. | [optional] 
-**metrics** | [**list[K8sIoApiAutoscalingV2MetricSpec]**](K8sIoApiAutoscalingV2MetricSpec.md) | Specification which are used to calculate the desired number of nodes. See the individual metric source types for more information about how each type of metric must respond. The HPA will be created to perform auto-scaling. | [optional] 
+**metrics** | [**list[V2MetricSpec]**](K8sIoApiAutoscalingV2MetricSpec.md) | Specification which are used to calculate the desired number of nodes. See the individual metric source types for more information about how each type of metric must respond. The HPA will be created to perform auto-scaling. | [optional] 
 **min_nodes** | **int** | Lower limit for the number of nodes to which training job can scale down. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/sdk/docs/TrainerV1alpha1TorchMLPolicySource.md
+++ b/sdk/docs/TrainerV1alpha1TorchMLPolicySource.md
@@ -5,7 +5,7 @@ TorchMLPolicySource represents a PyTorch runtime configuration.
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **elastic_policy** | [**TrainerV1alpha1TorchElasticPolicy**](TrainerV1alpha1TorchElasticPolicy.md) |  | [optional] 
-**num_proc_per_node** | [**K8sIoApimachineryPkgUtilIntstrIntOrString**](K8sIoApimachineryPkgUtilIntstrIntOrString.md) |  | [optional] 
+**num_proc_per_node** | [**Union[int, str]**](K8sIoApimachineryPkgUtilIntstrIntOrString.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/sdk/docs/TrainerV1alpha1TorchMLPolicySource.md
+++ b/sdk/docs/TrainerV1alpha1TorchMLPolicySource.md
@@ -5,7 +5,7 @@ TorchMLPolicySource represents a PyTorch runtime configuration.
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **elastic_policy** | [**TrainerV1alpha1TorchElasticPolicy**](TrainerV1alpha1TorchElasticPolicy.md) |  | [optional] 
-**num_proc_per_node** | [**Union[int, str]**](K8sIoApimachineryPkgUtilIntstrIntOrString.md) |  | [optional] 
+**num_proc_per_node** | [**object**](K8sIoApimachineryPkgUtilIntstrIntOrString.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/sdk/docs/TrainerV1alpha1Trainer.md
+++ b/sdk/docs/TrainerV1alpha1Trainer.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **env** | [**list[V1EnvVar]**](V1EnvVar.md) | List of environment variables to set in the training container. These values will be merged with the TrainingRuntime&#39;s trainer environments. | [optional] 
 **image** | **str** | Docker image for the training container. | [optional] 
 **num_nodes** | **int** | Number of training nodes. | [optional] 
-**num_proc_per_node** | [**Union[int, str]**](K8sIoApimachineryPkgUtilIntstrIntOrString.md) |  | [optional] 
+**num_proc_per_node** | [**object**](K8sIoApimachineryPkgUtilIntstrIntOrString.md) |  | [optional] 
 **resources_per_node** | [**V1ResourceRequirements**](V1ResourceRequirements.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/sdk/docs/TrainerV1alpha1Trainer.md
+++ b/sdk/docs/TrainerV1alpha1Trainer.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **env** | [**list[V1EnvVar]**](V1EnvVar.md) | List of environment variables to set in the training container. These values will be merged with the TrainingRuntime&#39;s trainer environments. | [optional] 
 **image** | **str** | Docker image for the training container. | [optional] 
 **num_nodes** | **int** | Number of training nodes. | [optional] 
-**num_proc_per_node** | [**K8sIoApimachineryPkgUtilIntstrIntOrString**](K8sIoApimachineryPkgUtilIntstrIntOrString.md) |  | [optional] 
+**num_proc_per_node** | [**Union[int, str]**](K8sIoApimachineryPkgUtilIntstrIntOrString.md) |  | [optional] 
 **resources_per_node** | [**V1ResourceRequirements**](V1ResourceRequirements.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/sdk/kubeflow/trainer/models/__init__.py
+++ b/sdk/kubeflow/trainer/models/__init__.py
@@ -43,5 +43,6 @@ from kubeflow.trainer.models.trainer_v1alpha1_training_runtime import TrainerV1a
 from kubeflow.trainer.models.trainer_v1alpha1_training_runtime_list import TrainerV1alpha1TrainingRuntimeList
 from kubeflow.trainer.models.trainer_v1alpha1_training_runtime_spec import TrainerV1alpha1TrainingRuntimeSpec
 
-# Import JobSet models for the serialization. It imports the Kubernetes models.
+# Import Kubernetes and JobSet models for the serialization. 
+from kubernetes.client import *
 from jobset.models import *

--- a/sdk/kubeflow/trainer/models/trainer_v1alpha1_torch_elastic_policy.py
+++ b/sdk/kubeflow/trainer/models/trainer_v1alpha1_torch_elastic_policy.py
@@ -35,7 +35,7 @@ class TrainerV1alpha1TorchElasticPolicy(object):
     openapi_types = {
         'max_nodes': 'int',
         'max_restarts': 'int',
-        'metrics': 'list[K8sIoApiAutoscalingV2MetricSpec]',
+        'metrics': 'list[V2MetricSpec]',
         'min_nodes': 'int'
     }
 
@@ -120,7 +120,7 @@ class TrainerV1alpha1TorchElasticPolicy(object):
         Specification which are used to calculate the desired number of nodes. See the individual metric source types for more information about how each type of metric must respond. The HPA will be created to perform auto-scaling.  # noqa: E501
 
         :return: The metrics of this TrainerV1alpha1TorchElasticPolicy.  # noqa: E501
-        :rtype: list[K8sIoApiAutoscalingV2MetricSpec]
+        :rtype: list[V2MetricSpec]
         """
         return self._metrics
 
@@ -131,7 +131,7 @@ class TrainerV1alpha1TorchElasticPolicy(object):
         Specification which are used to calculate the desired number of nodes. See the individual metric source types for more information about how each type of metric must respond. The HPA will be created to perform auto-scaling.  # noqa: E501
 
         :param metrics: The metrics of this TrainerV1alpha1TorchElasticPolicy.  # noqa: E501
-        :type: list[K8sIoApiAutoscalingV2MetricSpec]
+        :type: list[V2MetricSpec]
         """
 
         self._metrics = metrics

--- a/sdk/kubeflow/trainer/models/trainer_v1alpha1_torch_ml_policy_source.py
+++ b/sdk/kubeflow/trainer/models/trainer_v1alpha1_torch_ml_policy_source.py
@@ -34,7 +34,7 @@ class TrainerV1alpha1TorchMLPolicySource(object):
     """
     openapi_types = {
         'elastic_policy': 'TrainerV1alpha1TorchElasticPolicy',
-        'num_proc_per_node': 'K8sIoApimachineryPkgUtilIntstrIntOrString'
+        'num_proc_per_node': 'Union[int, str]'
     }
 
     attribute_map = {
@@ -84,7 +84,7 @@ class TrainerV1alpha1TorchMLPolicySource(object):
 
 
         :return: The num_proc_per_node of this TrainerV1alpha1TorchMLPolicySource.  # noqa: E501
-        :rtype: K8sIoApimachineryPkgUtilIntstrIntOrString
+        :rtype: Union[int, str]
         """
         return self._num_proc_per_node
 
@@ -94,7 +94,7 @@ class TrainerV1alpha1TorchMLPolicySource(object):
 
 
         :param num_proc_per_node: The num_proc_per_node of this TrainerV1alpha1TorchMLPolicySource.  # noqa: E501
-        :type: K8sIoApimachineryPkgUtilIntstrIntOrString
+        :type: Union[int, str]
         """
 
         self._num_proc_per_node = num_proc_per_node

--- a/sdk/kubeflow/trainer/models/trainer_v1alpha1_torch_ml_policy_source.py
+++ b/sdk/kubeflow/trainer/models/trainer_v1alpha1_torch_ml_policy_source.py
@@ -34,7 +34,7 @@ class TrainerV1alpha1TorchMLPolicySource(object):
     """
     openapi_types = {
         'elastic_policy': 'TrainerV1alpha1TorchElasticPolicy',
-        'num_proc_per_node': 'Union[int, str]'
+        'num_proc_per_node': 'object'
     }
 
     attribute_map = {
@@ -84,7 +84,7 @@ class TrainerV1alpha1TorchMLPolicySource(object):
 
 
         :return: The num_proc_per_node of this TrainerV1alpha1TorchMLPolicySource.  # noqa: E501
-        :rtype: Union[int, str]
+        :rtype: object
         """
         return self._num_proc_per_node
 
@@ -94,7 +94,7 @@ class TrainerV1alpha1TorchMLPolicySource(object):
 
 
         :param num_proc_per_node: The num_proc_per_node of this TrainerV1alpha1TorchMLPolicySource.  # noqa: E501
-        :type: Union[int, str]
+        :type: object
         """
 
         self._num_proc_per_node = num_proc_per_node

--- a/sdk/kubeflow/trainer/models/trainer_v1alpha1_trainer.py
+++ b/sdk/kubeflow/trainer/models/trainer_v1alpha1_trainer.py
@@ -38,7 +38,7 @@ class TrainerV1alpha1Trainer(object):
         'env': 'list[V1EnvVar]',
         'image': 'str',
         'num_nodes': 'int',
-        'num_proc_per_node': 'Union[int, str]',
+        'num_proc_per_node': 'object',
         'resources_per_node': 'V1ResourceRequirements'
     }
 
@@ -203,7 +203,7 @@ class TrainerV1alpha1Trainer(object):
 
 
         :return: The num_proc_per_node of this TrainerV1alpha1Trainer.  # noqa: E501
-        :rtype: Union[int, str]
+        :rtype: object
         """
         return self._num_proc_per_node
 
@@ -213,7 +213,7 @@ class TrainerV1alpha1Trainer(object):
 
 
         :param num_proc_per_node: The num_proc_per_node of this TrainerV1alpha1Trainer.  # noqa: E501
-        :type: Union[int, str]
+        :type: object
         """
 
         self._num_proc_per_node = num_proc_per_node

--- a/sdk/kubeflow/trainer/models/trainer_v1alpha1_trainer.py
+++ b/sdk/kubeflow/trainer/models/trainer_v1alpha1_trainer.py
@@ -38,7 +38,7 @@ class TrainerV1alpha1Trainer(object):
         'env': 'list[V1EnvVar]',
         'image': 'str',
         'num_nodes': 'int',
-        'num_proc_per_node': 'K8sIoApimachineryPkgUtilIntstrIntOrString',
+        'num_proc_per_node': 'Union[int, str]',
         'resources_per_node': 'V1ResourceRequirements'
     }
 
@@ -203,7 +203,7 @@ class TrainerV1alpha1Trainer(object):
 
 
         :return: The num_proc_per_node of this TrainerV1alpha1Trainer.  # noqa: E501
-        :rtype: K8sIoApimachineryPkgUtilIntstrIntOrString
+        :rtype: Union[int, str]
         """
         return self._num_proc_per_node
 
@@ -213,7 +213,7 @@ class TrainerV1alpha1Trainer(object):
 
 
         :param num_proc_per_node: The num_proc_per_node of this TrainerV1alpha1Trainer.  # noqa: E501
-        :type: K8sIoApimachineryPkgUtilIntstrIntOrString
+        :type: Union[int, str]
         """
 
         self._num_proc_per_node = num_proc_per_node


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR fixes the error that occurred in deserialization (`sdk/kubeflow/trainer/api_client.py`)

```
│ Traceback (most recent call last):                                                                                                                                                                       │   File "/usr/local/lib/python3.11/site-packages/kubeflow/trainer/api/trainer_client.py", line 103, in list_runtimes
│     runtime = self.api_client.deserialize(                                                                                                                                                               │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                               │   File "/usr/local/lib/python3.11/site-packages/kubeflow/trainer/api_client.py", line 280, in deserialize                                                                                                │     return self.__deserialize(data, response_type)
│            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                       │   File "/usr/local/lib/python3.11/site-packages/kubeflow/trainer/api_client.py", line 319, in __deserialize                                                                                              │     return self.__deserialize_model(data, klass)                                                                                                                                                         │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│   File "/usr/local/lib/python3.11/site-packages/kubeflow/trainer/api_client.py", line 658, in __deserialize_model                                                                                        │     kwargs[attr] = self.__deserialize(value, attr_type)                                                                                                                                                  │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                  │   File "/usr/local/lib/python3.11/site-packages/kubeflow/trainer/api_client.py", line 319, in __deserialize
│     return self.__deserialize_model(data, klass)                                                                                                                                                         │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                         │   File "/usr/local/lib/python3.11/site-packages/kubeflow/trainer/api_client.py", line 658, in __deserialize_model                                                                                        │r    kwargs[attr] = self.__deserialize(value, attr_type)
│                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                  │   File "/usr/local/lib/python3.11/site-packages/kubeflow/trainer/api_client.py", line 319, in __deserialize                                                                                              │     return self.__deserialize_model(data, klass)                                                                                                                                                         │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│   File "/usr/local/lib/python3.11/site-packages/kubeflow/trainer/api_client.py", line 658, in __deserialize_model                                                                                        │     kwargs[attr] = self.__deserialize(value, attr_type)                                                                                                                                                  │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                  │   File "/usr/local/lib/python3.11/site-packages/kubeflow/trainer/api_client.py", line 319, in __deserialize
│     return self.__deserialize_model(data, klass)
│            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│   File "/usr/local/lib/python3.11/site-packages/kubeflow/trainer/api_client.py", line 658, in __deserialize_model
│     kwargs[attr] = self.__deserialize(value, attr_type)
│                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│   File "/usr/local/lib/python3.11/site-packages/kubeflow/trainer/api_client.py", line 308, in __deserialize
│     klass = getattr(kubeflow.trainer.models, klass)
│             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│ AttributeError: module 'kubeflow.trainer.models' has no attribute 'K8sIoApimachineryPkgUtilIntstrIntOrString'
│
│ During handling of the above exception, another exception occurred:
│
│ Traceback (most recent call last):
│   File "/kubeflow-trainer/torch.py", line 3, in <module>
│     for r in TrainerClient().list_runtimes():
│              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│   File "/usr/local/lib/python3.11/site-packages/kubeflow/trainer/api/trainer_client.py", line 160, in list_runtimes
│     raise RuntimeError(
│ RuntimeError: Failed to list ClusterTrainingRuntimes in namespace: kubeflow-system
│ Stream closed EOF for kubeflow-system/zedd-trainer-pod (trainer-container)
```

I make these changes:

1. Add `kubernetes.client` import in `hack/python-sdk/gen-sdk.sh`
2. Make type conversion in swagger.json

/cc @kubeflow/wg-training-leads @astefanutti 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
