### PR TITLE
KEP-2401: Support loading local LLMs

### DIFF
--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -77,7 +77,7 @@ spec:
                         - dataset=torchtune.datasets.instruct_dataset
                         - dataset.source=parquet
                         - dataset.data_dir=/workspace/dataset/data
-                        - output_dir=/workspace/model/llama3_2/1B
+                        - output_dir=/workspace/model/output
                         - tokenizer.path=/workspace/model/original/tokenizer.model
                         - checkpointer.checkpoint_dir=/workspace/model
                       resources:

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -77,6 +77,9 @@ spec:
                         - dataset=torchtune.datasets.instruct_dataset
                         - dataset.source=parquet
                         - dataset.data_dir=/workspace/dataset/data
+                        - output_dir=/workspace/model/llama3_2/1B
+                        - tokenizer.path=/workspace/model/Llama-3.2-1B-Instruct/original/tokenizer.model
+                        - checkpointer.checkpoint_dir=/workspace/model/Llama-3.2-1B-Instruct
                       resources:
                         limits:
                           nvidia.com/gpu: 2

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -30,7 +30,7 @@ spec:
                   volumes:
                     - name: initializer
                       persistentVolumeClaim:
-                        claimName: initializer
+                        claimName: torchtune-llama3.2-1b
         - name: model-initializer
           dependsOn:
             - name: dataset-initializer
@@ -54,7 +54,7 @@ spec:
                   volumes:
                     - name: initializer
                       persistentVolumeClaim:
-                        claimName: initializer
+                        claimName: torchtune-llama3.2-1b
         - name: node
           dependsOn:
             - name: model-initializer
@@ -78,8 +78,8 @@ spec:
                         - dataset.source=parquet
                         - dataset.data_dir=/workspace/dataset/data
                         - output_dir=/workspace/model/llama3_2/1B
-                        - tokenizer.path=/workspace/model/Llama-3.2-1B-Instruct/original/tokenizer.model
-                        - checkpointer.checkpoint_dir=/workspace/model/Llama-3.2-1B-Instruct
+                        - tokenizer.path=/workspace/model/original/tokenizer.model
+                        - checkpointer.checkpoint_dir=/workspace/model
                       resources:
                         limits:
                           nvidia.com/gpu: 2
@@ -91,4 +91,4 @@ spec:
                   volumes:
                     - name: initializer
                       persistentVolumeClaim:
-                        claimName: initializer
+                        claimName: torchtune-llama3.2-1b

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -77,6 +77,9 @@ spec:
                         - dataset=torchtune.datasets.instruct_dataset
                         - dataset.source=parquet
                         - dataset.data_dir=/workspace/dataset/data
+                        - output_dir=/workspace/model/llama3_2/3B
+                        - tokenizer.path=/workspace/model/Llama-3.2-3B-Instruct/original/tokenizer.model
+                        - checkpointer.checkpoint_dir=/workspace/model/Llama-3.2-3B-Instruct
                       resources:
                         limits:
                           nvidia.com/gpu: 2

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -77,7 +77,7 @@ spec:
                         - dataset=torchtune.datasets.instruct_dataset
                         - dataset.source=parquet
                         - dataset.data_dir=/workspace/dataset/data
-                        - output_dir=/workspace/model/llama3_2/3B
+                        - output_dir=/workspace/model/output
                         - tokenizer.path=/workspace/model/original/tokenizer.model
                         - checkpointer.checkpoint_dir=/workspace/model
                       resources:

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -30,7 +30,7 @@ spec:
                   volumes:
                     - name: initializer
                       persistentVolumeClaim:
-                        claimName: initializer
+                        claimName: torchtune-llama3.2-3b
         - name: model-initializer
           dependsOn:
             - name: dataset-initializer
@@ -54,7 +54,7 @@ spec:
                   volumes:
                     - name: initializer
                       persistentVolumeClaim:
-                        claimName: initializer
+                        claimName: torchtune-llama3.2-3b
         - name: node
           dependsOn:
             - name: model-initializer
@@ -78,8 +78,8 @@ spec:
                         - dataset.source=parquet
                         - dataset.data_dir=/workspace/dataset/data
                         - output_dir=/workspace/model/llama3_2/3B
-                        - tokenizer.path=/workspace/model/Llama-3.2-3B-Instruct/original/tokenizer.model
-                        - checkpointer.checkpoint_dir=/workspace/model/Llama-3.2-3B-Instruct
+                        - tokenizer.path=/workspace/model/original/tokenizer.model
+                        - checkpointer.checkpoint_dir=/workspace/model
                       resources:
                         limits:
                           nvidia.com/gpu: 2
@@ -91,4 +91,4 @@ spec:
                   volumes:
                     - name: initializer
                       persistentVolumeClaim:
-                        claimName: initializer
+                        claimName: torchtune-llama3.2-3b

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -142,6 +142,15 @@ const (
 
 	// TorchTuneFullFinetuneMultiNodesConfigSuffix is the config suffix for the multi node distributed full finetune.
 	TorchTuneFullFinetuneMultiNodesConfigSuffix string = "_full_multinode"
+
+	// TorchTuneModelOutputDir is the config item name for the model output directory.
+	TorchTuneModelOutputDir string = "output_dir"
+
+	// TorchTuneTokenizerPath is the config item name for the tokenizer path.
+	TorchTuneTokenizerPath string = "tokenizer.path"
+
+	// TorchTuneCheckpointerDir is the config item name for the checkpointer directory.
+	TorchTuneCheckpointDir string = "checkpointer.checkpoint_dir"
 )
 
 const (
@@ -171,3 +180,32 @@ var (
 	// TorchTuneEntrypoint is the entrypoint for the torchtune.
 	TorchTuneEntrypoint = []string{"tune", "run"}
 )
+
+type TorchTuneModel struct {
+	// Name is the name of the model in HuggingFace.
+	Name string
+
+	// CheckpointDir is the checkpointer directory relative to the model repo.
+	CheckpointDir string
+
+	// TokenizerPath is the tokenizer path relative to the model repo.
+	TokenizerPath string
+}
+
+var DefaultTorchTuneModels = map[string]TorchTuneModel{
+	TORCHTUNE_MODEL_LLAMA3_2_1B: {
+		Name:          "Llama-3.2-1B-Instruct",
+		CheckpointDir: "/",
+		TokenizerPath: "/original/tokenizer.model",
+	},
+	TORCHTUNE_MODEL_LLAMA3_2_7B: {
+		Name:          "Llama-3.2-1B-Instruct",
+		CheckpointDir: "/",
+		TokenizerPath: "/original/tokenizer.model",
+	},
+	TORCHTUNE_MODEL_LLAMA3_3_70B: {
+		Name:          "Llama-3.3-70B-Instruct",
+		CheckpointDir: "/",
+		TokenizerPath: "/original/tokenizer.model",
+	},
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -182,24 +182,18 @@ var (
 )
 
 type TorchTuneModel struct {
-	// CheckpointDir is the checkpointer directory relative to the model repo.
-	CheckpointDir string
-
 	// TokenizerPath is the tokenizer path relative to the model repo.
 	TokenizerPath string
 }
 
 var DefaultTorchTuneModels = map[string]TorchTuneModel{
 	TORCHTUNE_MODEL_LLAMA3_2_1B: {
-		CheckpointDir: "/",
 		TokenizerPath: "/original/tokenizer.model",
 	},
 	TORCHTUNE_MODEL_LLAMA3_2_7B: {
-		CheckpointDir: "/",
 		TokenizerPath: "/original/tokenizer.model",
 	},
 	TORCHTUNE_MODEL_LLAMA3_3_70B: {
-		CheckpointDir: "/",
 		TokenizerPath: "/original/tokenizer.model",
 	},
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -180,20 +180,3 @@ var (
 	// TorchTuneEntrypoint is the entrypoint for the torchtune.
 	TorchTuneEntrypoint = []string{"tune", "run"}
 )
-
-type TorchTuneModel struct {
-	// TokenizerPath is the tokenizer path relative to the model repo.
-	TokenizerPath string
-}
-
-var DefaultTorchTuneModels = map[string]TorchTuneModel{
-	TORCHTUNE_MODEL_LLAMA3_2_1B: {
-		TokenizerPath: "/original/tokenizer.model",
-	},
-	TORCHTUNE_MODEL_LLAMA3_2_7B: {
-		TokenizerPath: "/original/tokenizer.model",
-	},
-	TORCHTUNE_MODEL_LLAMA3_3_70B: {
-		TokenizerPath: "/original/tokenizer.model",
-	},
-}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -182,9 +182,6 @@ var (
 )
 
 type TorchTuneModel struct {
-	// Name is the name of the model in HuggingFace.
-	Name string
-
 	// CheckpointDir is the checkpointer directory relative to the model repo.
 	CheckpointDir string
 
@@ -194,17 +191,14 @@ type TorchTuneModel struct {
 
 var DefaultTorchTuneModels = map[string]TorchTuneModel{
 	TORCHTUNE_MODEL_LLAMA3_2_1B: {
-		Name:          "Llama-3.2-1B-Instruct",
 		CheckpointDir: "/",
 		TokenizerPath: "/original/tokenizer.model",
 	},
 	TORCHTUNE_MODEL_LLAMA3_2_7B: {
-		Name:          "Llama-3.2-1B-Instruct",
 		CheckpointDir: "/",
 		TokenizerPath: "/original/tokenizer.model",
 	},
 	TORCHTUNE_MODEL_LLAMA3_3_70B: {
-		Name:          "Llama-3.3-70B-Instruct",
 		CheckpointDir: "/",
 		TokenizerPath: "/original/tokenizer.model",
 	},

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -179,4 +179,7 @@ var (
 
 	// TorchTuneEntrypoint is the entrypoint for the torchtune.
 	TorchTuneEntrypoint = []string{"tune", "run"}
+
+	// TorchTuneImmutableConfigs is the set of immutable configs for the TorchTune Trainer.
+	TorchTuneImmutableConfigs = sets.New(TorchTuneModelOutputDir, TorchTuneTokenizerPath, TorchTuneCheckpointDir)
 )

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -515,7 +515,22 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							Obj().
 							Spec,
 					).
-					Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					Container(
+						constants.Node,
+						constants.Node,
+						"test:runtime",
+						[]string{
+							"tune",
+							"run",
+							constants.TorchTuneFullFinetuneDistributed,
+							"--config llama3_3/70B_full_multinode.yaml",
+							"output_dir=/workspace/model/llama3_3/70B",
+							"tokenizer.path=/workspace/model/original/tokenizer.model",
+							"checkpointer.checkpoint_dir=/workspace/model",
+						},
+						[]string{"runtime"},
+						resRequests,
+					).
 					Obj(),
 			).Obj(),
 			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -555,6 +555,9 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							fmt.Sprintf("%s %s", constants.TorchTuneArgRdzvEndpoint, "test-job-node-0-0.test-job:29500"),
 							constants.TorchTuneFullFinetuneDistributed,
 							"--config llama3_3/70B_full_multinode.yaml",
+							"output_dir=/workspace/model/llama3_3/70B",
+							"tokenizer.path=/workspace/model/Llama-3.3-70B-Instruct/original/tokenizer.model",
+							"checkpointer.checkpoint_dir=/workspace/model/Llama-3.3-70B-Instruct",
 						},
 						[]string{
 							"dtype=fp16",

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -556,8 +556,8 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							constants.TorchTuneFullFinetuneDistributed,
 							"--config llama3_3/70B_full_multinode.yaml",
 							"output_dir=/workspace/model/llama3_3/70B",
-							"tokenizer.path=/workspace/model/Llama-3.3-70B-Instruct/original/tokenizer.model",
-							"checkpointer.checkpoint_dir=/workspace/model/Llama-3.3-70B-Instruct",
+							"tokenizer.path=/workspace/model/original/tokenizer.model",
+							"checkpointer.checkpoint_dir=/workspace/model",
 						},
 						[]string{
 							"dtype=fp16",

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -210,13 +210,10 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 			newCommand = append(newCommand, recipe, fmt.Sprintf("--config %s", config))
 
 			// 3. Load local model and export the fine-tuned model.
-			tokenizerPath := getTokenizerPath(model)
-			checkpointDir := getCheckpointDir(model)
-			outputDir := getModelOutputPath(model)
 			newCommand = append(newCommand,
-				fmt.Sprintf("%s=%s", constants.TorchTuneModelOutputDir, outputDir),
-				fmt.Sprintf("%s=%s", constants.TorchTuneTokenizerPath, tokenizerPath),
-				fmt.Sprintf("%s=%s", constants.TorchTuneCheckpointDir, checkpointDir),
+				fmt.Sprintf("%s=%s", constants.TorchTuneModelOutputDir, getModelOutputPath(model)),
+				fmt.Sprintf("%s=%s", constants.TorchTuneTokenizerPath, getTokenizerPath(model)),
+				fmt.Sprintf("%s=%s", constants.TorchTuneCheckpointDir, getCheckpointDir(model)),
 			)
 
 			trainJob.Spec.Trainer.Command = append(trainJob.Spec.Trainer.Command, newCommand...)

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -19,7 +19,6 @@ package torch
 import (
 	"context"
 	"fmt"
-	"path"
 	"slices"
 	"strings"
 
@@ -209,13 +208,6 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 			recipe, config := getRecipeAndConfig(numNodes, numProcPerNode, model, trainJob.Spec.Trainer.Args)
 			newCommand = append(newCommand, recipe, fmt.Sprintf("--config %s", config))
 
-			// 3. Load local model and export the fine-tuned model.
-			newCommand = append(newCommand,
-				fmt.Sprintf("%s=%s", constants.TorchTuneModelOutputDir, getModelOutputPath(model)),
-				fmt.Sprintf("%s=%s", constants.TorchTuneTokenizerPath, getTokenizerPath(model)),
-				fmt.Sprintf("%s=%s", constants.TorchTuneCheckpointDir, constants.ModelMountPath),
-			)
-
 			trainJob.Spec.Trainer.Command = append(trainJob.Spec.Trainer.Command, newCommand...)
 		}
 		// Add container port for the headless service.
@@ -254,18 +246,6 @@ func getRecipeAndConfig(numNodes int32, numProcPerNode intstr.IntOrString, model
 	}
 
 	return recipe, fmt.Sprintf("%s%s.yaml", model, suffix)
-}
-
-// getTokenizerPath returns the path to local tokenizer for the given model name.
-func getTokenizerPath(model string) string {
-	torchtuneModel := constants.DefaultTorchTuneModels[model]
-
-	return path.Join(constants.ModelMountPath, torchtuneModel.TokenizerPath)
-}
-
-// getModelOutputPath returns the model export path for the given model name.
-func getModelOutputPath(model string) string {
-	return path.Join(constants.ModelMountPath, model)
 }
 
 func getModelFromRuntimeRef(runtimeRefName string) string {

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -213,7 +213,7 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 			newCommand = append(newCommand,
 				fmt.Sprintf("%s=%s", constants.TorchTuneModelOutputDir, getModelOutputPath(model)),
 				fmt.Sprintf("%s=%s", constants.TorchTuneTokenizerPath, getTokenizerPath(model)),
-				fmt.Sprintf("%s=%s", constants.TorchTuneCheckpointDir, getCheckpointDir(model)),
+				fmt.Sprintf("%s=%s", constants.TorchTuneCheckpointDir, constants.ModelMountPath),
 			)
 
 			trainJob.Spec.Trainer.Command = append(trainJob.Spec.Trainer.Command, newCommand...)
@@ -261,13 +261,6 @@ func getTokenizerPath(model string) string {
 	torchtuneModel := constants.DefaultTorchTuneModels[model]
 
 	return path.Join(constants.ModelMountPath, torchtuneModel.TokenizerPath)
-}
-
-// getCheckpointDir returns the path to local model for the given model name.
-func getCheckpointDir(model string) string {
-	torchtuneModel := constants.DefaultTorchTuneModels[model]
-
-	return path.Join(constants.ModelMountPath, torchtuneModel.CheckpointDir)
 }
 
 // getModelOutputPath returns the model export path for the given model name.

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -214,9 +214,9 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 			checkpointDir := getCheckpointDir(model)
 			outputDir := getModelOutputPath(model)
 			newCommand = append(newCommand,
+				fmt.Sprintf("%s=%s", constants.TorchTuneModelOutputDir, outputDir),
 				fmt.Sprintf("%s=%s", constants.TorchTuneTokenizerPath, tokenizerPath),
 				fmt.Sprintf("%s=%s", constants.TorchTuneCheckpointDir, checkpointDir),
-				fmt.Sprintf("%s=%s", constants.TorchTuneModelOutputDir, outputDir),
 			)
 
 			trainJob.Spec.Trainer.Command = append(trainJob.Spec.Trainer.Command, newCommand...)

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -262,17 +262,15 @@ func getRecipeAndConfig(numNodes int32, numProcPerNode intstr.IntOrString, model
 // getTokenizerPath returns the path to local tokenizer for the given model name.
 func getTokenizerPath(model string) string {
 	torchtuneModel := constants.DefaultTorchTuneModels[model]
-	workDir := path.Join(constants.ModelMountPath, torchtuneModel.Name)
 
-	return path.Join(workDir, torchtuneModel.TokenizerPath)
+	return path.Join(constants.ModelMountPath, torchtuneModel.TokenizerPath)
 }
 
 // getCheckpointDir returns the path to local model for the given model name.
 func getCheckpointDir(model string) string {
 	torchtuneModel := constants.DefaultTorchTuneModels[model]
-	workDir := path.Join(constants.ModelMountPath, torchtuneModel.Name)
 
-	return path.Join(workDir, torchtuneModel.CheckpointDir)
+	return path.Join(constants.ModelMountPath, torchtuneModel.CheckpointDir)
 }
 
 // getModelOutputPath returns the model export path for the given model name.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

As I described in https://github.com/kubeflow/trainer/issues/2641, we need to load local LLMs downloaded by model-initializer to make the fine-tuning pipeline work as expected.

In this PR, I:

- Mutate the some torchtune config items in torch plugin
    1. `tokenizer.path`: the path to load tokenizer
    2. `checkpointer.checkpoint_dir`: the path to load the model checkpointer
    3. `output_dir`: the path to store the fine-tuned model
- Update UTs for loading local LLMs
- Update manifests to load local LLMs

/cc @kubeflow/wg-training-leads @astefanutti 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2641

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
