### PR TITLE
KEP-2401: Support mutating dataset preprocessing config in SDK

### DIFF
--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -242,7 +242,7 @@ We natively support all `recipe` and `config` supported by `torchtune`, since `t
 | epochs | Optional[int] | The number of samples processed before updating model weights. |
 | loss | Optional[Loss] | The loss algorithm we use to fine-tune the LLM, e.g. `torchtune.modules.loss.CEWithChunkedOutputLoss` |
 | peft_config | Optional[Union[LoraConfig]] | Configuration for the PEFT(Parameter-Efficient Fine-Tuning), including LoRA/QLoRA/DoRA, etc. |
-| dataset_preprocess_config | Optional[Union[InstructDataset, ChatDataset, MultimodalDataset]] | Configuration for dataset preprocessing. |
+| dataset_preprocess_config | Optional[Union[TorchTuneInstructDataset, TorchTuneChatDataset, TorchTuneMultimodalDataset]] | Configuration for dataset preprocessing. |
 | num_nodes | Optional[int] | The number of PyTorch Nodes in training |
 | resource_per_node | Optional[Dict] | The resource for each PyTorch Node |
 
@@ -267,7 +267,7 @@ class TorchTuneConfig:
     loss: Optional[Loss] = None
     peft_config: Optional[Union[LoraConfig]] = None
     dataset_preprocess_config: Optional[
-        Union[InstructDataset, ChatDataset, MultimodalDataset],
+        Union[TorchTuneInstructDataset, TorchTuneChatDataset, TorchTuneMultimodalDataset],
     ] = None
     num_nodes: Optional[int] = None,
     resources_per_node: Optional[Dict] = None,
@@ -516,7 +516,7 @@ volumes:
 
 ```python
 @datasetclass
-class InstructDataset:
+class TorchTuneInstructDataset:
     source: Optional[str] = None
     data_dir: Optional[str] = None
     data_files: Optional[List[str]] = None
@@ -531,7 +531,7 @@ class InstructDataset:
 
 ```python
 @datasetclass
-class ChatDataset:
+class TorchTuneChatDataset:
     source: Optional[str] = None
     data_dir: Optional[str] = None
     data_files: Optional[List[str]] = None
@@ -547,7 +547,7 @@ class ChatDataset:
 
 ```python
 @datasetclass
-class MultimodalDataset:
+class TorchTuneMultimodalDataset:
     source: Optional[str] = None
     data_dir: Optional[str] = None
     data_files: Optional[List[str]] = None
@@ -715,7 +715,7 @@ $ accelerate launch {my_script.py}
 | epochs | Optional[int] | The number of samples processed before updating model weights. |
 | loss | Optional[str] | The loss algorithm we use to fine-tune the LLM, e.g. `torchtune.modules.loss.CEWithChunkedOutputLoss` |
 | peft_config | Optional[Union[LoraConfig]] | Configuration for the PEFT(Parameter-Efficient Fine-Tuning), including LoRA/QLoRA/DoRA, etc. |
-| dataset_preprocess_config | Optional[Union[InstructDataset, ChatDataset, MultimodalDataset]] | Configuration for dataset preprocessing. |
+| dataset_preprocess_config | Optional[Union[TorchTuneInstructDataset, TorchTuneChatDataset, TorchTuneMultimodalDataset]] | Configuration for dataset preprocessing. |
 | num_nodes | Optional[int] | The number of PyTorch Nodes in training |
 | resource_per_node | Optional[Dict] | The resource for each PyTorch Node |
 
@@ -731,7 +731,7 @@ class TorchTuneConfig:
     loss: Optional[str] = None
     peft_config: Optional[Union[LoraConfig]] = None
     dataset_preprocess_config: Optional[
-        Union[InstructDataset, ChatDataset, MultimodalDataset],
+        Union[TorchTuneInstructDataset, TorchTuneChatDataset, TorchTuneMultimodalDataset],
     ] = None
     num_nodes: Optional[int] = None,
     resources_per_node: Optional[Dict] = None,

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -518,7 +518,8 @@ volumes:
 @datasetclass
 class InstructDataset:
     source: Optional[str] = None
-    data_files: Optional[str] = None
+    data_dir: Optional[str] = None
+    data_files: Optional[List[str]] = None
     split: Optional[str] = None
     train_on_input: Optional[bool] = None
     new_system_prompt: Optional[str] = None
@@ -532,7 +533,8 @@ class InstructDataset:
 @datasetclass
 class ChatDataset:
     source: Optional[str] = None
-    data_files: Optional[str] = None
+    data_dir: Optional[str] = None
+    data_files: Optional[List[str]] = None
     split: Optional[str] = None
     conversation_column: Optional[str] = None
     conversation_style: Optional[str] = None
@@ -547,7 +549,8 @@ class ChatDataset:
 @datasetclass
 class MultimodalDataset:
     source: Optional[str] = None
-    data_files: Optional[str] = None
+    data_dir: Optional[str] = None
+    data_files: Optional[List[str]] = None
     split: Optional[str] = None
     column_map: Optional[Dict[str, str]] = None
     image_dir: Optional[str] = None

--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -518,8 +518,6 @@ volumes:
 @datasetclass
 class TorchTuneInstructDataset:
     source: Optional[str] = None
-    data_dir: Optional[str] = None
-    data_files: Optional[List[str]] = None
     split: Optional[str] = None
     train_on_input: Optional[bool] = None
     new_system_prompt: Optional[str] = None
@@ -533,8 +531,6 @@ class TorchTuneInstructDataset:
 @datasetclass
 class TorchTuneChatDataset:
     source: Optional[str] = None
-    data_dir: Optional[str] = None
-    data_files: Optional[List[str]] = None
     split: Optional[str] = None
     conversation_column: Optional[str] = None
     conversation_style: Optional[str] = None
@@ -549,8 +545,6 @@ class TorchTuneChatDataset:
 @datasetclass
 class TorchTuneMultimodalDataset:
     source: Optional[str] = None
-    data_dir: Optional[str] = None
-    data_files: Optional[List[str]] = None
     split: Optional[str] = None
     column_map: Optional[Dict[str, str]] = None
     image_dir: Optional[str] = None

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -76,7 +76,7 @@ spec:
                         - --config llama3_2/1B_full.yaml
                         - dataset=torchtune.datasets.instruct_dataset
                         - dataset.source=parquet
-                        - dataset.data_dir=/workspace/dataset/alpaca/data
+                        - dataset.data_dir=/workspace/dataset/data
                       resources:
                         limits:
                           nvidia.com/gpu: 2

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -74,6 +74,9 @@ spec:
                         - run
                         - full_finetune_distributed
                         - --config llama3_2/1B_full.yaml
+                        - dataset=torchtune.datasets.instruct_dataset
+                        - dataset.source=parquet
+                        - dataset.data_dir=/workspace/dataset/alpaca/data
                       resources:
                         limits:
                           nvidia.com/gpu: 2

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -76,7 +76,7 @@ spec:
                         - --config llama3_2/3B_full.yaml
                         - dataset=torchtune.datasets.instruct_dataset
                         - dataset.source=parquet
-                        - dataset.data_dir=/workspace/dataset/alpaca/data
+                        - dataset.data_dir=/workspace/dataset/data
                       resources:
                         limits:
                           nvidia.com/gpu: 2

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -74,6 +74,9 @@ spec:
                         - run
                         - full_finetune_distributed
                         - --config llama3_2/3B_full.yaml
+                        - dataset=torchtune.datasets.instruct_dataset
+                        - dataset.source=parquet
+                        - dataset.data_dir=/workspace/dataset/alpaca/data
                       resources:
                         limits:
                           nvidia.com/gpu: 2

--- a/pkg/initializers/dataset/huggingface.py
+++ b/pkg/initializers/dataset/huggingface.py
@@ -21,9 +21,8 @@ class HuggingFace(utils.DatasetProvider):
 
     def download_dataset(self):
         storage_uri_parsed = urlparse(self.config.storage_uri)
-        dataset_uri = (
-            storage_uri_parsed.netloc + storage_uri_parsed.path.strip("/").split("/")[0]
-        )
+        repo_name = storage_uri_parsed.path.strip("/").split("/")[0]
+        dataset_uri = storage_uri_parsed.netloc + repo_name
 
         logging.info(f"Downloading dataset: {dataset_uri}")
         logging.info("-" * 40)

--- a/pkg/initializers/dataset/huggingface.py
+++ b/pkg/initializers/dataset/huggingface.py
@@ -21,8 +21,7 @@ class HuggingFace(utils.DatasetProvider):
 
     def download_dataset(self):
         storage_uri_parsed = urlparse(self.config.storage_uri)
-        repo_name = storage_uri_parsed.path.strip("/").split("/")[0]
-        dataset_uri = storage_uri_parsed.netloc + repo_name
+        dataset_uri = storage_uri_parsed.netloc + storage_uri_parsed.path.split("/")[1]
 
         logging.info(f"Downloading dataset: {dataset_uri}")
         logging.info("-" * 40)

--- a/pkg/initializers/dataset/huggingface.py
+++ b/pkg/initializers/dataset/huggingface.py
@@ -21,7 +21,9 @@ class HuggingFace(utils.DatasetProvider):
 
     def download_dataset(self):
         storage_uri_parsed = urlparse(self.config.storage_uri)
-        dataset_uri = storage_uri_parsed.netloc + storage_uri_parsed.path.split("/")[1]
+        dataset_uri = (
+            storage_uri_parsed.netloc + "/" + storage_uri_parsed.path.split("/")[1]
+        )
 
         logging.info(f"Downloading dataset: {dataset_uri}")
         logging.info("-" * 40)

--- a/pkg/initializers/dataset/huggingface.py
+++ b/pkg/initializers/dataset/huggingface.py
@@ -21,7 +21,9 @@ class HuggingFace(utils.DatasetProvider):
 
     def download_dataset(self):
         storage_uri_parsed = urlparse(self.config.storage_uri)
-        dataset_uri = storage_uri_parsed.netloc + storage_uri_parsed.path
+        dataset_uri = (
+            storage_uri_parsed.netloc + storage_uri_parsed.path.strip("/").split("/")[0]
+        )
 
         logging.info(f"Downloading dataset: {dataset_uri}")
         logging.info("-" * 40)

--- a/sdk/kubeflow/trainer/__init__.py
+++ b/sdk/kubeflow/trainer/__init__.py
@@ -33,7 +33,7 @@ from kubeflow.trainer.types.types import (
     HuggingFaceDatasetInitializer,
     HuggingFaceModelInitializer,
     Initializer,
-    InstructDataset,
+    TorchTuneInstructDataset,
     Loss,
     Runtime,
     Trainer,

--- a/sdk/kubeflow/trainer/__init__.py
+++ b/sdk/kubeflow/trainer/__init__.py
@@ -27,11 +27,13 @@ from kubeflow.trainer.constants.constants import DATASET_PATH, MODEL_PATH
 from kubeflow.trainer.types.types import (
     BuiltinTrainer,
     CustomTrainer,
+    DataFormat,
     DataType,
     Framework,
     HuggingFaceDatasetInitializer,
     HuggingFaceModelInitializer,
     Initializer,
+    InstructDataset,
     Loss,
     Runtime,
     Trainer,

--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -193,7 +193,9 @@ class TrainerClient:
 
             # If users choose to use a builtin trainer for post-training.
             elif isinstance(trainer, types.BuiltinTrainer):
-                trainer_crd = utils.get_trainer_crd_from_builtin_trainer(trainer)
+                trainer_crd = utils.get_trainer_crd_from_builtin_trainer(
+                    trainer, initializer
+                )
 
             else:
                 raise ValueError(

--- a/sdk/kubeflow/trainer/constants/constants.py
+++ b/sdk/kubeflow/trainer/constants/constants.py
@@ -122,3 +122,6 @@ MPI_HOSTFILE = "/etc/mpi/hostfile"
 
 # The default entrypoint for mpirun.
 MPI_ENTRYPOINT = "mpirun"
+
+# The Instruct Datasets class in torchtune
+TORCHTUNE_INSTRUCT_DATASET = "torchtune.datasets.instruct_dataset"

--- a/sdk/kubeflow/trainer/types/types.py
+++ b/sdk/kubeflow/trainer/types/types.py
@@ -82,12 +82,6 @@ class TorchTuneInstructDataset:
 
     Args:
         source (`Optional[DataFormat]`): Data file type.
-        data_dir (`Optional[str]`):
-            The path to the data directory. For HF dataset, the value should be `<repo>/<dir_path>`.
-            The behavior is equal to passing all data files under `data_dir` to `data_files`.
-            all the files in a directory. But if `data_files` is specified, `data_dir` is ignored.
-        data_files (`Optional[List[str]]`):
-            The path to the data files. For HF dataset, the value should be `<repo>/<file_path>`.
         split (`Optional[str]`):
             The split of the dataset to use.  You can use this argument to load a subset of
             a given split, e.g. split="train[:10%]". Default is `train`.
@@ -104,8 +98,6 @@ class TorchTuneInstructDataset:
     """
 
     source: Optional[DataFormat] = None
-    data_dir: Optional[str] = None
-    data_files: Optional[List[str]] = None
     split: Optional[str] = None
     train_on_input: Optional[bool] = None
     new_system_prompt: Optional[str] = None

--- a/sdk/kubeflow/trainer/types/types.py
+++ b/sdk/kubeflow/trainer/types/types.py
@@ -75,7 +75,7 @@ class DataFormat(Enum):
 
 # Configuration for the TorchTune Instruct dataset.
 @dataclass
-class InstructDataset:
+class TorchTuneInstructDataset:
     """
     Configuration for the custom dataset with user instruction prompts and model responses.
     REF: https://pytorch.org/torchtune/main/generated/torchtune.datasets.instruct_dataset.html
@@ -129,7 +129,7 @@ class TorchTuneConfig:
         loss (`Optional[Loss]`): The loss algorithm we use to fine-tune the LLM,
             e.g. `torchtune.modules.loss.CEWithChunkedOutputLoss`.
         num_nodes (`Optional[int]`): The number of nodes to use for training.
-        dataset_preprocess_config (`Optional[InstructDataset]`):
+        dataset_preprocess_config (`Optional[TorchTuneInstructDataset]`):
             Configuration for the dataset preprocessing.
         resources_per_node (`Optional[Dict]`): The computing resources to allocate per node.
     """
@@ -139,7 +139,7 @@ class TorchTuneConfig:
     epochs: Optional[int] = None
     loss: Optional[Loss] = None
     num_nodes: Optional[int] = None
-    dataset_preprocess_config: Optional[InstructDataset] = None
+    dataset_preprocess_config: Optional[TorchTuneInstructDataset] = None
     resources_per_node: Optional[Dict] = None
 
 

--- a/sdk/kubeflow/trainer/types/types.py
+++ b/sdk/kubeflow/trainer/types/types.py
@@ -62,7 +62,7 @@ class DataType(Enum):
 
 
 # Data file type for the TorchTune LLM Trainer.
-class DataFileType(Enum):
+class DataFormat(Enum):
     """Data file type for the TorchTune LLM Trainer."""
 
     JSON = "json"
@@ -81,7 +81,7 @@ class InstructDataset:
     REF: https://pytorch.org/torchtune/main/generated/torchtune.datasets.instruct_dataset.html
 
     Args:
-        source (`Optional[DataFileType]`): Data file type.
+        source (`Optional[DataFormat]`): Data file type.
         data_dir (`Optional[str]`):
             The path to the data directory. For HF dataset, the value should be `<repo>/<dir_path>`.
             The behavior is equal to passing all data files under `data_dir` to `data_files`.
@@ -103,7 +103,7 @@ class InstructDataset:
             "output" column names.
     """
 
-    source: Optional[DataFileType] = None
+    source: Optional[DataFormat] = None
     data_dir: Optional[str] = None
     data_files: Optional[List[str]] = None
     split: Optional[str] = None

--- a/sdk/kubeflow/trainer/types/types.py
+++ b/sdk/kubeflow/trainer/types/types.py
@@ -61,6 +61,57 @@ class DataType(Enum):
     FP32 = "fp32"
 
 
+# Data file type for the TorchTune LLM Trainer.
+class DataFileType(Enum):
+    """Data file type for the TorchTune LLM Trainer."""
+
+    JSON = "json"
+    CSV = "csv"
+    PARQUET = "parquet"
+    ARROW = "arrow"
+    TEXT = "text"
+    XML = "xml"
+
+
+# Configuration for the TorchTune Instruct dataset.
+@dataclass
+class InstructDataset:
+    """
+    Configuration for the custom dataset with user instruction prompts and model responses.
+    REF: https://pytorch.org/torchtune/main/generated/torchtune.datasets.instruct_dataset.html
+
+    Args:
+        source (`Optional[DataFileType]`): Data file type.
+        data_dir (`Optional[str]`):
+            The path to the data directory. For HF dataset, the value should be `<repo>/<dir_path>`.
+            The behavior is equal to passing all data files under `data_dir` to `data_files`.
+            all the files in a directory. But if `data_files` is specified, `data_dir` is ignored.
+        data_files (`Optional[List[str]]`):
+            The path to the data files. For HF dataset, the value should be `<repo>/<file_path>`.
+        split (`Optional[str]`):
+            The split of the dataset to use.  You can use this argument to load a subset of
+            a given split, e.g. split="train[:10%]". Default is `train`.
+        train_on_input (`Optional[bool]`):
+            Whether the model is trained on the user prompt or not. Default is False.
+        new_system_prompt (`Optional[str]`):
+            The new system prompt to use. If specified, prepend a system message.
+            This can serve as instructions to guide the model response. Default is None.
+        column_map (`Optional[Dict[str, str]]`):
+            A mapping to change the expected "input" and "output" column names to the actual
+            column names in the dataset. Keys should be "input" and "output" and values should
+            be the actual column names. Default is None, keeping the default "input" and
+            "output" column names.
+    """
+
+    source: Optional[DataFileType] = None
+    data_dir: Optional[str] = None
+    data_files: Optional[List[str]] = None
+    split: Optional[str] = None
+    train_on_input: Optional[bool] = None
+    new_system_prompt: Optional[str] = None
+    column_map: Optional[Dict[str, str]] = None
+
+
 # Configuration for the TorchTune LLM Trainer.
 @dataclass
 class TorchTuneConfig:
@@ -78,6 +129,8 @@ class TorchTuneConfig:
         loss (`Optional[Loss]`): The loss algorithm we use to fine-tune the LLM,
             e.g. `torchtune.modules.loss.CEWithChunkedOutputLoss`.
         num_nodes (`Optional[int]`): The number of nodes to use for training.
+        dataset_preprocess_config (`Optional[InstructDataset]`):
+            Configuration for the dataset preprocessing.
         resources_per_node (`Optional[Dict]`): The computing resources to allocate per node.
     """
 
@@ -86,6 +139,7 @@ class TorchTuneConfig:
     epochs: Optional[int] = None
     loss: Optional[Loss] = None
     num_nodes: Optional[int] = None
+    dataset_preprocess_config: Optional[InstructDataset] = None
     resources_per_node: Optional[Dict] = None
 
 

--- a/sdk/kubeflow/trainer/utils/utils.py
+++ b/sdk/kubeflow/trainer/utils/utils.py
@@ -540,23 +540,6 @@ def get_args_in_dataset_preprocess_config(
         args.append(f"dataset.source={dataset_preprocess_config.source}")
 
     # Override the data dir or data files if it is provided.
-    if dataset_preprocess_config.data_files:
-        if not isinstance(dataset_preprocess_config.data_files, List[str]):
-            raise ValueError(
-                f"Invalid data_files type: {type(dataset_preprocess_config.data_files)}."
-            )
-
-        paths = []
-        for path in dataset_preprocess_config.data_files:
-            paths.append(os.path.join(constants.DATASET_PATH, path))
-
-        args.append(f"dataset.data_files={paths}")
-
-    elif dataset_preprocess_config.data_dir:
-        data_dir = os.path.join(
-            constants.DATASET_PATH, dataset_preprocess_config.data_dir
-        )
-        args.append(f"dataset.data_dir={data_dir}")
 
     # Override the split field if it is provided.
     if dataset_preprocess_config.split:

--- a/sdk/kubeflow/trainer/utils/utils.py
+++ b/sdk/kubeflow/trainer/utils/utils.py
@@ -352,6 +352,11 @@ def get_args_using_torchtune_config(
     if fine_tuning_config.loss:
         args.append(f"loss={fine_tuning_config.loss}")
 
+    if fine_tuning_config.dataset_preprocess_config:
+        args += get_args_in_dataset_preprocess_config(
+            fine_tuning_config.dataset_preprocess_config
+        )
+
     return constants.DEFAULT_TORCHTUNE_COMMAND, args
 
 
@@ -507,3 +512,57 @@ def get_log_queue_pool(log_streams: List[Any]) -> List[queue.Queue]:
         pool.append(q)
         threading.Thread(target=wrap_log_stream, args=(q, log_stream)).start()
     return pool
+
+
+def get_args_in_dataset_preprocess_config(
+    dataset_preprocess_config: types.InstructDataset,
+) -> List[str]:
+    """
+    Get the args from the given dataset preprocess config.
+    """
+    args = []
+
+    if not isinstance(dataset_preprocess_config, types.InstructDataset):
+        raise ValueError(
+            f"Invalid dataset preprocess config type: {type(dataset_preprocess_config)}."
+        )
+
+    # Override the dataset type field in the torchtune config.
+    args.append(f"dataset={constants.TORCHTUNE_INSTRUCT_DATASET}")
+
+    # Override the dataset source field if it is provided.
+    if dataset_preprocess_config.source:
+        if not isinstance(dataset_preprocess_config.source, types.DataFormat):
+            raise ValueError(
+                f"Invalid data format: {dataset_preprocess_config.source}."
+            )
+
+        args.append(f"dataset.source={dataset_preprocess_config.source}")
+
+    # Override the data dir or data files if it is provided.
+    if dataset_preprocess_config.data_files:
+        args.append(f"dataset.data_files={dataset_preprocess_config.data_files}")
+    elif dataset_preprocess_config.data_dir:
+        args.append(f"dataset.data_dir={dataset_preprocess_config.data_dir}")
+
+    # Override the split field if it is provided.
+    if dataset_preprocess_config.split:
+        args.append(f"dataset.split={dataset_preprocess_config.split}")
+
+    # Override the train_on_input field if it is provided.
+    if dataset_preprocess_config.train_on_input:
+        args.append(
+            f"dataset.train_on_input={dataset_preprocess_config.train_on_input}"
+        )
+
+    # Override the new_system_prompt field if it is provided.
+    if dataset_preprocess_config.new_system_prompt:
+        args.append(
+            f"dataset.new_system_prompt={dataset_preprocess_config.new_system_prompt}"
+        )
+
+    # Override the column_map field if it is provided.
+    if dataset_preprocess_config.column_map:
+        args.append(f"dataset.column_map={dataset_preprocess_config.column_map}")
+
+    return args

--- a/sdk/kubeflow/trainer/utils/utils.py
+++ b/sdk/kubeflow/trainer/utils/utils.py
@@ -515,14 +515,14 @@ def get_log_queue_pool(log_streams: List[Any]) -> List[queue.Queue]:
 
 
 def get_args_in_dataset_preprocess_config(
-    dataset_preprocess_config: types.InstructDataset,
+    dataset_preprocess_config: types.TorchTuneInstructDataset,
 ) -> List[str]:
     """
     Get the args from the given dataset preprocess config.
     """
     args = []
 
-    if not isinstance(dataset_preprocess_config, types.InstructDataset):
+    if not isinstance(dataset_preprocess_config, types.TorchTuneInstructDataset):
         raise ValueError(
             f"Invalid dataset preprocess config type: {type(dataset_preprocess_config)}."
         )

--- a/sdk/kubeflow/trainer/utils/utils.py
+++ b/sdk/kubeflow/trainer/utils/utils.py
@@ -541,9 +541,22 @@ def get_args_in_dataset_preprocess_config(
 
     # Override the data dir or data files if it is provided.
     if dataset_preprocess_config.data_files:
-        args.append(f"dataset.data_files={dataset_preprocess_config.data_files}")
+        if not isinstance(dataset_preprocess_config.data_files, List[str]):
+            raise ValueError(
+                f"Invalid data_files type: {type(dataset_preprocess_config.data_files)}."
+            )
+
+        paths = []
+        for path in dataset_preprocess_config.data_files:
+            paths.append(os.path.join(constants.DATASET_PATH, path))
+
+        args.append(f"dataset.data_files={paths}")
+
     elif dataset_preprocess_config.data_dir:
-        args.append(f"dataset.data_dir={dataset_preprocess_config.data_dir}")
+        data_dir = os.path.join(
+            constants.DATASET_PATH, dataset_preprocess_config.data_dir
+        )
+        args.append(f"dataset.data_dir={data_dir}")
 
     # Override the split field if it is provided.
     if dataset_preprocess_config.split:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

As is described in #2506, we should allow users to mutate the dataset preprocessing configurations in SDK, which is necessary if we decide to support custom datasets.

So this PR:

- Add support for data preprocessing configurations in SDK

/cc @kubeflow/wg-training-leads @astefanutti 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2506

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
