### PR TITLE
feat(operator): Add validation for required containers in replicatedJobs

### DIFF
--- a/pkg/util/testing/wrapper.go
+++ b/pkg/util/testing/wrapper.go
@@ -270,6 +270,26 @@ func (j *JobSetWrapper) Container(rJobName, containerName, image string, command
 	return j
 }
 
+func (j *JobSetWrapper) ReplaceContainer(rJobName, containerName, newContainerName, image string, command, args []string, res corev1.ResourceList) *JobSetWrapper {
+	for i, rJob := range j.Spec.ReplicatedJobs {
+		if rJob.Name == rJobName {
+			for k, container := range rJob.Template.Spec.Template.Spec.Containers {
+				if container.Name == containerName {
+					j.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.Containers[k] = corev1.Container{
+						Name:      newContainerName,
+						Image:     image,
+						Command:   command,
+						Args:      args,
+						Resources: corev1.ResourceRequirements{Requests: res},
+					}
+					return j
+				}
+			}
+		}
+	}
+	return j
+}
+
 func (j *JobSetWrapper) ContainerTrainerPorts(ports []corev1.ContainerPort) *JobSetWrapper {
 	for i, rJob := range j.Spec.ReplicatedJobs {
 		if rJob.Name == constants.Node {

--- a/pkg/webhooks/trainingruntime_webhook.go
+++ b/pkg/webhooks/trainingruntime_webhook.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	rJobReplicasErrorMsg = "always must be 1"
+	rJobReplicasErrorMsg       = "always must be 1"
 	rJobContainerNamesErrorMsg = "must contain the required container for the ancestor: %s"
 )
 

--- a/pkg/webhooks/trainingruntime_webhook_test.go
+++ b/pkg/webhooks/trainingruntime_webhook_test.go
@@ -56,8 +56,6 @@ func TestValidateReplicatedJobs(t *testing.T) {
 					"2", ""),
 				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(1).Child("replicas"),
 					"2", ""),
-				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(2).Child("replicas"),
-					"2", ""),
 				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(3).Child("replicas"),
 					"2", ""),
 			},

--- a/pkg/webhooks/trainingruntime_webhook_test.go
+++ b/pkg/webhooks/trainingruntime_webhook_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
@@ -59,6 +60,22 @@ func TestValidateReplicatedJobs(t *testing.T) {
 					"2", ""),
 				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(3).Child("replicas"),
 					"2", ""),
+			},
+		},
+		"missing required container in replicatedJobs": {
+			rJobs: testingutil.MakeJobSetWrapper("ns", "valid").
+				Replicas(1, constants.Launcher, constants.Node, constants.DatasetInitializer, constants.ModelInitializer).
+				ReplaceContainer(constants.DatasetInitializer, constants.DatasetInitializer, "test", "", []string{}, []string{}, corev1.ResourceList{}).
+				ReplaceContainer(constants.ModelInitializer, constants.ModelInitializer, "test", "", []string{}, []string{}, corev1.ResourceList{}).
+				ReplaceContainer(constants.Node, constants.Node, "test", "", []string{}, []string{}, corev1.ResourceList{}).
+				Obj().Spec.ReplicatedJobs,
+			wantError: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(0).Child("template").Child("spec").Child("template").Child("spec").Child("containers"),
+					[]corev1.Container{{Name: "test"}}, ""),
+				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(1).Child("template").Child("spec").Child("template").Child("spec").Child("containers"),
+					[]corev1.Container{{Name: "test"}}, ""),
+				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(2).Child("template").Child("spec").Child("template").Child("spec").Child("containers"),
+					[]corev1.Container{{Name: "test"}}, ""),
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Currently, we'll override the `node` container if the target replicatedJob has `trainer.kubeflow.org/trainjob-ancestor-step: trainer` label:

https://github.com/kubeflow/trainer/blob/ed5f859a24a8b19f8bb7eb09320188050295e713/pkg/runtime/framework/plugins/jobset/builder.go#L119-L151

This design works well in official runtimes provided by Kubeflow Trainer. However, when it comes to custom runtimes written by users, they may find that they failed to override the configs in the target replicatedJob using if they assign different name to `node` container (like `train`, `trainer`). This is tricky, error prone, and hard to figure out.

In order to avoid this scenario, I add an validation condition in the (Cluster)TrainingRuntime's webhook, and also provide som e UTs for it.

/cc @kubeflow/wg-training-leads @astefanutti @rudeigerc 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
