### PR TITLE
Release Training Operator Image for v1.9.2

### DIFF
--- a/manifests/overlays/kubeflow/kustomization.yaml
+++ b/manifests/overlays/kubeflow/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - kubeflow-training-roles.yaml
 images:
   - name: ghcr.io/kubeflow/training-v1/training-operator
-    newTag: v1-5c0e763
+    newTag: v1-3f15cb8
 # TODO (tenzen-y): Once we support cert-manager, we need to remove this secret generation.
 # REF: https://github.com/kubeflow/training-operator/issues/2049
 secretGenerator:

--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - namespace.yaml
 images:
   - name: ghcr.io/kubeflow/training-v1/training-operator
-    newTag: v1-5c0e763
+    newTag: v1-3f15cb8
 secretGenerator:
   - name: training-operator-webhook-cert
     options:


### PR DESCRIPTION
I updated version tag for `v1.9.1` version.

/cc @kubeflow/wg-training-leads @astefanutti @Electronic-Waste 