### PR TITLE
KEP-2401: Add `TorchTuneConfig` to `train()` API

### DIFF
--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -240,7 +240,7 @@ We natively support all `recipe` and `config` supported by `torchtune`, since `t
 | dtype | Optional[str] | The underlying data type used to represent the model and optimizer parameters. Currently, we only support `bf16` and `fp32`. |
 | batch_size | Optional[int] | The number of samples processed before updating model weights. |
 | epochs | Optional[int] | The number of samples processed before updating model weights. |
-| loss | Optional[str] | The loss algorithm we use to fine-tune the LLM, e.g. `torchtune.modules.loss.CEWithChunkedOutputLoss` |
+| loss | Optional[Loss] | The loss algorithm we use to fine-tune the LLM, e.g. `torchtune.modules.loss.CEWithChunkedOutputLoss` |
 | peft_config | Optional[Union[LoraConfig]] | Configuration for the PEFT(Parameter-Efficient Fine-Tuning), including LoRA/QLoRA/DoRA, etc. |
 | dataset_preprocess_config | Optional[Union[InstructDataset, ChatDataset, MultimodalDataset]] | Configuration for dataset preprocessing. |
 | num_nodes | Optional[int] | The number of PyTorch Nodes in training |
@@ -253,7 +253,7 @@ class TorchTuneConfig:
     dtype: Optional[str] = None
     batch_size: Optional[int] = None
     epochs: Optional[int] = None
-    loss: Optional[str] = None
+    loss: Optional[Loss] = None
     peft_config: Optional[Union[LoraConfig]] = None
     dataset_preprocess_config: Optional[
         Union[InstructDataset, ChatDataset, MultimodalDataset],

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -237,7 +237,7 @@ We natively support all `recipe` and `config` supported by `torchtune`, since `t
 
 | Parameters | Type | What is it? |
 | - | - | - |
-| dtype | Optional[str] | The underlying data type used to represent the model and optimizer parameters. Currently, we only support `bf16` and `fp32`. |
+| dtype | Optional[DataType] | The underlying data type used to represent the model and optimizer parameters. Currently, we only support `bf16` and `fp32`. |
 | batch_size | Optional[int] | The number of samples processed before updating model weights. |
 | epochs | Optional[int] | The number of samples processed before updating model weights. |
 | loss | Optional[Loss] | The loss algorithm we use to fine-tune the LLM, e.g. `torchtune.modules.loss.CEWithChunkedOutputLoss` |

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -247,10 +247,21 @@ We natively support all `recipe` and `config` supported by `torchtune`, since `t
 | resource_per_node | Optional[Dict] | The resource for each PyTorch Node |
 
 ```python
+# Loss function for the TorchTune LLM Trainer.
+class Loss(Enum):
+    CEWithChunkedOutputLoss = "torchtune.modules.loss.CEWithChunkedOutputLoss"
+
+
+# Data type for the TorchTune LLM Trainer.
+class DataType(Enum):
+    BF16 = "bf16"
+    FP32 = "fp32"
+
+
 # TorchTuneConfig DataClass
 @dataclass
 class TorchTuneConfig:
-    dtype: Optional[str] = None
+    dtype: Optional[DataType] = None
     batch_size: Optional[int] = None
     epochs: Optional[int] = None
     loss: Optional[Loss] = None

--- a/sdk/kubeflow/trainer/__init__.py
+++ b/sdk/kubeflow/trainer/__init__.py
@@ -31,6 +31,7 @@ from kubeflow.trainer.types.types import (
     HuggingFaceDatasetInitializer,
     HuggingFaceModelInitializer,
     Initializer,
+    Loss,
     Runtime,
     Trainer,
     TrainerType,

--- a/sdk/kubeflow/trainer/__init__.py
+++ b/sdk/kubeflow/trainer/__init__.py
@@ -27,6 +27,7 @@ from kubeflow.trainer.constants.constants import DATASET_PATH, MODEL_PATH
 from kubeflow.trainer.types.types import (
     BuiltinTrainer,
     CustomTrainer,
+    DataType,
     Framework,
     HuggingFaceDatasetInitializer,
     HuggingFaceModelInitializer,

--- a/sdk/kubeflow/trainer/__init__.py
+++ b/sdk/kubeflow/trainer/__init__.py
@@ -34,4 +34,5 @@ from kubeflow.trainer.types.types import (
     Runtime,
     Trainer,
     TrainerType,
+    TorchTuneConfig,
 )

--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -157,15 +157,16 @@ class TrainerClient:
 
         - Custom Training Task: Training with a self-contained function that encapsulates
             the entire model training process.
-        - Fine-tuning Pre-Trained Models: Fine-tuning existing pre-trained models.
+        - Fine-tuning Pre-Trained Models: Fine-tuning existing pre-trained models with trainers
+            that already include the fine-tuning logic, requiring only parameter adjustments.
 
         Args:
             runtime_ref (`str`): Reference to the name of existing (Cluster)TrainingRuntime.
             trainer (`Optional[types.CustomTrainer]`):
-                The configuration of trainer which trains a model with a self-contained function
+                Configuration of the trainer which trains a model with a self-contained function
                     that encapsulates the entire model training process.
             fine_tuning_config (`Optional[types.TorchTuneConfig`]):
-                The configuration of trainer which fine-tunes existing pre-trained models.
+                Configuration of the trainer which fine-tunes existing pre-trained models.
                 Currently, we support these types of trainer:
                 - `types.TorchTuneConfig`: Training with the `torchtune` trainer that already
                     includes the fine-tuning logic, requiring only parameter adjustments.

--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -202,6 +202,11 @@ class TrainerClient:
 
         # Add command and args to the Trainer if training function is set.
         if trainer and trainer.func:
+            # Add resources per node to the Trainer.
+            if trainer.resources_per_node:
+                trainer_crd.resources_per_node = utils.get_resources_per_node(
+                    trainer.resources_per_node
+                )
 
             # TODO: Support train function parameters.
             trainer_crd.command, trainer_crd.args = (
@@ -225,17 +230,10 @@ class TrainerClient:
             if fine_tuning_config.num_nodes:
                 trainer_crd.num_nodes = fine_tuning_config.num_nodes
 
-            # Add resources per node and numProcPerNode to the Trainer.
+            # Add resources per node to the Trainer.
             if fine_tuning_config.resources_per_node:
                 trainer_crd.resources_per_node = utils.get_resources_per_node(
                     fine_tuning_config.resources_per_node
-                )
-                trainer_crd.num_proc_per_node = (
-                    models.IoK8sApimachineryPkgUtilIntstrIntOrString(
-                        utils.get_num_proc_per_node(
-                            fine_tuning_config.resources_per_node
-                        )
-                    )
                 )
 
             # Parse args in the TorchTuneConfig to the Trainer, preparing for the mutation of

--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -162,6 +162,8 @@ class TrainerClient:
 
         Args:
             runtime_ref (`str`): Reference to the name of existing (Cluster)TrainingRuntime.
+            initializer (`Optional[types.Initializer]`):
+                Configuration for Dataset and Model Initializers.
             trainer (`Optional[types.CustomTrainer, types.BuiltinTrainer]`):
                 Configuration for Custom Training Task or Config-driven Task with Existing Trainer.
 

--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -154,6 +154,23 @@ class TrainerClient:
     ) -> str:
         """Create the TrainJob. TODO (andreyvelich): Add description
 
+        Args:
+            runtime_ref (`str`): Reference to the name of existing (Cluster)TrainingRuntime.
+            trainer (`Optional[types.CustomTrainer]`):
+                The configuration of trainer which trains a model from scratch.
+                Currently, we support these types of trainer:
+                - `types.CustomTrainer`: Training with a self-contained function that
+                    encapsulates the entire model training process.
+            fine_tuning_config (`Optional[types.TorchTuneConfig`]):
+                The configuration of trainer which fine-tunes existing pre-trained models.
+                Currently, we support these types of trainer:
+                - `types.TorchTuneConfig`: Training with the `torchtune` trainer that already
+                    includes the fine-tuning logic, requiring only parameter adjustments.
+            dataset_config (`Optional[types.HuggingFaceDatasetConfig]`):
+                Configuration for the dataset provider.
+            model_config (`Optional[types.HuggingFaceModelInputConfig]`):
+                Configuration for the model provider.
+
         Returns:
             str: The unique name of the TrainJob that has been generated.
 

--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -18,7 +18,7 @@ import queue
 import random
 import string
 import uuid
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 import kubeflow.trainer.models as models
 from kubeflow.trainer.constants import constants
@@ -150,7 +150,7 @@ class TrainerClient:
         self,
         runtime: types.Runtime = types.DEFAULT_RUNTIME,
         initializer: Optional[types.Initializer] = None,
-        trainer: Optional[Union[types.CustomTrainer, types.BuiltinTrainer]] = None,
+        trainer: Optional[types.CustomTrainer] = None,
     ) -> str:
         """
         Create the TrainJob. You can configure these types of training task:
@@ -162,7 +162,7 @@ class TrainerClient:
             runtime (`types.Runtime`): Reference to one of existing Runtimes.
             initializer (`Optional[types.Initializer]`):
                 Configuration for the dataset and model initializers.
-            trainer (`Optional[types.CustomTrainer, types.BuiltinTrainer]`):
+            trainer (`Optional[types.CustomTrainer]`):
                 Configuration for Custom Training Task.
 
         Returns:

--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -238,6 +238,12 @@ class TrainerClient:
                     )
                 )
 
+            # Parse args in the TorchTuneConfig to the Trainer, preparing for the mutation of
+            # the torchtune config in the runtime plugin.
+            # Ref:https://github.com/kubeflow/trainer/tree/master/docs/proposals/2401-llm-trainer-v2
+            trainer_crd.command = constants.DEFAULT_TORCHTUNE_COMMAND
+            trainer_crd.args = utils.get_args_using_torchtune_config(fine_tuning_config)
+
         # If neither trainer nor fine_tuning_config is set, raise an value error.
         else:
             raise ValueError("Either trainer or fine_tuning_config must be set.")

--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -161,7 +161,7 @@ class TrainerClient:
             the post-training logic, requiring only parameter adjustments, e.g. `BuiltinTrainer`.
 
         Args:
-            runtime_ref (`str`): Reference to the name of existing (Cluster)TrainingRuntime.
+            runtime (`types.Runtime`): Reference to the existing (Cluster)TrainingRuntime.
             initializer (`Optional[types.Initializer]`):
                 Configuration for Dataset and Model Initializers.
             trainer (`Optional[types.CustomTrainer, types.BuiltinTrainer]`):

--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -157,8 +157,7 @@ class TrainerClient:
 
         - Custom Training Task: Training with a self-contained function that encapsulates
             the entire model training process.
-        - Fine-tuning Pre-Trained Models: Training with a Trainer that already includes
-            the fine-tuning logic, requiring only parameter adjustments.
+        - Fine-tuning Pre-Trained Models: Fine-tuning existing pre-trained models.
 
         Args:
             runtime_ref (`str`): Reference to the name of existing (Cluster)TrainingRuntime.

--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -152,7 +152,13 @@ class TrainerClient:
         initializer: Optional[types.Initializer] = None,
         trainer: Optional[types.CustomTrainer] = None,
     ) -> str:
-        """Create the TrainJob. TODO (andreyvelich): Add description
+        """
+        Create the TrainJob. You can configure these types of training task:
+
+        - Task with custom function: Training with a self-contained function that encapsulates
+            the entire model training process.
+        - Config-driven task with existing trainer: Training with a Trainer that already includes
+            the fine-tuning logic, requiring only parameter adjustments.
 
         Args:
             runtime_ref (`str`): Reference to the name of existing (Cluster)TrainingRuntime.

--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -157,15 +157,13 @@ class TrainerClient:
 
         - Custom Training Task: Training with a self-contained function that encapsulates
             the entire model training process, e.g. `CustomTrainer`.
-        - Config-driven Task with Existing Trainer: Training with a trainer that already includes
-            the post-training logic, requiring only parameter adjustments, e.g. `BuiltinTrainer`.
 
         Args:
-            runtime (`types.Runtime`): Reference to the existing (Cluster)TrainingRuntime.
+            runtime (`types.Runtime`): Reference to one of existing Runtimes.
             initializer (`Optional[types.Initializer]`):
-                Configuration for Dataset and Model Initializers.
+                Configuration for the dataset and model initializers.
             trainer (`Optional[types.CustomTrainer, types.BuiltinTrainer]`):
-                Configuration for Custom Training Task or Config-driven Task with Existing Trainer.
+                Configuration for Custom Training Task.
 
         Returns:
             str: The unique name of the TrainJob that has been generated.
@@ -211,12 +209,9 @@ class TrainerClient:
 
             # If users choose to use a builtin trainer for post-training.
             elif isinstance(trainer, types.BuiltinTrainer):
-                if trainer.config is None or not isinstance(
-                    trainer.config, types.TorchTuneConfig
-                ):
+                if not isinstance(trainer.config, types.TorchTuneConfig):
                     raise ValueError(
-                        "The config is missing or not supported for the BuiltinTrainer. "
-                        "Currently, we only support `TorchTuneConfig` as parameter."
+                        f"The BuiltinTrainer config is invalid: {trainer.config}"
                     )
 
                 # Add number of nodes to the Trainer.

--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -184,51 +184,13 @@ class TrainerClient:
         if trainer:
             # If users choose to use a custom training function.
             if isinstance(trainer, types.CustomTrainer):
-                # Add number of nodes to the Trainer.
-                if trainer.num_nodes:
-                    trainer_crd.num_nodes = trainer.num_nodes
-
-                # Add resources per node to the Trainer.
-                if trainer.resources_per_node:
-                    trainer_crd.resources_per_node = utils.get_resources_per_node(
-                        trainer.resources_per_node
-                    )
-
-                # Add command and args to the Trainer.
-                trainer_crd.command = constants.DEFAULT_CUSTOM_COMMAND
-                # TODO: Support train function parameters.
-                trainer_crd.command, trainer_crd.args = (
-                    utils.get_entrypoint_using_train_func(
-                        runtime,
-                        trainer.func,
-                        trainer.func_args,
-                        trainer.pip_index_url,
-                        trainer.packages_to_install,
-                    )
+                trainer_crd = utils.get_trainer_crd_from_custom_trainer(
+                    trainer, runtime
                 )
 
             # If users choose to use a builtin trainer for post-training.
             elif isinstance(trainer, types.BuiltinTrainer):
-                if not isinstance(trainer.config, types.TorchTuneConfig):
-                    raise ValueError(
-                        f"The BuiltinTrainer config is invalid: {trainer.config}"
-                    )
-
-                # Add number of nodes to the Trainer.
-                if trainer.config.num_nodes:
-                    trainer_crd.num_nodes = trainer.config.num_nodes
-
-                # Add resources per node to the Trainer.
-                if trainer.config.resources_per_node:
-                    trainer_crd.resources_per_node = utils.get_resources_per_node(
-                        trainer.config.resources_per_node
-                    )
-
-                # Parse args in the TorchTuneConfig to the Trainer, preparing for the mutation of
-                # the torchtune config in the runtime plugin.
-                # Ref:https://github.com/kubeflow/trainer/tree/master/docs/proposals/2401-llm-trainer-v2
-                trainer_crd.command = constants.DEFAULT_TORCHTUNE_COMMAND
-                trainer_crd.args = utils.get_args_using_torchtune_config(trainer)
+                trainer_crd = utils.get_trainer_crd_from_builtin_trainer(trainer)
 
             else:
                 raise ValueError(

--- a/sdk/kubeflow/trainer/constants/constants.py
+++ b/sdk/kubeflow/trainer/constants/constants.py
@@ -98,8 +98,16 @@ POD_PENDING = "Pending"
 # The default PIP index URL to download Python packages.
 DEFAULT_PIP_INDEX_URL = os.getenv("DEFAULT_PIP_INDEX_URL", "https://pypi.org/simple")
 
+<<<<<<< HEAD
 # The default command for the Trainer container.
 DEFAULT_COMMAND = ["bash", "-c"]
+=======
+# The default command for the Custom Trainer.
+DEFAULT_CUSTOM_COMMAND = ["bash", "-c"]
+
+# The default command for the TorchTune Trainer.
+DEFAULT_TORCHTUNE_COMMAND = ["tune", "run"]
+>>>>>>> 4f486e35 (chore(sdk): update the launching command and args.)
 
 # The default entrypoint for torchrun.
 TORCH_ENTRYPOINT = "torchrun"

--- a/sdk/kubeflow/trainer/constants/constants.py
+++ b/sdk/kubeflow/trainer/constants/constants.py
@@ -104,9 +104,6 @@ DEFAULT_CUSTOM_COMMAND = ["bash", "-c"]
 # The default command for the TorchTune Trainer.
 DEFAULT_TORCHTUNE_COMMAND = ["tune", "run"]
 
-# The supported dtypes for the TorchTune Trainer.
-TORCHTUNE_DTYPES = ["bf16", "fp32"]
-
 # The default entrypoint for torchrun.
 TORCH_ENTRYPOINT = "torchrun"
 

--- a/sdk/kubeflow/trainer/constants/constants.py
+++ b/sdk/kubeflow/trainer/constants/constants.py
@@ -107,6 +107,9 @@ DEFAULT_TORCHTUNE_COMMAND = ["tune", "run"]
 # The supported dtypes for the TorchTune Trainer.
 TORCHTUNE_DTYPES = ["bf16", "fp32"]
 
+# The default entrypoint for torchrun.
+TORCH_ENTRYPOINT = "torchrun"
+
 # The Torch env name for the number of procs per node (e.g. number of GPUs per Pod).
 TORCH_ENV_NUM_PROC_PER_NODE = "PET_NPROC_PER_NODE"
 

--- a/sdk/kubeflow/trainer/constants/constants.py
+++ b/sdk/kubeflow/trainer/constants/constants.py
@@ -107,53 +107,6 @@ DEFAULT_TORCHTUNE_COMMAND = ["tune", "run"]
 # The supported dtypes for the TorchTune Trainer.
 TORCHTUNE_DTYPES = ["bf16", "fp32"]
 
-# Distributed PyTorch entrypoint.
-ENTRYPOINT_TORCH = "torchrun"
-
-# The label key to identify the JobSet name of the Pod.
-JOBSET_NAME_KEY = "jobset.sigs.k8s.io/jobset-name"
-
-# The label key to identify the JobSet's ReplicatedJob of the Pod.
-REPLICATED_JOB_KEY = "jobset.sigs.k8s.io/replicatedjob-name"
-
-# The label key to identify the Job completion index of the Pod.
-JOB_INDEX_KEY = "batch.kubernetes.io/job-completion-index"
-
-# The default path to the users' workspace.
-# TODO (andreyvelich): Discuss how to keep this path is sync with pkg.initializers.constants
-WORKSPACE_PATH = "/workspace"
-
-# The name of the ReplicatedJob and container of the dataset initializer
-DATASET_INITIALIZER = "dataset-initializer"
-
-# The path where initializer downloads dataset.
-DATASET_PATH = os.path.join(WORKSPACE_PATH, "dataset")
-
-# The name of the ReplicatedJob and container of the model initializer
-MODEL_INITIALIZER = "model-initializer"
-
-# The path where initializer downloads model.
-MODEL_PATH = os.path.join(WORKSPACE_PATH, "model")
-
-# The Job name for the launcher (e.g. mpirun launcher).
-JOB_LAUNCHER = "launcher"
-
-# The container name for the launcher
-CONTAINER_LAUNCHER = "launcher"
-
-# The Job name for the trainer nodes.
-JOB_TRAINER_NODE = "trainer-node"
-
-# The Pod type for the master node.
-MASTER_NODE = f"{JOB_TRAINER_NODE}-0"
-
-# The Pod pending phase indicates that Pod has been accepted by the Kubernetes cluster,
-# but one or more of the containers has not been made ready to run.
-POD_PENDING = "Pending"
-
-# The container name for the Trainer.
-CONTAINER_TRAINER = "trainer"
-
 # The Torch env name for the number of procs per node (e.g. number of GPUs per Pod).
 TORCH_ENV_NUM_PROC_PER_NODE = "PET_NPROC_PER_NODE"
 

--- a/sdk/kubeflow/trainer/constants/constants.py
+++ b/sdk/kubeflow/trainer/constants/constants.py
@@ -98,19 +98,61 @@ POD_PENDING = "Pending"
 # The default PIP index URL to download Python packages.
 DEFAULT_PIP_INDEX_URL = os.getenv("DEFAULT_PIP_INDEX_URL", "https://pypi.org/simple")
 
-<<<<<<< HEAD
-# The default command for the Trainer container.
-DEFAULT_COMMAND = ["bash", "-c"]
-=======
 # The default command for the Custom Trainer.
 DEFAULT_CUSTOM_COMMAND = ["bash", "-c"]
 
 # The default command for the TorchTune Trainer.
 DEFAULT_TORCHTUNE_COMMAND = ["tune", "run"]
->>>>>>> 4f486e35 (chore(sdk): update the launching command and args.)
 
-# The default entrypoint for torchrun.
-TORCH_ENTRYPOINT = "torchrun"
+# The supported dtypes for the TorchTune Trainer.
+TORCHTUNE_DTYPES = ["bf16", "fp32"]
+
+# Distributed PyTorch entrypoint.
+ENTRYPOINT_TORCH = "torchrun"
+
+# The label key to identify the JobSet name of the Pod.
+JOBSET_NAME_KEY = "jobset.sigs.k8s.io/jobset-name"
+
+# The label key to identify the JobSet's ReplicatedJob of the Pod.
+REPLICATED_JOB_KEY = "jobset.sigs.k8s.io/replicatedjob-name"
+
+# The label key to identify the Job completion index of the Pod.
+JOB_INDEX_KEY = "batch.kubernetes.io/job-completion-index"
+
+# The default path to the users' workspace.
+# TODO (andreyvelich): Discuss how to keep this path is sync with pkg.initializers.constants
+WORKSPACE_PATH = "/workspace"
+
+# The name of the ReplicatedJob and container of the dataset initializer
+DATASET_INITIALIZER = "dataset-initializer"
+
+# The path where initializer downloads dataset.
+DATASET_PATH = os.path.join(WORKSPACE_PATH, "dataset")
+
+# The name of the ReplicatedJob and container of the model initializer
+MODEL_INITIALIZER = "model-initializer"
+
+# The path where initializer downloads model.
+MODEL_PATH = os.path.join(WORKSPACE_PATH, "model")
+
+# The Job name for the launcher (e.g. mpirun launcher).
+JOB_LAUNCHER = "launcher"
+
+# The container name for the launcher
+CONTAINER_LAUNCHER = "launcher"
+
+# The Job name for the trainer nodes.
+JOB_TRAINER_NODE = "trainer-node"
+
+# The Pod type for the master node.
+MASTER_NODE = f"{JOB_TRAINER_NODE}-0"
+
+# The Pod pending phase indicates that Pod has been accepted by the Kubernetes cluster,
+# but one or more of the containers has not been made ready to run.
+POD_PENDING = "Pending"
+
+# The container name for the Trainer.
+CONTAINER_TRAINER = "trainer"
 
 # The Torch env name for the number of procs per node (e.g. number of GPUs per Pod).
 TORCH_ENV_NUM_PROC_PER_NODE = "PET_NPROC_PER_NODE"

--- a/sdk/kubeflow/trainer/types/types.py
+++ b/sdk/kubeflow/trainer/types/types.py
@@ -21,7 +21,7 @@ from typing import Callable, Dict, List, Optional, Union
 from kubeflow.trainer.constants import constants
 
 
-# Configuration for the custom trainer.
+# Configuration for the Custom Trainer.
 @dataclass
 class CustomTrainer:
     """Custom Trainer configuration. Configure the self-contained function
@@ -100,6 +100,34 @@ class TrainJob:
     runtime: Runtime
     steps: List[Step]
     status: Optional[str] = constants.UNKNOWN
+
+
+# Configuration for the TorchTune LLM Trainer.
+@dataclass
+class TorchTuneConfig:
+    """TorchTune LLM Trainer configuration. Configure the parameters in
+        the TorchTune LLM Trainer that already includes the fine-tuning logic.
+
+    Args:
+        dtype (`Optional[str]`):
+            The underlying data type used to represent the model and optimizer parameters.
+            Currently, we only support `bf16` and `fp32`.
+        batch_size (`Optional[int]`):
+            The number of samples processed before updating model weights.
+        epochs (`Optional[int]`):
+            The number of samples processed before updating model weights.
+        loss (`Optional[str]`): The loss algorithm we use to fine-tune the LLM,
+            e.g. `torchtune.modules.loss.CEWithChunkedOutputLoss`.
+        num_nodes (`Optional[int]`): The number of nodes to use for training.
+        resources_per_node (`Optional[Dict]`): The computing resources to allocate per node.
+    """
+
+    dtype: Optional[str] = None
+    batch_size: Optional[int] = None
+    epochs: Optional[int] = None
+    loss: Optional[str] = None
+    num_nodes: Optional[int] = None
+    resources_per_node: Optional[Dict] = None
 
 
 # Configuration for the HuggingFace dataset initializer.

--- a/sdk/kubeflow/trainer/types/types.py
+++ b/sdk/kubeflow/trainer/types/types.py
@@ -130,6 +130,20 @@ class TorchTuneConfig:
     resources_per_node: Optional[Dict] = None
 
 
+# Configuration for the Builtin Trainer.
+@dataclass
+class BuiltinTrainer:
+    """
+    Builtin Trainer configuration. Configure the builtin trainer that already includes
+        the fine-tuning logic, requiring only parameter adjustments.
+
+    Args:
+        config (`TorchTuneConfig`): The configuration for the builtin trainer.
+    """
+
+    config: TorchTuneConfig
+
+
 # Configuration for the HuggingFace dataset initializer.
 # TODO (andreyvelich): Discuss how to keep these configurations is sync with pkg.initializers.types
 @dataclass

--- a/sdk/kubeflow/trainer/types/types.py
+++ b/sdk/kubeflow/trainer/types/types.py
@@ -53,6 +53,14 @@ class Loss(Enum):
     CEWithChunkedOutputLoss = "torchtune.modules.loss.CEWithChunkedOutputLoss"
 
 
+# Data type for the TorchTune LLM Trainer.
+class DataType(Enum):
+    """Data type for the TorchTune LLM Trainer."""
+
+    BF16 = "bf16"
+    FP32 = "fp32"
+
+
 # Configuration for the TorchTune LLM Trainer.
 @dataclass
 class TorchTuneConfig:
@@ -60,20 +68,20 @@ class TorchTuneConfig:
         the TorchTune LLM Trainer that already includes the fine-tuning logic.
 
     Args:
-        dtype (`Optional[str]`):
+        dtype (`Optional[Dtype]`):
             The underlying data type used to represent the model and optimizer parameters.
             Currently, we only support `bf16` and `fp32`.
         batch_size (`Optional[int]`):
             The number of samples processed before updating model weights.
         epochs (`Optional[int]`):
             The number of samples processed before updating model weights.
-        loss (`Optional[str]`): The loss algorithm we use to fine-tune the LLM,
+        loss (`Optional[Loss]`): The loss algorithm we use to fine-tune the LLM,
             e.g. `torchtune.modules.loss.CEWithChunkedOutputLoss`.
         num_nodes (`Optional[int]`): The number of nodes to use for training.
         resources_per_node (`Optional[Dict]`): The computing resources to allocate per node.
     """
 
-    dtype: Optional[str] = None
+    dtype: Optional[DataType] = None
     batch_size: Optional[int] = None
     epochs: Optional[int] = None
     loss: Optional[Loss] = None

--- a/sdk/kubeflow/trainer/types/types.py
+++ b/sdk/kubeflow/trainer/types/types.py
@@ -45,6 +45,14 @@ class CustomTrainer:
     resources_per_node: Optional[Dict] = None
 
 
+# TODO(Electronic-Waste): Add more loss functions.
+# Loss function for the TorchTune LLM Trainer.
+class Loss(Enum):
+    """Loss function for the TorchTune LLM Trainer."""
+
+    CEWithChunkedOutputLoss = "torchtune.modules.loss.CEWithChunkedOutputLoss"
+
+
 # Configuration for the TorchTune LLM Trainer.
 @dataclass
 class TorchTuneConfig:
@@ -68,7 +76,7 @@ class TorchTuneConfig:
     dtype: Optional[str] = None
     batch_size: Optional[int] = None
     epochs: Optional[int] = None
-    loss: Optional[str] = None
+    loss: Optional[Loss] = None
     num_nodes: Optional[int] = None
     resources_per_node: Optional[Dict] = None
 

--- a/sdk/kubeflow/trainer/types/types.py
+++ b/sdk/kubeflow/trainer/types/types.py
@@ -45,10 +45,46 @@ class CustomTrainer:
     resources_per_node: Optional[Dict] = None
 
 
+# Configuration for the TorchTune LLM Trainer.
+@dataclass
+class TorchTuneConfig:
+    """TorchTune LLM Trainer configuration. Configure the parameters in
+        the TorchTune LLM Trainer that already includes the fine-tuning logic.
+
+    Args:
+        dtype (`Optional[str]`):
+            The underlying data type used to represent the model and optimizer parameters.
+            Currently, we only support `bf16` and `fp32`.
+        batch_size (`Optional[int]`):
+            The number of samples processed before updating model weights.
+        epochs (`Optional[int]`):
+            The number of samples processed before updating model weights.
+        loss (`Optional[str]`): The loss algorithm we use to fine-tune the LLM,
+            e.g. `torchtune.modules.loss.CEWithChunkedOutputLoss`.
+        num_nodes (`Optional[int]`): The number of nodes to use for training.
+        resources_per_node (`Optional[Dict]`): The computing resources to allocate per node.
+    """
+
+    dtype: Optional[str] = None
+    batch_size: Optional[int] = None
+    epochs: Optional[int] = None
+    loss: Optional[str] = None
+    num_nodes: Optional[int] = None
+    resources_per_node: Optional[Dict] = None
+
+
 # Configuration for the Builtin Trainer.
 @dataclass
 class BuiltinTrainer:
-    pass
+    """
+    Builtin Trainer configuration. Configure the builtin trainer that already includes
+        the fine-tuning logic, requiring only parameter adjustments.
+
+    Args:
+        config (`TorchTuneConfig`): The configuration for the builtin trainer.
+    """
+
+    config: TorchTuneConfig
 
 
 class TrainerType(Enum):
@@ -100,48 +136,6 @@ class TrainJob:
     runtime: Runtime
     steps: List[Step]
     status: Optional[str] = constants.UNKNOWN
-
-
-# Configuration for the TorchTune LLM Trainer.
-@dataclass
-class TorchTuneConfig:
-    """TorchTune LLM Trainer configuration. Configure the parameters in
-        the TorchTune LLM Trainer that already includes the fine-tuning logic.
-
-    Args:
-        dtype (`Optional[str]`):
-            The underlying data type used to represent the model and optimizer parameters.
-            Currently, we only support `bf16` and `fp32`.
-        batch_size (`Optional[int]`):
-            The number of samples processed before updating model weights.
-        epochs (`Optional[int]`):
-            The number of samples processed before updating model weights.
-        loss (`Optional[str]`): The loss algorithm we use to fine-tune the LLM,
-            e.g. `torchtune.modules.loss.CEWithChunkedOutputLoss`.
-        num_nodes (`Optional[int]`): The number of nodes to use for training.
-        resources_per_node (`Optional[Dict]`): The computing resources to allocate per node.
-    """
-
-    dtype: Optional[str] = None
-    batch_size: Optional[int] = None
-    epochs: Optional[int] = None
-    loss: Optional[str] = None
-    num_nodes: Optional[int] = None
-    resources_per_node: Optional[Dict] = None
-
-
-# Configuration for the Builtin Trainer.
-@dataclass
-class BuiltinTrainer:
-    """
-    Builtin Trainer configuration. Configure the builtin trainer that already includes
-        the fine-tuning logic, requiring only parameter adjustments.
-
-    Args:
-        config (`TorchTuneConfig`): The configuration for the builtin trainer.
-    """
-
-    config: TorchTuneConfig
 
 
 # Configuration for the HuggingFace dataset initializer.

--- a/sdk/kubeflow/trainer/utils/utils.py
+++ b/sdk/kubeflow/trainer/utils/utils.py
@@ -287,7 +287,7 @@ def get_entrypoint_using_train_func(
         # The default file location is: /home/mpiuser/<FILE_NAME>.py
         func_file = os.path.join(constants.DEFAULT_MPI_USER_HOME, func_file)
     else:
-        container_command = constants.DEFAULT_COMMAND
+        container_command = constants.DEFAULT_CUSTOM_COMMAND
         python_entrypoint = " ".join(runtime.trainer.entrypoint)
 
     exec_script = textwrap.dedent(

--- a/sdk/kubeflow/trainer/utils/utils.py
+++ b/sdk/kubeflow/trainer/utils/utils.py
@@ -327,10 +327,10 @@ def get_args_using_torchtune_config(
 
     # Override the dtype if it is provided.
     if fine_tuning_config.dtype:
-        if fine_tuning_config.dtype not in constants.TORCHTUNE_DTYPES:
+        if fine_tuning_config.dtype not in [dtype.value for dtype in types.DataType]:
             raise ValueError(
                 f"Unsupported dtype: {fine_tuning_config.dtype}. "
-                f"Supported dtypes are: {constants.TORCHTUNE_DTYPES}"
+                f"Supported dtypes are: {[dtype.value for dtype in types.DataType]}"
             )
 
         args.append(f"dtype={fine_tuning_config.dtype}")

--- a/sdk/kubeflow/trainer/utils/utils.py
+++ b/sdk/kubeflow/trainer/utils/utils.py
@@ -327,11 +327,8 @@ def get_args_using_torchtune_config(
 
     # Override the dtype if it is provided.
     if fine_tuning_config.dtype:
-        if fine_tuning_config.dtype not in [dtype.value for dtype in types.DataType]:
-            raise ValueError(
-                f"Unsupported dtype: {fine_tuning_config.dtype}. "
-                f"Supported dtypes are: {[dtype.value for dtype in types.DataType]}"
-            )
+        if not isinstance(fine_tuning_config.dtype, types.DataType):
+            raise ValueError(f"Invalid dtype: {fine_tuning_config.dtype}.")
 
         args.append(f"dtype={fine_tuning_config.dtype}")
 

--- a/sdk/kubeflow/trainer/utils/utils.py
+++ b/sdk/kubeflow/trainer/utils/utils.py
@@ -317,6 +317,39 @@ def get_entrypoint_using_train_func(
     return container_command, [exec_script]
 
 
+def get_args_using_torchtune_config(
+    fine_tuning_config: types.TorchTuneConfig,
+) -> List[str]:
+    """
+    Get the Trainer args from the TorchTuneConfig.
+    """
+    args = []
+
+    # Override the dtype if it is provided.
+    if fine_tuning_config.dtype:
+        if fine_tuning_config.dtype not in constants.TORCHTUNE_DTYPES:
+            raise ValueError(
+                f"Unsupported dtype: {fine_tuning_config.dtype}. "
+                f"Supported dtypes are: {constants.TORCHTUNE_DTYPES}"
+            )
+
+        args.append(f"dtype={fine_tuning_config.dtype}")
+
+    # Override the batch size if it is provided.
+    if fine_tuning_config.batch_size:
+        args.append(f"batch_size={fine_tuning_config.batch_size}")
+
+    # Override the epochs if it is provided.
+    if fine_tuning_config.epochs:
+        args.append(f"epochs={fine_tuning_config.epochs}")
+
+    # Override the loss if it is provided.
+    if fine_tuning_config.loss:
+        args.append(f"loss={fine_tuning_config.loss}")
+
+    return args
+
+
 def get_script_for_python_packages(
     packages_to_install: List[str], pip_index_url: str
 ) -> str:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR adds the initial implementation of `TorchTuneConfig`:

```python
# Configuration for the TorchTune LLM Trainer.
@dataclass
class TorchTuneConfig:
    dtype: Optional[str] = None
    batch_size: Optional[int] = None
    epochs: Optional[int] = None
    loss: Optional[str] = None
    num_nodes: Optional[int] = None
    resources_per_node: Optional[Dict] = None

```

And refactor the `train()` API to add support fine-tuning with `torchtune`. Now, we can specify two types of task in `train()`:

1. **Custom Training Task**: Training with a self-contained function that encapsulates the entire model training process.
2. **Fine-tuning Pre-Trained Models**: Fine-tuning existing pre-trained models.

/cc @kubeflow/wg-training-leads @astefanutti @franciscojavierarceo @deepanker13 @saileshd1402 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2504

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
