### PR TITLE
feat(doc): add Runtime API design in KEP-2401.

### DIFF
--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -292,7 +292,7 @@ In that case, we plan to design `Runtime` dataclass as the following:
 ```python
 # Runtime DataClass
 @dataclass
-class Runtimne:
+class Runtime:
     name: str
     method: str
     framework: str

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -283,21 +283,49 @@ In that case, we plan to design `Runtime` dataclass as the following:
 | - | - | - |
 | name | str | The name of TrainingRuntime/ClusterTrainingRuntime. |
 | trainer_type | str | The training method of this runtime, chosen from `custom-trainer`, `builtin-trainer`. |
-| framework | str | The ML framework used for training, e.g. `pytorch`, `torchtune`. |
 | pretrained_model | Optional[str] | The pretrained model specified for this runtime, e.g. `llama3.1-8B`. |
-| accelerator | str | The type of devices, e.g. `nvidia.com/gpu`. |
-| accelerator_count | str | The number of devices. |
+
 
 ```python
 # Runtime DataClass
 @dataclass
 class Runtime:
     name: str
-    trainer_type: str
-    framework: str
+    trainer: Trainer
     pretrained_model: Optional[str] = None
-    accelerator: str
-    accelerator_count: str,
+
+```
+
+`Trainer` dataclass:
+
+| Fields | Type | What is it? |
+| trainer_type | TrainerType | Selected from CustomTrainer and BuiltinTrainer. |
+| framework | Framework | The ML framework used for training, e.g. `torch`, `torchtune`. |
+| entrypoint | Optional[List[str]] | Entrypoint for the trainer node. |
+| accelerator | str | The type of devices, e.g. `nvidia.com/gpu`. |
+| accelerator_count | Union[str, float, int] | The number of devices. |
+
+```python
+class TrainerType(Enum):
+    CUSTOM_TRAINER = CustomTrainer.__name__
+    BUILTIN_TRAINER = BuiltinTrainer.__name__
+
+
+class Framework(Enum):
+    TORCH = "torch"
+    DEEPSPEED = "deepspeed"
+    MLX = "mlx"
+    TORCHTUNE = "torchtune"
+
+
+# Representation for the Trainer of the runtime.
+@dataclass
+class Trainer:
+    trainer_type: TrainerType
+    framework: Framework
+    entrypoint: Optional[List[str]] = None
+    accelerator: str = constants.UNKNOWN
+    accelerator_count: Union[str, float, int] = constants.UNKNOWN
 
 ```
 
@@ -534,7 +562,7 @@ We will use [papermill](https://github.com/nteract/papermill) to execute these n
 
 - 2025-01-31: Create KEP-2401 doc
 - 2025-03-11: KEP-2401 1st version & Start implementation
-- 2025-03-12: Add new `Runtime` dataclass design
+- 2025-03-24: Add new `Runtime` dataclass design
 
 ## Alternatives
 

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -262,7 +262,7 @@ class TorchTuneConfig:
 
 #### `list_runtimes()` API
 
-We should allow users to easily get the available TrainingRuntimes/ClusterTrainingRuntimes with the SDK, followed with information related to the training method, framework, model, phase and device. When users execute:
+We should allow users to easily get the available TrainingRuntimes/ClusterTrainingRuntimes with the SDK, followed with information related to the trainer type, framework, model, and device. When users execute:
 
 ```python
 TrainingClient().list_runtimes()
@@ -271,10 +271,10 @@ TrainingClient().list_runtimes()
 They are expected to get:
 
 ```
-Runtime                             Method                Framework   Pretrained Model    Phase           Accelerator       Count
+Runtime                             Trainer Type          Framework   Pretrained Model    Accelerator       Count
 
-pytorch-distributed                 custom-trainer        pytorch     <undefined>         any             nvidia.com/GPU    2
-torchtune-llama3.1-8B-finetuning    predefined-trainer    torchtune   Llama3.1-8B         post-training   nvidia.com/GPU    4
+pytorch-distributed                 custom-trainer        pytorch     <undefined>         nvidia.com/GPU    2
+torchtune-llama3.1-8B-finetuning    builtin-trainer       torchtune   Llama3.1-8B         nvidia.com/GPU    4
 ```
 
 In that case, we plan to design `Runtime` dataclass as the following:
@@ -282,10 +282,9 @@ In that case, we plan to design `Runtime` dataclass as the following:
 | Fields | Type | What is it? |
 | - | - | - |
 | name | str | The name of TrainingRuntime/ClusterTrainingRuntime. |
-| method | str | The training method of this runtime, chosen from `custom-trainer`, `predefined-trainer`. |
+| trainer_type | str | The training method of this runtime, chosen from `custom-trainer`, `builtin-trainer`. |
 | framework | str | The ML framework used for training, e.g. `pytorch`, `torchtune`. |
 | pretrained_model | Optional[str] | The pretrained model specified for this runtime, e.g. `llama3.1-8B`. |
-| phase | str | The training phase of this runtime, chosen from `any`, `post-training`. |
 | accelerator | str | The type of devices, e.g. `nvidia.com/gpu`. |
 | accelerator_count | str | The number of devices. |
 
@@ -294,10 +293,9 @@ In that case, we plan to design `Runtime` dataclass as the following:
 @dataclass
 class Runtime:
     name: str
-    method: str
+    trainer_type: str
     framework: str
     pretrained_model: Optional[str] = None
-    phase: str
     accelerator: str
     accelerator_count: str,
 

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -271,10 +271,10 @@ TrainingClient().list_runtimes()
 They are expected to get:
 
 ```
-Runtime                             Method                Framework   Model         Phase           Accelerator       Count
+Runtime                             Method                Framework   Pretrained Model    Phase           Accelerator       Count
 
-pytorch-distributed                 custom-trainer        pytorch     <undefined>   any             nvidia.com/GPU    2
-torchtune-llama3.1-8B-finetuning    predefined-trainer    torchtune   Llama3.1-8B   post-training   nvidia.com/GPU    4
+pytorch-distributed                 custom-trainer        pytorch     <undefined>         any             nvidia.com/GPU    2
+torchtune-llama3.1-8B-finetuning    predefined-trainer    torchtune   Llama3.1-8B         post-training   nvidia.com/GPU    4
 ```
 
 In that case, we plan to design `Runtime` dataclass as the following:
@@ -284,7 +284,7 @@ In that case, we plan to design `Runtime` dataclass as the following:
 | name | str | The name of TrainingRuntime/ClusterTrainingRuntime. |
 | method | str | The training method of this runtime, chosen from `custom-trainer`, `predefined-trainer`. |
 | framework | str | The ML framework used for training, e.g. `pytorch`, `torchtune`. |
-| model | Optional[str] | The model specified for this runtime, e.g. `llama3.1-8B`. |
+| pretrained_model | Optional[str] | The pretrained model specified for this runtime, e.g. `llama3.1-8B`. |
 | phase | str | The training phase of this runtime, chosen from `any`, `post-training`. |
 | accelerator | str | The type of devices, e.g. `nvidia.com/gpu`. |
 | accelerator_count | str | The number of devices. |
@@ -296,7 +296,7 @@ class Runtime:
     name: str
     method: str
     framework: str
-    model: Optional[str] = None
+    pretrained_model: Optional[str] = None
     phase: str
     accelerator: str
     accelerator_count: str,

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -260,6 +260,49 @@ class TorchTuneConfig:
 
 ```
 
+#### `list_runtimes()` API
+
+We should allow users to easily get the available TrainingRuntimes/ClusterTrainingRuntimes with the SDK, followed with information related to the training method, framework, model, phase and device. When users execute:
+
+```python
+TrainingClient().list_runtimes()
+```
+
+They are expected to get:
+
+```
+Runtime                             Method                Framework   Model         Phase           Accelerator       Count
+
+pytorch-distributed                 custom-trainer        pytorch     <undefined>   any             nvidia.com/GPU    2
+torchtune-llama3.1-8B-finetuning    predefined-trainer    torchtune   Llama3.1-8B   post-training   nvidia.com/GPU    4
+```
+
+In that case, we plan to design `Runtime` dataclass as the following:
+
+| Fields | Type | What is it? |
+| - | - | - |
+| name | str | The name of TrainingRuntime/ClusterTrainingRuntime. |
+| method | str | The training method of this runtime, chosen from `custom-trainer`, `predefined-trainer`. |
+| framework | str | The ML framework used for training, e.g. `pytorch`, `torchtune`. |
+| model | Optional[str] | The model specified for this runtime, e.g. `llama3.1-8B`. |
+| phase | str | The training phase of this runtime, chosen from `any`, `post-training`. |
+| accelerator | str | The type of devices, e.g. `nvidia.com/gpu`. |
+| accelerator_count | str | The number of devices. |
+
+```python
+# Runtime DataClass
+@dataclass
+class Runtimne:
+    name: str
+    method: str
+    framework: str
+    model: Optional[str] = None
+    phase: str
+    accelerator: str
+    accelerator_count: str,
+
+```
+
 ### Complement `torch` Plugin
 
 #### Perform Mutation in `torch` Plugin

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -535,7 +535,8 @@ We will use [papermill](https://github.com/nteract/papermill) to execute these n
 ## Implementation History
 
 - 2025-01-31: Create KEP-2401 doc
-- 2025-03-07: KEP-2401 1st version & Start implementation
+- 2025-03-11: KEP-2401 1st version & Start implementation
+- 2025-03-12: Add new `Runtime` dataclass design
 
 ## Alternatives
 

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -94,7 +94,7 @@ job_id = TrainerClient().train(
             storage_uri="tatsu-lab/alpaca",
         )
     ),
-    runtime_ref=Runtime(
+    runtime=Runtime(
       name="torchtune-llama3.1-8B-finetuning",
     ),
 )
@@ -348,7 +348,7 @@ Related changes:
 
 #### Create Map from `TorchTuneConfig` to Specific Recipes and Configs
 
-We will create a map from (`TorchTuneConfig`, `num_nodes`, `nproc_per_node`, `runtime_ref`) to dedicated `recipe` and `config` in the server side. This will allow users to fine-tune their LLMs without knowing about `torchtune`'s recipes and configs and prevent SDK from changing frequently.
+We will create a map from (`TorchTuneConfig`, `num_nodes`, `nproc_per_node`, `runtime`) to dedicated `recipe` and `config` in the server side. This will allow users to fine-tune their LLMs without knowing about `torchtune`'s recipes and configs and prevent SDK from changing frequently.
 
 - How to Select `recipe`
 
@@ -359,13 +359,13 @@ We will create a map from (`TorchTuneConfig`, `num_nodes`, `nproc_per_node`, `ru
 
 - How to Select `config`
 
-We will create one `ClusterTrainingRuntime` for one model. In this way, we can extract the model info in `runtime_ref`, and select corresponding config file according to the `recipe`.
+We will create one `ClusterTrainingRuntime` for one model. In this way, we can extract the model info in `runtime`, and select corresponding config file according to the `recipe`.
 
 #### Validate Fine-Tuning Configurations
 
 In order to ensure the validity of the configurations propagated by SDK, we plan to add some validating requirements to the TrainJob Webhook. We'll implement validations in torch plugin [`CustomValidationPlugin`](https://github.com/kubeflow/trainer/blob/1f443729ebdb3e792d4b9cd2b242f33b0e86fe14/pkg/runtime/framework/interface.go#L34-L37):
 
-1. The ClusterTrainingRuntime referenced by `runtime_ref` exists in the control plane.
+1. The ClusterTrainingRuntime referenced by `runtime` exists in the control plane.
 
 #### Determine Default Resources
 

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -94,7 +94,9 @@ job_id = TrainerClient().train(
             storage_uri="tatsu-lab/alpaca",
         )
     ),
-    runtime_ref="torchtune-llama3.1-8B-finetuning",
+    runtime_ref=Runtime(
+      name="torchtune-llama3.1-8B-finetuning",
+    ),
 )
 ```
 
@@ -188,7 +190,7 @@ To provide a better user experience, we need to offer a simple SDK that allows u
 ```python
 # By default we can fine-tune models without any additional configurations from users
 TrainerClient().train(
-    runtime_ref="torchtune-llama-3.3-70b"
+    runtime=Runtime(name="torchtune-llama-3.3-70b"),
 )
 ```
 
@@ -203,7 +205,8 @@ So we plan to modify the `train()` API to:
 
 ```python
 def train(
-    runtime_ref: str,
+    self,
+    runtime: types.Runtime = types.DEFAULT_RUNTIME,
     trainer: Optional[Union[CustomTrainer, BuiltinTrainer]] = None,
     initializer: Optional[Initializer] = None,
 ) -> str:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

As we discussed in the Slack channel https://cloud-native.slack.com/archives/C0742LDFZ4K/p1741272854367919?thread_ts=1741263570.091899&cid=C0742LDFZ4K, we will add the detailed design of `Runtime` dataclass in the KEP.

We plan to define it as:

```python
# Runtime DataClass
@dataclass
class Runtime:
    name: str # The name of TrainingRuntime/ClusterTrainingRuntime.
    method: str # The training method of this runtime, chosen from `custom-trainer`, `predefined-trainer`.
    framework: str # The ML framework used for training, e.g. `pytorch`, `torchtune`.
    model: Optional[str] = None # The model specified for this runtime, e.g. `llama3.1-8B`.
    phase: str # The training phase of this runtime, chosen from `any`, `post-training`.
    accelerator: str # The type of devices, e.g. `nvidia.com/gpu`.
    accelerator_count: str, # The number of devices.

```

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
