### PR TITLE
KEP-2401: Create LLM Training Runtimes for Llama 3.2 model family

### DIFF
--- a/manifests/base/runtimes/kustomization.yaml
+++ b/manifests/base/runtimes/kustomization.yaml
@@ -5,4 +5,3 @@ resources:
   - mlx_distributed.yaml
   - mpi_distributed.yaml
   - torch_distributed.yaml
-  - torchtune

--- a/manifests/base/runtimes/kustomization.yaml
+++ b/manifests/base/runtimes/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - mlx_distributed.yaml
   - mpi_distributed.yaml
   - torch_distributed.yaml
+  - torchtune

--- a/manifests/base/runtimes/torchtune/kustomization.yaml
+++ b/manifests/base/runtimes/torchtune/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - llama3_2/llama3_2_1B.yaml
+  - llama3_2/llama3_2_3B.yaml

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -32,6 +32,9 @@ spec:
                       persistentVolumeClaim:
                         claimName: initializer
         - name: model-initializer
+          dependsOn:
+            - name: dataset-initializer
+              status: Complete
           template:
             metadata:
               labels:
@@ -54,8 +57,6 @@ spec:
                         claimName: initializer
         - name: node
           dependsOn:
-            - name: dataset-initializer
-              status: Complete
             - name: model-initializer
               status: Complete
           template:

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -70,13 +70,10 @@ spec:
                     - name: node
                       image: ghcr.io/kubeflow/trainer/torchtune-trainer
                       command:
-                         - /bin/bash
-                          - -c
-                          - |
-                            echo "TorchTune Llama3.2-1B Finetuning Runtime"
-
-                            echo "--------------------------------------"
-                            pip list
+                        - tune
+                        - run
+                        - full_finetune_distributed
+                        - --config llama3_2/1B_full.yaml
                       resources:
                         limits:
                           nvidia.com/gpu: 2

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -10,7 +10,27 @@ spec:
   template:
     spec:
       replicatedJobs:
-        # TODO(Electronic-Waste): Add dataset initializer when we support loading custom datasets.
+        - name: dataset-initializer
+          template:
+            spec:
+              template:
+                metadata:
+                  labels:
+                    trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer
+                spec:
+                  containers:
+                    - name: dataset-initializer
+                      image: ghcr.io/kubeflow/trainer/dataset-initializer
+                      env:
+                        - name: STORAGE_URI
+                          value: hf://tatsu-lab/alpaca
+                      volumeMounts:
+                        - mountPath: /workspace/dataset
+                          name: initializer
+                  volumes:
+                    - name: initializer
+                      persistentVolumeClaim:
+                        claimName: initializer
         - name: model-initializer
           template:
             metadata:
@@ -26,13 +46,18 @@ spec:
                         - name: STORAGE_URI
                           value: hf://meta-llama/Llama-3.2-1B-Instruct
                       volumeMounts:
-                        - name: model-initializer
+                        - name: initializer
                           mountPath: /workspace/model
                   volumes:
-                    - name: model-initializer
+                    - name: initializer
                       persistentVolumeClaim:
-                        claimName: model-initializer
+                        claimName: initializer
         - name: node
+          dependsOn:
+            - name: dataset-initializer
+              status: Complete
+            - name: model-initializer
+              status: Complete
           template:
             metadata:
               labels:
@@ -51,3 +76,15 @@ spec:
 
                             echo "--------------------------------------"
                             pip list
+                      resources:
+                        limits:
+                          nvidia.com/gpu: 2
+                      volumeMounts:
+                        - mountPath: /workspace/dataset
+                          name: initializer
+                        - mountPath: /workspace/model
+                          name: initializer
+                  volumes:
+                    - name: initializer
+                      persistentVolumeClaim:
+                        claimName: initializer

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -1,0 +1,53 @@
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: ClusterTrainingRuntime
+metadata:
+  name: torchtune-llama3.2-1b
+spec:
+  mlPolicy:
+    numNodes: 1
+    torch:
+      numProcPerNode: 2
+  template:
+    spec:
+      replicatedJobs:
+        # TODO(Electronic-Waste): Add dataset initializer when we support loading custom datasets.
+        - name: model-initializer
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: model-initializer
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: model-initializer
+                      image: ghcr.io/kubeflow/trainer/model-initializer
+                      env:
+                        - name: STORAGE_URI
+                          value: hf://meta-llama/Llama-3.2-1B-Instruct
+                      volumeMounts:
+                        - name: model-initializer
+                          mountPath: /workspace/model
+                  volumes:
+                    - name: model-initializer
+                      persistentVolumeClaim:
+                        claimName: model-initializer
+        - name: node
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: trainer
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: node
+                      image: ghcr.io/kubeflow/trainer/torchtune-trainer
+                      command:
+                         - /bin/bash
+                          - -c
+                          - |
+                            echo "TorchTune Llama3.2-1B Finetuning Runtime"
+
+                            echo "--------------------------------------"
+                            pip list

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -32,6 +32,9 @@ spec:
                       persistentVolumeClaim:
                         claimName: initializer
         - name: model-initializer
+          dependsOn:
+            - name: dataset-initializer
+              status: Complete
           template:
             metadata:
               labels:
@@ -54,8 +57,6 @@ spec:
                         claimName: initializer
         - name: node
           dependsOn:
-            - name: dataset-initializer
-              status: Complete
             - name: model-initializer
               status: Complete
           template:

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -10,7 +10,27 @@ spec:
   template:
     spec:
       replicatedJobs:
-        # TODO(Electronic-Waste): Add dataset initializer when we support loading custom datasets.
+        - name: dataset-initializer
+          template:
+            spec:
+              template:
+                metadata:
+                  labels:
+                    trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer
+                spec:
+                  containers:
+                    - name: dataset-initializer
+                      image: ghcr.io/kubeflow/trainer/dataset-initializer
+                      env:
+                        - name: STORAGE_URI
+                          value: hf://tatsu-lab/alpaca
+                      volumeMounts:
+                        - mountPath: /workspace/dataset
+                          name: initializer
+                  volumes:
+                    - name: initializer
+                      persistentVolumeClaim:
+                        claimName: initializer
         - name: model-initializer
           template:
             metadata:
@@ -26,13 +46,18 @@ spec:
                         - name: STORAGE_URI
                           value: hf://meta-llama/Llama-3.2-3B-Instruct
                       volumeMounts:
-                        - name: model-initializer
+                        - name: initializer
                           mountPath: /workspace/model
                   volumes:
-                    - name: model-initializer
+                    - name: initializer
                       persistentVolumeClaim:
-                        claimName: model-initializer
+                        claimName: initializer
         - name: node
+          dependsOn:
+            - name: dataset-initializer
+              status: Complete
+            - name: model-initializer
+              status: Complete
           template:
             metadata:
               labels:
@@ -51,3 +76,15 @@ spec:
 
                             echo "--------------------------------------"
                             pip list
+                      resources:
+                        limits:
+                          nvidia.com/gpu: 2
+                      volumeMounts:
+                        - mountPath: /workspace/dataset
+                          name: initializer
+                        - mountPath: /workspace/model
+                          name: initializer
+                  volumes:
+                    - name: initializer
+                      persistentVolumeClaim:
+                        claimName: initializer

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -1,0 +1,53 @@
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: ClusterTrainingRuntime
+metadata:
+  name: torchtune-llama3.2-3b
+spec:
+  mlPolicy:
+    numNodes: 1
+    torch:
+      numProcPerNode: 2
+  template:
+    spec:
+      replicatedJobs:
+        # TODO(Electronic-Waste): Add dataset initializer when we support loading custom datasets.
+        - name: model-initializer
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: model-initializer
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: model-initializer
+                      image: ghcr.io/kubeflow/trainer/model-initializer
+                      env:
+                        - name: STORAGE_URI
+                          value: hf://meta-llama/Llama-3.2-3B-Instruct
+                      volumeMounts:
+                        - name: model-initializer
+                          mountPath: /workspace/model
+                  volumes:
+                    - name: model-initializer
+                      persistentVolumeClaim:
+                        claimName: model-initializer
+        - name: node
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: trainer
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: node
+                      image: ghcr.io/kubeflow/trainer/torchtune-trainer
+                      command:
+                         - /bin/bash
+                          - -c
+                          - |
+                            echo "TorchTune Llama3.2-3B Finetuning Runtime"
+
+                            echo "--------------------------------------"
+                            pip list

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -70,13 +70,10 @@ spec:
                     - name: node
                       image: ghcr.io/kubeflow/trainer/torchtune-trainer
                       command:
-                         - /bin/bash
-                          - -c
-                          - |
-                            echo "TorchTune Llama3.2-3B Finetuning Runtime"
-
-                            echo "--------------------------------------"
-                            pip list
+                        - tune
+                        - run
+                        - full_finetune_distributed
+                        - --config llama3_2/3B_full.yaml
                       resources:
                         limits:
                           nvidia.com/gpu: 2

--- a/manifests/overlays/runtimes/kustomization.yaml
+++ b/manifests/overlays/runtimes/kustomization.yaml
@@ -2,3 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base/runtimes
+
+# Update the Kubeflow LLM Trainer image tag.
+images:
+  - name: ghcr.io/kubeflow/trainer/torchtune-trainer
+    newTag: latest

--- a/manifests/overlays/runtimes/kustomization.yaml
+++ b/manifests/overlays/runtimes/kustomization.yaml
@@ -7,3 +7,7 @@ resources:
 images:
   - name: ghcr.io/kubeflow/trainer/torchtune-trainer
     newTag: latest
+  - name: ghcr.io/kubeflow/trainer/dataset-initializer
+    newTag: latest
+  - name: ghcr.io/kubeflow/trainer/model-initializer
+    newTag: latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR adds the CTRs for Llama 3.2 model family, including:

1. Llama 3.2 1B Instruct: https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct
2. Llama 3.2 3B Instruct: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2510

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
