### PR TITLE
fix(manifests): fix position of labels of dataset-initializer from pod to job

### DIFF
--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -12,11 +12,11 @@ spec:
       replicatedJobs:
         - name: dataset-initializer
           template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer
             spec:
               template:
-                metadata:
-                  labels:
-                    trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer
                 spec:
                   containers:
                     - name: dataset-initializer

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -12,11 +12,11 @@ spec:
       replicatedJobs:
         - name: dataset-initializer
           template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer
             spec:
               template:
-                metadata:
-                  labels:
-                    trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer
                 spec:
                   containers:
                     - name: dataset-initializer


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This pull request updates the positions of labels for `dataset-initilizer` from `PodSpec` to `JobSpec` for TorchTune Llama `ClusterTrainingRuntimes`.

/cc @Electronic-Waste @kubeflow/wg-training-leads

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
