### PR TITLE
fix: read only permission for PRs

### DIFF
--- a/.github/workflows/test-e2e-gpu.yaml
+++ b/.github/workflows/test-e2e-gpu.yaml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize, labeled]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   gpu-e2e-test:
     name: GPU E2E Test


### PR DESCRIPTION
This fixes and scopes the PRs for read only access during `GPU E2E Test`

Related: 

- https://github.com/kubeflow/trainer/pull/2818
- https://github.com/kubeflow/trainer/pull/2762

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
