### PR TITLE
chore(build): Support Podman to run OpenAPI generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ HELM_CHART_TESTING_VERSION ?= v3.12.0
 HELM_DOCS_VERSION ?= v1.14.2
 YQ_VERSION ?= v4.45.1
 
+# Container runtime (docker or podman)
+CONTAINER_RUNTIME ?=
+
 # Tool binaries
 GINKGO ?= $(LOCALBIN)/ginkgo
 ENVTEST ?= $(LOCALBIN)/setup-envtest
@@ -122,8 +125,8 @@ manifests: controller-gen ## Generate manifests.
 generate: go-mod-download manifests ## Generate APIs and SDK.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate/boilerplate.go.txt" paths="./pkg/apis/..."
 	hack/update-codegen.sh
-	hack/python-api/gen-api.sh
-	hack/python-sdk/gen-sdk.sh
+	CONTAINER_RUNTIME=$(CONTAINER_RUNTIME) hack/python-api/gen-api.sh
+	CONTAINER_RUNTIME=$(CONTAINER_RUNTIME) hack/python-sdk/gen-sdk.sh
 
 .PHONY: go-mod-download
 go-mod-download: ## Run go mod download to download modules.

--- a/hack/python-api/gen-api.sh
+++ b/hack/python-api/gen-api.sh
@@ -19,6 +19,13 @@
 set -o errexit
 set -o nounset
 
+# Source container runtime utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../scripts/container-runtime.sh"
+
+# Setup container runtime
+setup_container_runtime
+
 # TODO (andreyvelich): Read this data from the global VERSION file.
 API_VERSION="2.0.0"
 API_OUTPUT_PATH="api/python_api"
@@ -29,9 +36,9 @@ TRAINER_ROOT="$(pwd)"
 SWAGGER_CODEGEN_CONF="hack/python-api/swagger_config.json"
 SWAGGER_CODEGEN_FILE="api/openapi-spec/swagger.json"
 
-echo "Generating Python API models for Kubeflow Trainer V2 ..."
+echo "Generating Python API models for Kubeflow Trainer V2 using ${CONTAINER_RUNTIME}..."
 # We need to add user to allow container override existing files.
-docker run --user "$(id -u)":"$(id -g)" --rm \
+${CONTAINER_RUNTIME} run --user "$(id -u)":"$(id -g)" --rm \
   -v "${TRAINER_ROOT}:/local" docker.io/openapitools/openapi-generator-cli:${OPENAPI_GENERATOR_VERSION} generate \
   -g python \
   -i "local/${SWAGGER_CODEGEN_FILE}" \

--- a/hack/python-sdk/gen-sdk.sh
+++ b/hack/python-sdk/gen-sdk.sh
@@ -19,6 +19,13 @@
 set -o errexit
 set -o nounset
 
+# Source container runtime utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../scripts/container-runtime.sh"
+
+# Setup container runtime
+setup_container_runtime
+
 # TODO (andreyvelich): Read this data from the global VERSION file.
 SDK_VERSION="0.1.0"
 SDK_OUTPUT_PATH="sdk"
@@ -28,9 +35,9 @@ TRAINER_ROOT="$(pwd)"
 SWAGGER_CODEGEN_CONF="hack/python-sdk/swagger_config.json"
 SWAGGER_CODEGEN_FILE="api/openapi-spec/swagger.json"
 
-echo "Generating Python SDK for Kubeflow Trainer V2 ..."
+echo "Generating Python SDK for Kubeflow Trainer V2 using ${CONTAINER_RUNTIME}..."
 # We need to add user to allow container override existing files.
-docker run --user "$(id -u)":"$(id -g)" --rm \
+${CONTAINER_RUNTIME} run --user "$(id -u)":"$(id -g)" --rm \
   -v "${TRAINER_ROOT}:/local" docker.io/openapitools/openapi-generator-cli:${OPENAPI_GENERATOR_VERSION} generate \
   -g python \
   -i "local/${SWAGGER_CODEGEN_FILE}" \

--- a/hack/scripts/container-runtime.sh
+++ b/hack/scripts/container-runtime.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Container runtime detection and setup utilities
+
+# Detect available container runtime (Docker or Podman)
+detect_container_runtime() {
+  if command -v docker &> /dev/null; then
+    echo "docker"
+  elif command -v podman &> /dev/null; then
+    echo "podman"
+  else
+    echo "Error: Neither docker nor podman found" >&2
+    exit 1
+  fi
+}
+
+# Setup container runtime variable
+# Uses provided CONTAINER_RUNTIME environment variable or auto-detects
+setup_container_runtime() {
+  if [[ -z "${CONTAINER_RUNTIME:-}" ]]; then
+    CONTAINER_RUNTIME=$(detect_container_runtime)
+  fi
+  export CONTAINER_RUNTIME
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

This makes running the OpenAPI generator container with Podman possible as an alternative to Docker.

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
