### PR TITLE
fix(rbac): Add required RBAC to update ClusterTrainingRuntimes on OpenShift

### DIFF
--- a/manifests/base/rbac/role.yaml
+++ b/manifests/base/rbac/role.yaml
@@ -52,9 +52,12 @@ rules:
   resources:
   - clustertrainingruntimes
   - trainingruntimes
+  - trainjobs
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - trainer.kubeflow.org
@@ -67,13 +70,3 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - trainer.kubeflow.org
-  resources:
-  - trainjobs
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch

--- a/pkg/controller/clustertrainingruntime_controller.go
+++ b/pkg/controller/clustertrainingruntime_controller.go
@@ -62,7 +62,7 @@ func NewClusterTrainingRuntimeReconciler(cli client.Client, recorder record.Even
 	}
 }
 
-// +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=clustertrainingruntimes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=clustertrainingruntimes,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=clustertrainingruntimes/finalizers,verbs=get;update;patch
 
 func (r *ClusterTrainingRuntimeReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {

--- a/pkg/controller/trainingruntime_controller.go
+++ b/pkg/controller/trainingruntime_controller.go
@@ -66,7 +66,7 @@ func NewTrainingRuntimeReconciler(cli client.Client, recorder record.EventRecord
 	}
 }
 
-// +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainingruntimes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainingruntimes,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainingruntimes/finalizers,verbs=get;update;patch
 
 func (r *TrainingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the required verbs so the TR and CTR controllers can add the `resource-in-use` finalizer on OpenShift.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2681

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
