### PR TITLE
feat(operator): force trainjob name to be compliant with RFC 1035 for jobset

### DIFF
--- a/pkg/webhooks/trainjob_webhook.go
+++ b/pkg/webhooks/trainjob_webhook.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -49,13 +51,21 @@ func (w *TrainJobWebhook) ValidateCreate(ctx context.Context, obj apiruntime.Obj
 	trainJob := obj.(*trainer.TrainJob)
 	log := ctrl.LoggerFrom(ctx).WithName("trainJob-webhook")
 	log.V(5).Info("Validating create", "TrainJob", klog.KObj(trainJob))
+
+	allErrs := field.ErrorList{}
+
+	// Check RFC 1035 name validation errors
+	for _, err := range validation.IsDNS1035Label(trainJob.Name) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), trainJob.Name, err))
+	}
+
 	runtimeRefGK := runtime.RuntimeRefToRuntimeRegistryKey(trainJob.Spec.RuntimeRef)
 	runtime, ok := w.runtimes[runtimeRefGK]
 	if !ok {
 		return nil, fmt.Errorf("unsupported runtime: %s", runtimeRefGK)
 	}
 	warnings, errors := runtime.ValidateObjects(ctx, nil, trainJob)
-	return warnings, errors.ToAggregate()
+	return warnings, append(allErrs, errors...).ToAggregate()
 }
 
 func (w *TrainJobWebhook) ValidateUpdate(ctx context.Context, oldObj apiruntime.Object, newObj apiruntime.Object) (admission.Warnings, error) {

--- a/pkg/webhooks/trainjob_webhook_test.go
+++ b/pkg/webhooks/trainjob_webhook_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2025 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/klog/v2/ktesting"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	runtimecore "github.com/kubeflow/trainer/v2/pkg/runtime/core"
+	testingutil "github.com/kubeflow/trainer/v2/pkg/util/testing"
+)
+
+func TestValidateCreate(t *testing.T) {
+	cases := map[string]struct {
+		obj          *trainer.TrainJob
+		wantError    field.ErrorList
+		wantWarnings admission.Warnings
+	}{
+		"valid trainjob name compliant with RFC 1035": {
+			obj: testingutil.MakeTrainJobWrapper("default", "valid-job-name").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
+				Obj(),
+			wantError:    nil,
+			wantWarnings: nil,
+		},
+		"invalid trainjob name with uppercase letters": {
+			obj: testingutil.MakeTrainJobWrapper("default", "Invalid-job-name").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
+				Obj(),
+			wantError: field.ErrorList{
+				&field.Error{
+					Type:     field.ErrorTypeInvalid,
+					Field:    "metadata.name",
+					BadValue: "Invalid-job-name",
+				},
+			},
+			wantWarnings: nil,
+		},
+		"unsupported runtime": {
+			obj: testingutil.MakeTrainJobWrapper("default", "valid-job-name").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "unsupported-runtime").
+				Obj(),
+			wantError: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "spec.RuntimeRef",
+					BadValue: trainer.RuntimeRef{
+						Name:     "unsupported-runtime",
+						APIGroup: ptr.To(trainer.SchemeGroupVersion.Group),
+						Kind:     ptr.To(trainer.ClusterTrainingRuntimeKind),
+					},
+				},
+			},
+			wantWarnings: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+
+			var cancel func()
+			ctx, cancel = context.WithCancel(ctx)
+			t.Cleanup(cancel)
+
+			clusterTrainingRuntime := testingutil.MakeClusterTrainingRuntimeWrapper("test-runtime").
+				RuntimeSpec(trainer.TrainingRuntimeSpec{
+					Template: trainer.JobSetTemplateSpec{
+						Spec: testingutil.MakeJobSetWrapper("", "").Obj().Spec,
+					},
+				}).Obj()
+
+			clientBuilder := testingutil.NewClientBuilder().WithObjects(clusterTrainingRuntime)
+			runtimes, err := runtimecore.New(context.Background(), clientBuilder.Build(), testingutil.AsIndex(clientBuilder))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			validator := &TrainJobWebhook{
+				runtimes: runtimes,
+			}
+
+			warnings, err := validator.ValidateCreate(ctx, tc.obj)
+			if diff := cmp.Diff(tc.wantWarnings, warnings); len(diff) != 0 {
+				t.Errorf("Unexpected warnings from ValidateCreate (-want, +got): %s", diff)
+			}
+			if diff := cmp.Diff(tc.wantError.ToAggregate(), err, cmpopts.IgnoreFields(field.Error{}, "Detail")); len(diff) != 0 {
+				t.Errorf("Unexpected error from ValidateCreate (-want, +got): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This pull request forces the name of trainjobs to be compliant with RFC 1035 for jobset.

The generated Job names by JobSet (format: `<jobset-name>-<replicatedJobName>-<jobIndex>-<podIndex>.<subdomain>`) should be valid DNS labels as defined in RFC 1035 as mentioned in the [documentation of JobSet](https://jobset.sigs.k8s.io/docs/troubleshooting/#2-jobset-is-created-but-child-jobs-andor-pods-are-not-being-created), where `jobset-name` is the same as the name of trainjob.

/cc @andreyvelich @tenzen-y @Electronic-Waste @kubeflow/wg-training-leads

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
