### PR TITLE
feat: support add pending, runing condition to trainjob

### DIFF
--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -50,6 +50,12 @@ type TrainJob struct {
 }
 
 const (
+	// TrainJobPending means that TrainJob is Pending.
+	TrainJobPending string = "Pending"
+
+	// TrainJobRunning means that TrainJob is Running.
+	TrainJobRunning string = "Running"
+
 	// TrainJobSuspended means that TrainJob is suspended.
 	TrainJobSuspended string = "Suspended"
 
@@ -61,6 +67,12 @@ const (
 )
 
 const (
+	// TrainJobPendingReason is the "Pending" condition reason
+	TrainJobPendingReason string = "Pending"
+
+	// TrainJobRunningReason is the "Running" condition reason
+	TrainJobRunningReason string = "Running"
+
 	// TrainJobSuspendedReason is the "Suspended" condition reason
 	// when the TrainJob is suspended.
 	TrainJobSuspendedReason string = "Suspended"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -3,10 +3,9 @@ package constants
 import (
 	"fmt"
 
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-
-	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 )
 
 const (
@@ -56,6 +55,14 @@ const (
 	// TrainJobResumedMessage is status condition message for the
 	// {"type": "Suspended", "status": "True", "reason": "Resumed"} condition.
 	TrainJobResumedMessage = "TrainJob is resumed"
+
+	// TrainJobPendingMessage is status condition message for the
+	// {"type": "Pending", "status": "True", "reason": "Pending"} condition.
+	TrainJobPendingMessage string = "TrainJob is pending"
+
+	// TrainJobRunningMessage is status condition message for the
+	// {"type": "Running", "status": "True", "reason": "Running"} condition.
+	TrainJobRunningMessage string = "TrainJob is running"
 
 	// Node is the name of the Job and container for the MPI launcher.
 	// When RunLauncherAsNode: true, for the launcher Job the container name is node.


### PR DESCRIPTION
**What this PR does / why we need it**:
Proposed additions:
Add Running status condition when the underlying JobSet/Jobs are actively executing
Add Pending status condition when the TrainJob is created but not yet running (e.g., waiting for resources, scheduling, etc.)

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #https://github.com/kubeflow/trainer/issues/2713

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
