### PR TITLE
fix(sdk): Add missing import types.

### DIFF
--- a/sdk/kubeflow/trainer/__init__.py
+++ b/sdk/kubeflow/trainer/__init__.py
@@ -25,8 +25,13 @@ from kubeflow.trainer.constants.constants import DATASET_PATH, MODEL_PATH
 
 # Import the Kubeflow Trainer types.
 from kubeflow.trainer.types.types import (
+    BuiltinTrainer,
     CustomTrainer,
+    Framework,
     HuggingFaceDatasetInitializer,
     HuggingFaceModelInitializer,
     Initializer,
+    Runtime,
+    Trainer,
+    TrainerType,
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Since we will use `BuiltinTrainer`, `Runtime` and their related data structures in `train()` API:

https://github.com/kubeflow/trainer/blob/8aa97a4806b00752acac14fbad2cdee6e36d40c2/sdk/kubeflow/trainer/api/trainer_client.py#L149-L154

We should always import them in the `sdk/kubeflow/trainer/__init__.py`.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
