### PR TITLE
fix(doc): Update `train()` API in KEP-2401

### DIFF
--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -193,14 +193,14 @@ TrainerClient().train(
 )
 ```
 
-#### Modify the `train` API
+#### Modify the `train()` API
 
-As we discussed in [Github](https://github.com/kubeflow/trainer/pull/2410#discussion_r1963832826), the `train` API mainly executes two types of training tasks:
+As we discussed in [Github](https://github.com/kubeflow/trainer/pull/2410#discussion_r1963832826), the `train()` API mainly executes two types of training tasks:
 
 1. **Type 1: Training with custom function/image**: A self-contained function/image that encapsulates the entire model training process.
 2. **Type 2: Config-driven approach with existing Trainer**: A trainer that already includes fine-tuning logic, requiring only parameter adjustments.
 
-So we plan to modify the `train` API to:
+So we plan to modify the `train()` API to:
 
 ```python
 def train(

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -77,15 +77,17 @@ To hide users from complex Kubernetes configuations, we will provide a simple ye
 
 ```python
 job_id = TrainingClient().train(
-    trainer=TorchTuneConfig(
-        dtype="bf16",
-        batch_size=1,
-        epochs=1,
-        peft_config=LoraConfig(
-            lora_rank=64,
-            lora_alpha=128,
+    trainer=BuiltinTrainer(
+        config=TorchTuneConfig(
+            dtype="bf16",
+            batch_size=1,
+            epochs=1,
+            peft_config=LoraConfig(
+                lora_rank=64,
+                lora_alpha=128,
+            ),
+            num_nodes=5,
         ),
-        num_nodes=5,
     ),
     initializer=Initializer(
         dataset=HuggingFaceDatasetInitializer(

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -212,7 +212,7 @@ def train(
 
 @dataclass
 class CustomTrainer:
-    func: Optional[Callable] = None
+    func: Callable
     func_args: Optional[Dict] = None
     packages_to_install: Optional[List[str]] = None
     pip_index_url: str = constants.DEFAULT_PIP_INDEX_URL

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -215,7 +215,7 @@ class CustomTrainer:
     func: Callable
     func_args: Optional[Dict] = None
     packages_to_install: Optional[List[str]] = None
-    pip_index_url: str = constants.DEFAULT_PIP_INDEX_URL
+    pip_index_url: Optional[str] = constants.DEFAULT_PIP_INDEX_URL
     num_nodes: Optional[int] = None
     resources_per_node: Optional[Dict] = None
 

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -76,7 +76,7 @@ By adopting `torchtune` as the low-level runtime for LLM fine-tuning, we can eas
 To hide users from complex Kubernetes configuations, we will provide a simple yet flexible Python SDK wrapping all specifications of models, datasets, training runtime and fine-tuning configs. Like this:
 
 ```python
-job_id = TrainingClient().train(
+job_id = TrainerClient().train(
     trainer=BuiltinTrainer(
         config=TorchTuneConfig(
             dtype="bf16",

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -77,10 +77,7 @@ To hide users from complex Kubernetes configuations, we will provide a simple ye
 
 ```python
 job_id = TrainingClient().train(
-    dataset_config=HuggingFaceDatasetConfig(
-        storage_uri="tatsu-lab/alpaca",
-    ),
-    fine_tuning_config=TorchTuneConfig(
+    trainer=TorchTuneConfig(
         dtype="bf16",
         batch_size=1,
         epochs=1,
@@ -89,6 +86,11 @@ job_id = TrainingClient().train(
             lora_alpha=128,
         ),
         num_nodes=5,
+    ),
+    initializer=Initializer(
+        dataset=HuggingFaceDatasetInitializer(
+            storage_uri="tatsu-lab/alpaca",
+        )
     ),
     runtime_ref="torchtune-llama3.1-8B-finetuning",
 )

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -204,9 +204,9 @@ So we plan to modify the `train` API to:
 
 ```python
 def train(
+    runtime_ref: str,
     trainer: Optional[Union[CustomTrainer, BuiltinTrainer]] = None,
     initializer: Optional[Initializer] = None,
-    runtime_ref: Optional[str] = None,
 ) -> str:
     pass
 

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -221,7 +221,7 @@ class CustomTrainer:
 
 @dataclass
 class BuiltinTrainer:
-    config: Optional[TorchTuneConfig] = None
+    config: TorchTuneConfig
 
 ```
 

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -200,10 +200,8 @@ So we plan to modify the `train` API to:
 
 ```python
 def train(
-    trainer: Optional[CustomTrainer] = None,
-    fine_tuning_config: Optional[Union[TorchTuneConfig]] = None,
-    dataset_config: Optional[types.HuggingFaceDatasetConfig] = None,
-    model_config: Optional[types.HuggingFaceModelInputConfig] = None,
+    trainer: Optional[Union[CustomTrainer, BuiltinTrainer]] = None,
+    initializer: Optional[Initializer] = None,
     runtime_ref: Optional[str] = None,
 ) -> str:
     pass
@@ -217,11 +215,15 @@ class CustomTrainer:
     num_nodes: Optional[int] = None
     resources_per_node: Optional[Dict] = None
 
+@dataclass
+class BuiltinTrainer:
+    config: Optional[TorchTuneConfig] = None
+
 ```
 
-`trainer` defines the parameters for Type 1 tasks, and will add support for custom function in the initial stage.
+`CustomTrainer` defines the parameters for Type 1 tasks, and will add support for custom function in the initial stage.
 
-`fine_tuning_config` defines the parameters for LLM fine-tuning task in Type 2, and will add support for fine-tuning with `torchtune` in the early stage.
+`BuiltinTrainer` defines the parameters for Type 2 tasks, and will add support for post-training with `torchtune` in the early stage.
 
 We natively support all `recipe` and `config` supported by `torchtune`, since `torchtune` has already provided us with default `config`. We just cannot mutate them if we do not support the corresponding mutation config.
 

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -197,8 +197,8 @@ TrainerClient().train(
 
 As we discussed in [Github](https://github.com/kubeflow/trainer/pull/2410#discussion_r1963832826), the `train()` API mainly executes two types of training tasks:
 
-1. **Type 1: Training with custom function/image**: A self-contained function/image that encapsulates the entire model training process.
-2. **Type 2: Config-driven approach with existing Trainer**: A trainer that already includes fine-tuning logic, requiring only parameter adjustments.
+1. **Type 1: Training with custom function/image**: A self-contained function/image that encapsulates the entire model training process (e.g. `CustomTrainer`).
+2. **Type 2: Config-driven approach with existing Trainer**: A trainer that already includes fine-tuning logic, requiring only parameter adjustments (e.g. `BuiltinTrainer`).
 
 So we plan to modify the `train()` API to:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

As we discussed in https://github.com/kubeflow/trainer/pull/2522#discussion_r1996970904, we need to update the `train()` API in the KEP-2401. The new API will be:

```python
def train(
    trainer: Optional[Union[CustomTrainer, BuiltinTrainer]] = None,
    initializer: Optional[Initializer] = None,
    runtime_ref: Optional[str] = None,
) -> str:
    pass

@dataclass
class CustomTrainer:
    func: Callable = None
    func_args: Optional[Dict] = None
    packages_to_install: Optional[List[str]] = None
    pip_index_url: Optional[str] = constants.DEFAULT_PIP_INDEX_URL
    num_nodes: Optional[int] = None
    resources_per_node: Optional[Dict] = None

@dataclass
class BuiltinTrainer:
    config: TorchTuneConfig

```

After updating the KEP, we can continue our work in #2522 

/cc @kubeflow/wg-training-leads @astefanutti 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
