### PR TITLE
fix(runtimes): Set numProcPerNode: 1 in DeepSpeed Runtime

### DIFF
--- a/manifests/base/runtimes/deepspeed_distributed.yaml
+++ b/manifests/base/runtimes/deepspeed_distributed.yaml
@@ -8,9 +8,7 @@ spec:
   mlPolicy:
     numNodes: 1
     mpi:
-      # TODO (andreyvelich): Change num proc to 1 and remove container resources after we
-      # allow to override it via TrainJob APIs.
-      numProcPerNode: 4
+      numProcPerNode: 1
       mpiImplementation: OpenMPI
       sshAuthMountPath: /home/mpiuser/.ssh
       runLauncherAsNode: true


### PR DESCRIPTION
We should set the `numProcPerNode: 1` in DeepSpeed runtime by default for now.

Users have to manually configure resources in MPI-based runtimes if they want to override it.

We have an open issue to enhance resources for MPI-based runtimes: https://github.com/kubeflow/trainer/issues/2751

/assign @kubeflow/kubeflow-trainer-team @astefanutti 