### PR TITLE
fix(manifests): Update manifests to enable LLM fine-tuning workflow with CTR and TrainJob yaml files

### DIFF
--- a/manifests/base/runtimes/kustomization.yaml
+++ b/manifests/base/runtimes/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - mlx_distributed.yaml
   - mpi_distributed.yaml
   - torch_distributed.yaml
+  - torchtune

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -72,12 +72,14 @@ spec:
                       command:
                         - tune
                         - run
+                        - --rdzv_endpoint=localhost:29500
                         - full_finetune_distributed
-                        - --config llama3_2/1B_full.yaml
+                        - --config
+                        - llama3_2/1B_full
                         - dataset=torchtune.datasets.instruct_dataset
                         - dataset.source=parquet
                         - dataset.data_dir=/workspace/dataset/data
-                        - output_dir=/workspace/model/output
+                        - output_dir=/workspace/output/model
                         - tokenizer.path=/workspace/model/original/tokenizer.model
                         - checkpointer.checkpoint_dir=/workspace/model
                       resources:
@@ -87,6 +89,8 @@ spec:
                         - mountPath: /workspace/dataset
                           name: initializer
                         - mountPath: /workspace/model
+                          name: initializer
+                        - mountPath: /workspace/output
                           name: initializer
                   volumes:
                     - name: initializer

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -25,7 +25,7 @@ spec:
                         - name: STORAGE_URI
                           value: hf://tatsu-lab/alpaca
                       volumeMounts:
-                        - mountPath: /workspace/dataset
+                        - mountPath: /workspace
                           name: initializer
                   volumes:
                     - name: initializer
@@ -50,7 +50,7 @@ spec:
                           value: hf://meta-llama/Llama-3.2-1B-Instruct
                       volumeMounts:
                         - name: initializer
-                          mountPath: /workspace/model
+                          mountPath: /workspace
                   volumes:
                     - name: initializer
                       persistentVolumeClaim:
@@ -86,11 +86,7 @@ spec:
                         limits:
                           nvidia.com/gpu: 2
                       volumeMounts:
-                        - mountPath: /workspace/dataset
-                          name: initializer
-                        - mountPath: /workspace/model
-                          name: initializer
-                        - mountPath: /workspace/output
+                        - mountPath: /workspace
                           name: initializer
                   volumes:
                     - name: initializer

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -6,7 +6,7 @@ spec:
   mlPolicy:
     numNodes: 1
     torch:
-      numProcPerNode: 2
+      numProcPerNode: auto
   template:
     spec:
       replicatedJobs:

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -79,7 +79,7 @@ spec:
                         - dataset=torchtune.datasets.instruct_dataset
                         - dataset.source=parquet
                         - dataset.data_dir=/workspace/dataset/data
-                        - output_dir=/workspace/output/model
+                        - output_dir=/workspace/output
                         - tokenizer.path=/workspace/model/original/tokenizer.model
                         - checkpointer.checkpoint_dir=/workspace/model
                       resources:

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -25,7 +25,7 @@ spec:
                         - name: STORAGE_URI
                           value: hf://tatsu-lab/alpaca
                       volumeMounts:
-                        - mountPath: /workspace/dataset
+                        - mountPath: /workspace
                           name: initializer
                   volumes:
                     - name: initializer
@@ -50,7 +50,7 @@ spec:
                           value: hf://meta-llama/Llama-3.2-3B-Instruct
                       volumeMounts:
                         - name: initializer
-                          mountPath: /workspace/model
+                          mountPath: /workspace
                   volumes:
                     - name: initializer
                       persistentVolumeClaim:
@@ -86,11 +86,7 @@ spec:
                         limits:
                           nvidia.com/gpu: 2
                       volumeMounts:
-                        - mountPath: /workspace/dataset
-                          name: initializer
-                        - mountPath: /workspace/model
-                          name: initializer
-                        - mountPath: /workspace/output
+                        - mountPath: /workspace
                           name: initializer
                   volumes:
                     - name: initializer

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -6,7 +6,7 @@ spec:
   mlPolicy:
     numNodes: 1
     torch:
-      numProcPerNode: 2
+      numProcPerNode: auto
   template:
     spec:
       replicatedJobs:

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -79,7 +79,7 @@ spec:
                         - dataset=torchtune.datasets.instruct_dataset
                         - dataset.source=parquet
                         - dataset.data_dir=/workspace/dataset/data
-                        - output_dir=/workspace/output/model
+                        - output_dir=/workspace/output
                         - tokenizer.path=/workspace/model/original/tokenizer.model
                         - checkpointer.checkpoint_dir=/workspace/model
                       resources:

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -72,12 +72,14 @@ spec:
                       command:
                         - tune
                         - run
+                        - --rdzv_endpoint=localhost:29500
                         - full_finetune_distributed
-                        - --config llama3_2/3B_full.yaml
+                        - --config
+                        - llama3_2/3B_full
                         - dataset=torchtune.datasets.instruct_dataset
                         - dataset.source=parquet
                         - dataset.data_dir=/workspace/dataset/data
-                        - output_dir=/workspace/model/output
+                        - output_dir=/workspace/output/model
                         - tokenizer.path=/workspace/model/original/tokenizer.model
                         - checkpointer.checkpoint_dir=/workspace/model
                       resources:
@@ -87,6 +89,8 @@ spec:
                         - mountPath: /workspace/dataset
                           name: initializer
                         - mountPath: /workspace/model
+                          name: initializer
+                        - mountPath: /workspace/output
                           name: initializer
                   volumes:
                     - name: initializer

--- a/manifests/overlays/manager/kustomization.yaml
+++ b/manifests/overlays/manager/kustomization.yaml
@@ -15,7 +15,8 @@ resources:
 # Update the Kubeflow Trainer controller manager image tag.
 images:
   - name: ghcr.io/kubeflow/trainer/trainer-controller-manager
-    newTag: latest
+    newName: docker.io/electronicwaste/trainer-controller-manager
+    newTag: v0.1
 
 # Secret for the Kubeflow Training webhook.
 secretGenerator:

--- a/manifests/overlays/manager/kustomization.yaml
+++ b/manifests/overlays/manager/kustomization.yaml
@@ -15,8 +15,7 @@ resources:
 # Update the Kubeflow Trainer controller manager image tag.
 images:
   - name: ghcr.io/kubeflow/trainer/trainer-controller-manager
-    newName: docker.io/electronicwaste/trainer-controller-manager
-    newTag: v0.1
+    newTag: latest
 
 # Secret for the Kubeflow Training webhook.
 secretGenerator:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR fixed some errors occurred in the LLM fine-tuning workflow, which is conducted by applying TrainJob yaml files:

```
apiVersion: trainer.kubeflow.org/v1alpha1
kind: TrainJob
metadata:
  name: torchtune-llama3-2-1b
  namespace: kubeflow
spec:
  runtimeRef:
    name: torchtune-llama3.2-1b
  trainer:
    resourcesPerNode:
      requests:
        nvidia.com/gpu: 1
      limits:
        nvidia.com/gpu: 1
    numProcPerNode: 1
  initializer:
    model:
      env:
        - name: ACCESS_TOKEN
          value: <MY_HF_TOKEN>
```

### Results

- Model Initializer

```
kubectl logs torchtune-llama3-2-1b-model-initializer-0-0-hrcws -n kubeflow
2025-06-14T05:58:37Z INFO     [__main__.py:16] Starting pre-trained model initialization
2025-06-14T05:58:37Z INFO     [huggingface.py:26] Downloading model: meta-llama/Llama-3.2-1B-Instruct
2025-06-14T05:58:37Z INFO     [huggingface.py:27] ----------------------------------------
Fetching 8 files: 100%|██████████| 8/8 [00:43<00:00,  5.41s/it]
2025-06-14T05:59:21Z INFO     [huggingface.py:43] Model has been downloaded
```

- Dataset Initializer

```
kubectl logs torchtune-llama3-2-1b-dataset-initializer-0-0-97k42 -n kubeflow
2025-06-14T05:58:18Z INFO     [__main__.py:16] Starting dataset initialization
2025-06-14T05:58:18Z INFO     [huggingface.py:28] Downloading dataset: tatsu-lab/alpaca
2025-06-14T05:58:18Z INFO     [huggingface.py:29] ----------------------------------------
Fetching 3 files: 100%|██████████| 3/3 [00:02<00:00,  1.47it/s]
2025-06-14T05:58:21Z INFO     [huggingface.py:40] Dataset has been downloaded
```

- TorchTune Trainer

```
INFO:torchtune.utils._logging:Running FullFinetuneRecipeDistributed with resolved config:

batch_size: 4
checkpointer:
  _component_: torchtune.training.FullModelHFCheckpointer
  checkpoint_dir: /workspace/model
  checkpoint_files:
  - model.safetensors
  model_type: LLAMA3_2
  output_dir: /workspace/output/model
  recipe_checkpoint: null
clip_grad_norm: null
compile: false
dataset:
  _component_: torchtune.datasets.instruct_dataset
  data_dir: /workspace/dataset/data
  packed: false
  source: parquet
device: cuda
dtype: bf16
enable_activation_checkpointing: false
enable_activation_offloading: false
epochs: 1
gradient_accumulation_steps: 8
log_every_n_steps: 1
log_peak_memory_stats: true
loss:
  _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
max_steps_per_epoch: null
metric_logger:
  _component_: torchtune.training.metric_logging.DiskLogger
  log_dir: /workspace/output/model/logs
model:
  _component_: torchtune.models.llama3_2.llama3_2_1b
optimizer:
  _component_: torch.optim.AdamW
  fused: true
  lr: 2.0e-05
optimizer_in_bwd: false
output_dir: /workspace/output/model
profiler:
  _component_: torchtune.training.setup_torch_profiler
  active_steps: 2
  cpu: true
  cuda: true
  enabled: false
  num_cycles: 1
  output_dir: /workspace/output/model/profiling_outputs
  profile_memory: false
  record_shapes: true
  wait_steps: 5
  warmup_steps: 3
  with_flops: false
  with_stack: false
resume_from_checkpoint: false
seed: null
shuffle: true
tokenizer:
  _component_: torchtune.models.llama3.llama3_tokenizer
  max_seq_len: null
  path: /workspace/model/original/tokenizer.model

DEBUG:torchtune.utils._logging:Setting manual seed to local seed 3412313428. Local seed is seed + rank = 3412313428 + 0
Writing logs to /workspace/output/model/logs/log_1749908355.txt
INFO:torchtune.utils._logging:Distributed training is enabled. Instantiating model and loading checkpoint on Rank 0 ...
INFO:torchtune.utils._logging:Instantiating model and loading checkpoint took 19.08 secs
INFO:torchtune.utils._logging:Memory stats after model init:
        GPU peak memory allocation: 2.33 GiB
        GPU peak memory reserved: 2.34 GiB
        GPU peak memory active: 2.33 GiB
INFO:torchtune.utils._logging:Optimizer is initialized.
INFO:torchtune.utils._logging:Loss is initialized.
Generating train split: 52002 examples [00:00, 190018.20 examples/s]
INFO:torchtune.utils._logging:No learning rate scheduler configured. Using constant learning rate.
WARNING:torchtune.utils._logging: Profiling disabled.
INFO:torchtune.utils._logging: Profiler config after instantiation: {'enabled': False}
1|99|Loss: 1.545789361000061:   6%|▌         | 100/1625 [01:16<19:08,  1.33it/%
```

/cc @kubeflow/wg-training-leads @astefanutti 
/milestone v2.0

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
