### PR TITLE
chore(ci): Add more workaround no space left on device

### DIFF
--- a/.github/workflows/free-up-disk-space/action.yaml
+++ b/.github/workflows/free-up-disk-space/action.yaml
@@ -28,6 +28,22 @@ runs:
       run: |
         docker image prune -a -f
         docker system df
+        echo "Disk usage after image prune:"
+        df -hT
+
+    - name: Turn swap off
+      shell: bash
+      run: |
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        echo "Disk usage after swap off:"
+        df -hT
+
+    - name: apt clean
+      shell: bash
+      run: |
+        sudo apt clean
+        echo "Disk usage after apt clean:"
         df -hT
 
     - name: Move docker data directory


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR tries to free more space to fix "No space left on device" errors that have surfaced in #2636.

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
