### PR TITLE
fix(ci): Change publish dir from `training` to `trainer`

### DIFF
--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -75,7 +75,7 @@ jobs:
         with:
           image: |
             docker.io/kubeflow/${{ inputs.component-name }}
-            ghcr.io/kubeflow/training/${{ inputs.component-name }}
+            ghcr.io/kubeflow/trainer/${{ inputs.component-name }}
           dockerfile: ${{ inputs.dockerfile }}
           platforms: ${{ inputs.platforms }}
           context: ${{ inputs.context }}
@@ -88,7 +88,7 @@ jobs:
         with:
           image: |
             docker.io/kubeflow/${{ inputs.component-name }}
-            ghcr.io/kubeflow/training/${{ inputs.component-name }}
+            ghcr.io/kubeflow/trainer/${{ inputs.component-name }}
           dockerfile: ${{ inputs.dockerfile }}
           platforms: ${{ inputs.platforms }}
           context: ${{ inputs.context }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Currently, we introduced wrong package destination in https://github.com/kubeflow/trainer/pull/2491. So I raised this PR to fix the error we discussed in: https://github.com/kubeflow/trainer/pull/2544#discussion_r2002323616.

/cc @kubeflow/wg-training-leads @astefanutti @saileshd1402 @mahdikhashan 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
