### PR TITLE
feat(runtimes): Remove command from the Runtimes with CustomTrainer

### DIFF
--- a/manifests/base/runtimes/deepspeed_distributed.yaml
+++ b/manifests/base/runtimes/deepspeed_distributed.yaml
@@ -34,20 +34,6 @@ spec:
                       image: ghcr.io/kubeflow/trainer/deepspeed-runtime
                       securityContext:
                         runAsUser: 1000
-                      command:
-                        - mpirun
-                        - -n
-                        - "1"
-                        - bash
-                        - -c
-                        - |
-                          echo "DeepSpeed Distributed Runtime"
-
-                          echo "--------------------------------------"
-                          set -e
-                          mpirun --version
-                          python --version
-                          pip list
         - name: node
           template:
             spec:

--- a/manifests/base/runtimes/mlx_distributed.yaml
+++ b/manifests/base/runtimes/mlx_distributed.yaml
@@ -32,20 +32,6 @@ spec:
                       image: ghcr.io/kubeflow/trainer/mlx-runtime
                       securityContext:
                         runAsUser: 1000
-                      command:
-                        - mpirun
-                        - -n
-                        - "1"
-                        - bash
-                        - -c
-                        - |
-                          echo "MLX Distributed Runtime"
-
-                          echo "--------------------------------------"
-                          set -e
-                          mpirun --version
-                          python --version
-                          pip list
         - name: node
           template:
             spec:

--- a/manifests/base/runtimes/torch_distributed.yaml
+++ b/manifests/base/runtimes/torch_distributed.yaml
@@ -21,14 +21,3 @@ spec:
                   containers:
                     - name: node
                       image: pytorch/pytorch:2.7.1-cuda12.8-cudnn9-runtime
-                      command:
-                        - /bin/bash
-                        - -c
-                        - |
-                          echo "Torch Distributed Runtime"
-
-                          echo "--------------------------------------"
-                          echo "Torch Default Runtime Env"
-                          env | grep PET_
-
-                          pip list


### PR DESCRIPTION
As we discussed in the Slack thread, we would like to remove the `command` from the Runtimes which relates to the `CustomTrainer`.
https://cloud-native.slack.com/archives/C0742LDFZ4K/p1753482858201689

We will introduce the `get_runtime_packages()` API in the SDK to give users information about installed packages in the Runtime.

/assign @kubeflow/kubeflow-trainer-team @astefanutti @kramaranya @szaher 

