### PR TITLE
feat: Add PVC existence check for torchtune runtimes

### DIFF
--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -40,7 +40,7 @@ import (
 	"github.com/kubeflow/trainer/pkg/runtime/framework"
 )
 
-type Torch struct{
+type Torch struct {
 	client client.Client
 	scheme *apiruntime.Scheme
 }

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -120,7 +120,7 @@ func (t *Torch) Validate(runtimeInfo *runtime.Info, _, newObj *trainer.TrainJob)
 					if err := t.client.Get(context.TODO(), client.ObjectKey{Namespace: newObj.Namespace, Name: name}, &pvc); err != nil {
 						allErrs = append(allErrs, field.Invalid(runtimeRefNamePath, newObj.Spec.RuntimeRef.Name, fmt.Sprintf("PVC %s must be created before the TrainJob is created", name)))
 					} else if pvc.Status.Phase != corev1.ClaimBound {
-						allErrs = append(allErrs, field.Invalid(runtimeRefNamePath, newObj.Spec.RuntimeRef.Name, fmt.Sprintf("PVC %s must be bound before the TrainJob is created", name)))
+						allErrs = append(allErrs, field.Invalid(runtimeRefNamePath, newObj.Spec.RuntimeRef.Name, fmt.Sprintf("PVC %s must be bounded before the TrainJob is created", name)))
 					}
 				}
 			}

--- a/pkg/runtime/framework/plugins/torch/torch_test.go
+++ b/pkg/runtime/framework/plugins/torch/torch_test.go
@@ -29,8 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	batchv1ac "k8s.io/client-go/applyconfigurations/batch/v1"
+	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1416,7 +1416,7 @@ func TestTorch(t *testing.T) {
 func TestValidate(t *testing.T) {
 	cases := map[string]struct {
 		info         *runtime.Info
-		objs		 []client.Object
+		objs         []client.Object
 		oldObj       *trainer.TrainJob
 		newObj       *trainer.TrainJob
 		wantError    field.ErrorList

--- a/pkg/util/testing/wrapper.go
+++ b/pkg/util/testing/wrapper.go
@@ -1189,3 +1189,31 @@ func (s *SecretWrapper) ControllerReference(gvk schema.GroupVersionKind, name, u
 func (s *SecretWrapper) Obj() *corev1.Secret {
 	return &s.Secret
 }
+
+type PersistentVolumeClaimWrapper struct {
+	corev1.PersistentVolumeClaim
+}
+
+func MakePersistentVolumeClaimWrapper(name, ns string) *PersistentVolumeClaimWrapper {
+	return &PersistentVolumeClaimWrapper{
+		PersistentVolumeClaim: corev1.PersistentVolumeClaim{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "PersistentVolumeClaim",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+			},
+		},
+	}
+}
+
+func (p *PersistentVolumeClaimWrapper) WithPhase(phase corev1.PersistentVolumeClaimPhase) *PersistentVolumeClaimWrapper {
+	p.Status.Phase = phase
+	return p
+}
+
+func (p *PersistentVolumeClaimWrapper) Obj() *corev1.PersistentVolumeClaim {
+	return &p.PersistentVolumeClaim
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

As we discussed in https://github.com/kubeflow/trainer/pull/2590#discussion_r2068652278, PVC should exist before TrainJob creation. We need to add the validation in torch plugin temporarily util we support stateful jobset: https://github.com/kubeflow/trainer/issues/2630

/cc @kubeflow/wg-training-leads @astefanutti 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
