### PR TITLE
fix: read only permission for PRs

### DIFF
--- a/.github/workflows/test-e2e-gpu.yaml
+++ b/.github/workflows/test-e2e-gpu.yaml
@@ -77,7 +77,7 @@ jobs:
           mkdir -p artifacts/notebooks
           make test-e2e-notebook NOTEBOOK_INPUT=./examples/torchtune/llama3_2/alpaca-trainjob-yaml.ipynb NOTEBOOK_OUTPUT=./artifacts/notebooks/${{ matrix.kubernetes-version }}_alpaca-trainjob-yaml.ipynb TIMEOUT=900
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }} 
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
       - name: Upload Artifacts to GitHub
         if: always()


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures GPU tests run safely without risking sensitive data.

- Removed `pull_request_target` to prevent exposing secrets to untrusted code.
- Switched to `pull_request` event for safer workflow triggers.
- Added environment protection for secrets (e.g., `HF_TOKEN`) requiring reviewer approval.
- Secrets are exposed only when a maintainer applies `ok-to-test-gpu-runner` and approves the `gpu-tests` environment.

**Which issue(s) this PR fixes** 
Fixes #2828

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
