### PR TITLE
Make MPIMLPolicySource optional fields as a pointer

### DIFF
--- a/pkg/apis/trainer/v1alpha1/trainingruntime_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainingruntime_types.go
@@ -216,11 +216,11 @@ type MPIMLPolicySource struct {
 	// Implementation name for the MPI to create the appropriate hostfile.
 	// Defaults to OpenMPI.
 	// +kubebuilder:default=OpenMPI
-	MPIImplementation MPIImplementation `json:"mpiImplementation,omitempty"`
+	MPIImplementation *MPIImplementation `json:"mpiImplementation,omitempty"`
 
 	// Directory where SSH keys are mounted.
 	// Defaults to /root/.ssh.
-	SSHAuthMountPath string `json:"sshAuthMountPath,omitempty"`
+	SSHAuthMountPath *string `json:"sshAuthMountPath,omitempty"`
 
 	// Whether to run training process on the launcher Job.
 	// Defaults to false.

--- a/pkg/apis/trainer/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/trainer/v1alpha1/zz_generated.deepcopy.go
@@ -311,6 +311,16 @@ func (in *MPIMLPolicySource) DeepCopyInto(out *MPIMLPolicySource) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MPIImplementation != nil {
+		in, out := &in.MPIImplementation, &out.MPIImplementation
+		*out = new(MPIImplementation)
+		**out = **in
+	}
+	if in.SSHAuthMountPath != nil {
+		in, out := &in.SSHAuthMountPath, &out.SSHAuthMountPath
+		*out = new(string)
+		**out = **in
+	}
 	if in.RunLauncherAsNode != nil {
 		in, out := &in.RunLauncherAsNode, &out.RunLauncherAsNode
 		*out = new(bool)

--- a/pkg/runtime/framework/plugins/plainml/plainml_test.go
+++ b/pkg/runtime/framework/plugins/plainml/plainml_test.go
@@ -78,7 +78,7 @@ func TestPlainML(t *testing.T) {
 				runtime.WithMLPolicy(
 					utiltesting.MakeMLPolicyWrapper().
 						WithNumNodes(100).
-						MPIPolicy(ptr.To[int32](1), trainer.MPIImplementationOpenMPI, "", false).
+						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), nil, false).
 						Obj(),
 				),
 			),
@@ -87,7 +87,7 @@ func TestPlainML(t *testing.T) {
 				runtime.WithMLPolicy(
 					utiltesting.MakeMLPolicyWrapper().
 						WithNumNodes(100).
-						MPIPolicy(ptr.To[int32](1), trainer.MPIImplementationOpenMPI, "", false).
+						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), nil, false).
 						Obj(),
 				),
 			),

--- a/pkg/util/testing/wrapper.go
+++ b/pkg/util/testing/wrapper.go
@@ -779,7 +779,7 @@ func (m *MLPolicyWrapper) TorchPolicy(numProcPerNode string, elasticPolicy *trai
 	return m
 }
 
-func (m *MLPolicyWrapper) MPIPolicy(numProcPerNode *int32, MPImplementation trainer.MPIImplementation, sshAuthMountPath string, runLauncherAsWorker bool) *MLPolicyWrapper {
+func (m *MLPolicyWrapper) MPIPolicy(numProcPerNode *int32, MPImplementation *trainer.MPIImplementation, sshAuthMountPath *string, runLauncherAsWorker bool) *MLPolicyWrapper {
 	if m.MLPolicySource.MPI == nil {
 		m.MLPolicySource.MPI = &trainer.MPIMLPolicySource{}
 	}

--- a/test/integration/webhooks/trainingruntime_webhook_test.go
+++ b/test/integration/webhooks/trainingruntime_webhook_test.go
@@ -189,7 +189,7 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 					runtime.Spec.MLPolicy = &trainer.MLPolicy{
 						MLPolicySource: trainer.MLPolicySource{
 							MPI: &trainer.MPIMLPolicySource{
-								MPIImplementation: trainer.MPIImplementationOpenMPI,
+								MPIImplementation: ptr.To(trainer.MPIImplementationOpenMPI),
 								RunLauncherAsNode: ptr.To(false),
 							},
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
The optional fields should be pointer fields as the Kubernetes API principle.

As I synced with @andreyvelich offline, he changed this typed in the MPI impl PR since swagger does not support pointers.
This means Python SDK can not handle the differences between None and empty.

After I told this principle, we reached an agreement for making optional fields as pointer.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
