### PR TITLE
feat(runtimes): Add LoRA/QLoRA/DoRA support in LLM Trainer V2

### DIFF
--- a/docs/proposals/2401-llm-trainer-v2/README.md
+++ b/docs/proposals/2401-llm-trainer-v2/README.md
@@ -452,8 +452,8 @@ class LoraConfig:
     lora_attn_modules: Optional[List[str]] = None
     lora_rank: Optional[int] = None
     lora_alpha: Optional[int] = None
-    lora_dropout: optional[float] = None
-    quantize_base: optional[bool] = None
+    lora_dropout: Optional[float] = None
+    quantize_base: Optional[bool] = None
     use_dora: Optional[bool] = None
 
 ```

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -158,6 +158,9 @@ const (
 	// TorchTuneLoRAFinetuneDistributedConfigSuffix is the config suffix for the distributed LoRA finetune.
 	TorchTuneLoRAFinetuneDistributedConfigSuffix string = "_lora"
 
+	// TorchTuneTrainerUseLoRA is the flag for the PEFT method in torchtune.
+	TorchTuneTrainerUseLoRA string = "--trainer-use-lora"
+
 	// TorchTuneModelOutputDir is the config item name for the model output directory.
 	TorchTuneModelOutputDir string = "output_dir"
 
@@ -203,4 +206,7 @@ var (
 
 	// TorchTuneImmutableConfigs is the set of immutable configs for the TorchTune Trainer.
 	TorchTuneImmutableConfigs = sets.New(TorchTuneModelOutputDir, TorchTuneTokenizerPath, TorchTuneCheckpointDir, TorchTuneTokenizerMergeFile)
+
+	// TorchTuneFilteredArgs is the set of args that will be filtered out from the user provided args.
+	TorchTuneFilteredArgs = sets.New(TorchTuneTrainerUseLoRA)
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -152,14 +152,23 @@ const (
 	// TorchTuneLoRAFinetuneSingleDeviceConfigSuffix is the config suffix for the single device LoRA finetune.
 	TorchTuneLoRAFinetuneSingleDeviceConfigSuffix string = "_lora_single_device"
 
+	// TorchTuneQLoRAFinetuneSingleDeviceConfigSuffix is the config suffix for the single device QLoRA finetune.
+	TorchTuneQLoRAFinetuneSingleDeviceConfigSuffix string = "_qlora_single_device"
+
 	// TorchTuneLoRAFinetuneDistributed Recipe is the recipe for the distributed LoRA finetune.
 	TorchTuneLoRAFinetuneDistributed string = "lora_finetune_distributed"
 
 	// TorchTuneLoRAFinetuneDistributedConfigSuffix is the config suffix for the distributed LoRA finetune.
 	TorchTuneLoRAFinetuneDistributedConfigSuffix string = "_lora"
 
-	// TorchTuneTrainerUseLoRA is the flag for the PEFT method in torchtune.
+	// TorchTuneQLoRAFinetuneDistributedConfigSuffix is the config suffix for the distributed QLoRA finetune.
+	TorchTuneQLoRAFinetuneDistributedConfigSuffix string = "_qlora"
+
+	// TorchTuneTrainerUseLoRA is the flag for the LoRA/DoRA method in torchtune.
 	TorchTuneTrainerUseLoRA string = "--trainer-use-lora"
+
+	// TorchTuneTrainerUseQLoRA is the flag for the QLoRA method in torchtune.
+	TorchTuneTrainerUseQLoRA string = "--trainer-use-qlora"
 
 	// TorchTuneModelOutputDir is the config item name for the model output directory.
 	TorchTuneModelOutputDir string = "output_dir"
@@ -208,5 +217,5 @@ var (
 	TorchTuneImmutableConfigs = sets.New(TorchTuneModelOutputDir, TorchTuneTokenizerPath, TorchTuneCheckpointDir, TorchTuneTokenizerMergeFile)
 
 	// TorchTuneFilteredArgs is the set of args that will be filtered out from the user provided args.
-	TorchTuneFilteredArgs = sets.New(TorchTuneTrainerUseLoRA)
+	TorchTuneFilteredArgs = sets.New(TorchTuneTrainerUseLoRA, TorchTuneTrainerUseQLoRA)
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -146,6 +146,18 @@ const (
 	// TorchTuneFullFinetuneMultiNodesConfigSuffix is the config suffix for the multi node distributed full finetune.
 	TorchTuneFullFinetuneMultiNodesConfigSuffix string = "_full_multinode"
 
+	// TorchTuneLoRAFinetuneSingleDevice Recipe is the recipe for the single device LoRA finetune.
+	TorchTuneLoRAFinetuneSingleDevice string = "lora_finetune_single_device"
+
+	// TorchTuneLoRAFinetuneSingleDeviceConfigSuffix is the config suffix for the single device LoRA finetune.
+	TorchTuneLoRAFinetuneSingleDeviceConfigSuffix string = "_lora_single_device"
+
+	// TorchTuneLoRAFinetuneDistributed Recipe is the recipe for the distributed LoRA finetune.
+	TorchTuneLoRAFinetuneDistributed string = "lora_finetune_distributed"
+
+	// TorchTuneLoRAFinetuneDistributedConfigSuffix is the config suffix for the distributed LoRA finetune.
+	TorchTuneLoRAFinetuneDistributedConfigSuffix string = "_lora"
+
 	// TorchTuneModelOutputDir is the config item name for the model output directory.
 	TorchTuneModelOutputDir string = "output_dir"
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -187,8 +187,8 @@ const (
 	// TORCHTUNE_MODEL_LLAMA3_2_1B is the model name for the Llama3.2 1B Instruct model.
 	TORCHTUNE_MODEL_LLAMA3_2_1B = "llama3_2/1B"
 
-	// TORCHTUNE_MODEL_LLAMA3_2_7B is the model name for the Llama3.2 7B Instruct model.
-	TORCHTUNE_MODEL_LLAMA3_2_7B = "llama3_2/7B"
+	// TORCHTUNE_MODEL_LLAMA3_2_3B is the model name for the Llama3.2 3B Instruct model.
+	TORCHTUNE_MODEL_LLAMA3_2_3B = "llama3_2/3B"
 
 	// TORCHTUNE_MODEL_LLAMA3_3_70B is the model name for the Llama3.3 70B Instruct model.
 	TORCHTUNE_MODEL_LLAMA3_3_70B = "llama3_3/70B"
@@ -208,7 +208,7 @@ var (
 	ResourceInUseFinalizer = fmt.Sprintf("%s/resource-in-use", trainer.GroupVersion.Group)
 
 	// TorchTuneSupportedPretrainedModels supported pretrained models for TorchTune Trainer.
-	TorchTuneSupportedPretrainedModels = sets.New(TORCHTUNE_MODEL_LLAMA3_2_1B, TORCHTUNE_MODEL_LLAMA3_2_7B, TORCHTUNE_MODEL_LLAMA3_3_70B, TORCHTUNE_MODEL_QWEN2_5_1_5B)
+	TorchTuneSupportedPretrainedModels = sets.New(TORCHTUNE_MODEL_LLAMA3_2_1B, TORCHTUNE_MODEL_LLAMA3_2_3B, TORCHTUNE_MODEL_LLAMA3_3_70B, TORCHTUNE_MODEL_QWEN2_5_1_5B)
 
 	// TorchTuneEntrypoint is the entrypoint for the torchtune.
 	TorchTuneEntrypoint = []string{"tune", "run"}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -164,11 +164,14 @@ const (
 	// TorchTuneQLoRAFinetuneDistributedConfigSuffix is the config suffix for the distributed QLoRA finetune.
 	TorchTuneQLoRAFinetuneDistributedConfigSuffix string = "_qlora"
 
-	// TorchTuneTrainerUseLoRA is the flag for the LoRA/DoRA method in torchtune.
-	TorchTuneTrainerUseLoRA string = "--trainer-use-lora"
+	// TorchTuneLoraAttnModules is the config item name for the LoRA attention modules.
+	TorchTuneLoraAttnModules string = "model.lora_attn_modules"
 
-	// TorchTuneTrainerUseQLoRA is the flag for the QLoRA method in torchtune.
-	TorchTuneTrainerUseQLoRA string = "--trainer-use-qlora"
+	// TorchTuneQuantizeBase is the config item name for the quantization base.
+	TorchTuneQuantizeBase string = "model.quantize_base"
+
+	// TorchTuneUseDora is the config item name for using DoRA.
+	TorchTuneUseDora string = "model.use_dora"
 
 	// TorchTuneModelOutputDir is the config item name for the model output directory.
 	TorchTuneModelOutputDir string = "output_dir"
@@ -215,7 +218,4 @@ var (
 
 	// TorchTuneImmutableConfigs is the set of immutable configs for the TorchTune Trainer.
 	TorchTuneImmutableConfigs = sets.New(TorchTuneModelOutputDir, TorchTuneTokenizerPath, TorchTuneCheckpointDir, TorchTuneTokenizerMergeFile)
-
-	// TorchTuneFilteredArgs is the set of args that will be filtered out from the user provided args.
-	TorchTuneFilteredArgs = sets.New(TorchTuneTrainerUseLoRA, TorchTuneTrainerUseQLoRA)
 )

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -1290,11 +1290,10 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 								"dataset=torchtune.datasets.instruct_dataset",
 								"dataset.source=parquet",
 							},
-							resRequests,
+							corev1.ResourceList{"example.com/gpu": resource.MustParse("2")},
 						).
 						NumNodes(1).
 						NumProcPerNode(intstr.FromString("auto")).
-						ResourcesPerNode(corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")}).
 						Obj(),
 				).
 				Obj(),
@@ -1327,7 +1326,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							"dataset=torchtune.datasets.instruct_dataset",
 							"dataset.source=parquet",
 						},
-						corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")},
+						corev1.ResourceList{"example.com/gpu": resource.MustParse("2")},
 					).
 					ContainerTrainerPorts([]corev1.ContainerPort{{ContainerPort: constants.ContainerTrainerPort}}).
 					Env(constants.Node, constants.Node,
@@ -1433,11 +1432,10 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 								"dataset=torchtune.datasets.instruct_dataset",
 								"dataset.source=parquet",
 							},
-							resRequests,
+							corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
 						).
 						NumNodes(1).
 						NumProcPerNode(intstr.FromString("auto")).
-						ResourcesPerNode(corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}).
 						Obj(),
 				).
 				Obj(),
@@ -1470,9 +1468,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							"dataset=torchtune.datasets.instruct_dataset",
 							"dataset.source=parquet",
 						},
-						corev1.ResourceList{
-							"nvidia.com/gpu": resource.MustParse("1"),
-						},
+						corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
 					).
 					ContainerTrainerPorts([]corev1.ContainerPort{{ContainerPort: constants.ContainerTrainerPort}}).
 					Env(constants.Node, constants.Node,
@@ -1579,11 +1575,10 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 								"dataset=torchtune.datasets.instruct_dataset",
 								"dataset.source=parquet",
 							},
-							resRequests,
+							corev1.ResourceList{"example.com/gpu": resource.MustParse("2")},
 						).
 						NumNodes(1).
 						NumProcPerNode(intstr.FromString("auto")).
-						ResourcesPerNode(corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}).
 						Obj(),
 				).
 				Obj(),
@@ -1601,9 +1596,10 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 						[]string{
 							"tune",
 							"run",
-							constants.TorchTuneLoRAFinetuneSingleDevice,
+							fmt.Sprintf("%s=%s", constants.TorchTuneArgRdzvEndpoint, "test-job-node-0-0.test-job:29500"),
+							constants.TorchTuneLoRAFinetuneDistributed,
 							"--config",
-							"llama3_2/1B_lora_single_device",
+							"llama3_2/1B_lora",
 							"output_dir=/workspace/output",
 							"tokenizer.path=/workspace/model/original/tokenizer.model",
 							"checkpointer.checkpoint_dir=/workspace/model",
@@ -1617,9 +1613,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							"dataset=torchtune.datasets.instruct_dataset",
 							"dataset.source=parquet",
 						},
-						corev1.ResourceList{
-							"nvidia.com/gpu": resource.MustParse("1"),
-						},
+						corev1.ResourceList{"example.com/gpu": resource.MustParse("2")},
 					).
 					ContainerTrainerPorts([]corev1.ContainerPort{{ContainerPort: constants.ContainerTrainerPort}}).
 					Env(constants.Node, constants.Node,

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -1292,7 +1292,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 								"dataset.source=parquet",
 							},
 							resRequests,
-							).
+						).
 						NumNodes(1).
 						NumProcPerNode(intstr.FromString("auto")).
 						ResourcesPerNode(corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")}).

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -1466,6 +1466,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							"dataset.data_dir=/workspace/dataset/data",
 							"model.apply_lora_to_mlp=True",
 							"model.lora_attn_modules=[q_proj,k_proj,v_proj,output_proj]",
+							"model.quantize_base=True",
 							"dataset=torchtune.datasets.instruct_dataset",
 							"dataset.source=parquet",
 						},

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -1287,7 +1287,6 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 								"dataset.data_dir=/workspace/dataset/data",
 								"model.apply_lora_to_mlp=True",
 								"model.lora_attn_modules=[q_proj,k_proj,v_proj,output_proj]",
-								"--trainer-use-lora",
 								"dataset=torchtune.datasets.instruct_dataset",
 								"dataset.source=parquet",
 							},
@@ -1430,7 +1429,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 								"dataset.data_dir=/workspace/dataset/data",
 								"model.apply_lora_to_mlp=True",
 								"model.lora_attn_modules=[q_proj,k_proj,v_proj,output_proj]",
-								"--trainer-use-qlora",
+								"model.quantize_base=True",
 								"dataset=torchtune.datasets.instruct_dataset",
 								"dataset.source=parquet",
 							},
@@ -1467,6 +1466,153 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							"dataset.data_dir=/workspace/dataset/data",
 							"model.apply_lora_to_mlp=True",
 							"model.lora_attn_modules=[q_proj,k_proj,v_proj,output_proj]",
+							"dataset=torchtune.datasets.instruct_dataset",
+							"dataset.source=parquet",
+						},
+						corev1.ResourceList{
+							"nvidia.com/gpu": resource.MustParse("1"),
+						},
+					).
+					ContainerTrainerPorts([]corev1.ContainerPort{{ContainerPort: constants.ContainerTrainerPort}}).
+					Env(constants.Node, constants.Node,
+						[]corev1.EnvVar{
+							{
+								Name:  constants.TorchEnvNumNodes,
+								Value: "1",
+							},
+							{
+								Name:  constants.TorchEnvNumProcPerNode,
+								Value: "auto",
+							},
+							{
+								Name: constants.TorchEnvNodeRank,
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: constants.JobCompletionIndexFieldPath,
+									},
+								},
+							},
+						}...,
+					).
+					DependsOn(constants.Node,
+						[]jobsetv1alpha2.DependsOn{
+							{
+								Name:   constants.DatasetInitializer,
+								Status: jobsetv1alpha2.DependencyComplete,
+							},
+							{
+								Name:   constants.ModelInitializer,
+								Status: jobsetv1alpha2.DependencyComplete,
+							},
+						}...,
+					).
+					Obj(),
+			},
+		},
+		"succeeded to build Jobset with TorchTune values from the TrainJob (DoRA)": {
+			trainingRuntime: testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "torchtune-llama3.2-1b").RuntimeSpec(
+				testingutil.MakeTrainingRuntimeSpecWrapper(testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "torchtune-llama3.2-1b").Spec).
+					WithMLPolicy(
+						testingutil.MakeMLPolicyWrapper().
+							WithNumNodes(1).
+							WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+								TorchPolicy(ptr.To(intstr.FromString("auto")), nil).
+								Obj(),
+							).
+							Obj(),
+					).
+					JobSetSpec(
+						testingutil.MakeJobSetWrapper("", "").
+							DependsOn(constants.Node,
+								[]jobsetv1alpha2.DependsOn{
+									{
+										Name:   constants.DatasetInitializer,
+										Status: jobsetv1alpha2.DependencyComplete,
+									},
+									{
+										Name:   constants.ModelInitializer,
+										Status: jobsetv1alpha2.DependencyComplete,
+									},
+								}...,
+							).
+							Obj().
+							Spec,
+					).
+					Container(
+						constants.Node,
+						constants.Node,
+						"test:runtime",
+						[]string{
+							"tune",
+							"run",
+							"--rdzv_endpoint=localhost:29500",
+							constants.TorchTuneFullFinetuneDistributed,
+							"--config",
+							"llama3_2/1B_full",
+							"dataset=torchtune.datasets.instruct_dataset",
+							"dataset.source=parquet",
+							"dataset.data_dir=/workspace/dataset/data",
+							"output_dir=/workspace/output",
+							"tokenizer.path=/workspace/model/original/tokenizer.model",
+							"checkpointer.checkpoint_dir=/workspace/model",
+						},
+						[]string{"runtime"},
+						resRequests,
+					).
+					Obj(),
+			).Obj(),
+			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				UID("uid").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "torchtune-llama3.2-1b").
+				Trainer(
+					testingutil.MakeTrainJobTrainerWrapper().
+						Container(
+							"test:trainjob",
+							[]string{"tune", "run"},
+							[]string{
+								"dataset.data_dir=/workspace/dataset/data",
+								"model.apply_lora_to_mlp=True",
+								"model.lora_attn_modules=[q_proj,k_proj,v_proj,output_proj]",
+								"model.quantize_base=True",
+								"model.use_dora=True",
+								"dataset=torchtune.datasets.instruct_dataset",
+								"dataset.source=parquet",
+							},
+							resRequests,
+						).
+						NumNodes(1).
+						NumProcPerNode(intstr.FromString("auto")).
+						ResourcesPerNode(corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}).
+						Obj(),
+				).
+				Obj(),
+			wantObjs: []runtime.Object{
+				testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
+					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
+					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Node, constants.Launcher).
+					Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer).
+					Completions(1, constants.DatasetInitializer, constants.ModelInitializer).
+					NumNodes(1).
+					Container(
+						constants.Node,
+						constants.Node,
+						"test:trainjob",
+						[]string{
+							"tune",
+							"run",
+							constants.TorchTuneLoRAFinetuneSingleDevice,
+							"--config",
+							"llama3_2/1B_lora_single_device",
+							"output_dir=/workspace/output",
+							"tokenizer.path=/workspace/model/original/tokenizer.model",
+							"checkpointer.checkpoint_dir=/workspace/model",
+						},
+						[]string{
+							"dataset.data_dir=/workspace/dataset/data",
+							"model.apply_lora_to_mlp=True",
+							"model.lora_attn_modules=[q_proj,k_proj,v_proj,output_proj]",
+							"model.quantize_base=True",
+							"model.use_dora=True",
 							"dataset=torchtune.datasets.instruct_dataset",
 							"dataset.source=parquet",
 						},

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -1286,7 +1286,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							[]string{
 								"dataset.data_dir=/workspace/dataset/data",
 								"model.apply_lora_to_mlp=True",
-								"model.lora_attn_modules=\"[q_proj,k_proj,v_proj,output_proj]\"",
+								"model.lora_attn_modules=[q_proj,k_proj,v_proj,output_proj]",
 								"--trainer-use-lora",
 								"dataset=torchtune.datasets.instruct_dataset",
 								"dataset.source=parquet",
@@ -1324,7 +1324,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 						[]string{
 							"dataset.data_dir=/workspace/dataset/data",
 							"model.apply_lora_to_mlp=True",
-							"model.lora_attn_modules=\"[q_proj,k_proj,v_proj,output_proj]\"",
+							"model.lora_attn_modules=[q_proj,k_proj,v_proj,output_proj]",
 							"dataset=torchtune.datasets.instruct_dataset",
 							"dataset.source=parquet",
 						},
@@ -1429,7 +1429,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							[]string{
 								"dataset.data_dir=/workspace/dataset/data",
 								"model.apply_lora_to_mlp=True",
-								"model.lora_attn_modules=\"[q_proj,k_proj,v_proj,output_proj]\"",
+								"model.lora_attn_modules=[q_proj,k_proj,v_proj,output_proj]",
 								"--trainer-use-qlora",
 								"dataset=torchtune.datasets.instruct_dataset",
 								"dataset.source=parquet",
@@ -1466,7 +1466,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 						[]string{
 							"dataset.data_dir=/workspace/dataset/data",
 							"model.apply_lora_to_mlp=True",
-							"model.lora_attn_modules=\"[q_proj,k_proj,v_proj,output_proj]\"",
+							"model.lora_attn_modules=[q_proj,k_proj,v_proj,output_proj]",
 							"dataset=torchtune.datasets.instruct_dataset",
 							"dataset.source=parquet",
 						},

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -1127,7 +1127,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							"run",
 							constants.TorchTuneFullFinetuneDistributed,
 							"--config",
-							"llama3_3/70B_full_multinode.yaml",
+							"llama3_3/70B_full_multinode",
 							"output_dir=/workspace/model/llama3_3/70B",
 							"tokenizer.path=/workspace/model/original/tokenizer.model",
 							"checkpointer.checkpoint_dir=/workspace/model",
@@ -1197,6 +1197,293 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							{
 								Name:  constants.TorchEnvNumProcPerNode,
 								Value: "3",
+							},
+							{
+								Name: constants.TorchEnvNodeRank,
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: constants.JobCompletionIndexFieldPath,
+									},
+								},
+							},
+						}...,
+					).
+					DependsOn(constants.Node,
+						[]jobsetv1alpha2.DependsOn{
+							{
+								Name:   constants.DatasetInitializer,
+								Status: jobsetv1alpha2.DependencyComplete,
+							},
+							{
+								Name:   constants.ModelInitializer,
+								Status: jobsetv1alpha2.DependencyComplete,
+							},
+						}...,
+					).
+					Obj(),
+			},
+		},
+		"succeeded to build Jobset with TorchTune values from the TrainJob (LoRA)": {
+			trainingRuntime: testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "torchtune-llama3.2-1b").RuntimeSpec(
+				testingutil.MakeTrainingRuntimeSpecWrapper(testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "torchtune-llama3.2-1b").Spec).
+					WithMLPolicy(
+						testingutil.MakeMLPolicyWrapper().
+							WithNumNodes(1).
+							WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+								TorchPolicy(ptr.To(intstr.FromString("auto")), nil).
+								Obj(),
+							).
+							Obj(),
+					).
+					JobSetSpec(
+						testingutil.MakeJobSetWrapper("", "").
+							DependsOn(constants.Node,
+								[]jobsetv1alpha2.DependsOn{
+									{
+										Name:   constants.DatasetInitializer,
+										Status: jobsetv1alpha2.DependencyComplete,
+									},
+									{
+										Name:   constants.ModelInitializer,
+										Status: jobsetv1alpha2.DependencyComplete,
+									},
+								}...,
+							).
+							Obj().
+							Spec,
+					).
+					Container(
+						constants.Node,
+						constants.Node,
+						"test:runtime",
+						[]string{
+							"tune",
+							"run",
+							"--rdzv_endpoint=localhost:29500",
+							constants.TorchTuneFullFinetuneDistributed,
+							"--config",
+							"llama3_2/1B_full",
+							"dataset=torchtune.datasets.instruct_dataset",
+							"dataset.source=parquet",
+							"dataset.data_dir=/workspace/dataset/data",
+							"output_dir=/workspace/output",
+							"tokenizer.path=/workspace/model/original/tokenizer.model",
+							"checkpointer.checkpoint_dir=/workspace/model",
+						},
+						[]string{"runtime"},
+						resRequests,
+					).
+					Obj(),
+			).Obj(),
+			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				UID("uid").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "torchtune-llama3.2-1b").
+				Trainer(
+					testingutil.MakeTrainJobTrainerWrapper().
+						Container(
+							"test:trainjob",
+							[]string{"tune", "run"},
+							[]string{
+								"dataset.data_dir=/workspace/dataset/data",
+								"model.apply_lora_to_mlp=True",
+								"model.lora_attn_modules=\"[q_proj,k_proj,v_proj,output_proj]\"",
+								"--trainer-use-lora",
+								"dataset=torchtune.datasets.instruct_dataset",
+								"dataset.source=parquet",
+							},
+							resRequests,
+							).
+						NumNodes(1).
+						NumProcPerNode(intstr.FromString("auto")).
+						ResourcesPerNode(corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")}).
+						Obj(),
+				).
+				Obj(),
+			wantObjs: []runtime.Object{
+				testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
+					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
+					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Node, constants.Launcher).
+					Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer).
+					Completions(1, constants.DatasetInitializer, constants.ModelInitializer).
+					NumNodes(1).
+					Container(
+						constants.Node,
+						constants.Node,
+						"test:trainjob",
+						[]string{
+							"tune",
+							"run",
+							fmt.Sprintf("%s=%s", constants.TorchTuneArgRdzvEndpoint, "test-job-node-0-0.test-job:29500"),
+							constants.TorchTuneLoRAFinetuneDistributed,
+							"--config",
+							"llama3_2/1B_lora",
+							"output_dir=/workspace/output",
+							"tokenizer.path=/workspace/model/original/tokenizer.model",
+							"checkpointer.checkpoint_dir=/workspace/model",
+						},
+						[]string{
+							"dataset.data_dir=/workspace/dataset/data",
+							"model.apply_lora_to_mlp=True",
+							"model.lora_attn_modules=\"[q_proj,k_proj,v_proj,output_proj]\"",
+							"dataset=torchtune.datasets.instruct_dataset",
+							"dataset.source=parquet",
+						},
+						corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("2")},
+					).
+					ContainerTrainerPorts([]corev1.ContainerPort{{ContainerPort: constants.ContainerTrainerPort}}).
+					Env(constants.Node, constants.Node,
+						[]corev1.EnvVar{
+							{
+								Name:  constants.TorchEnvNumNodes,
+								Value: "1",
+							},
+							{
+								Name:  constants.TorchEnvNumProcPerNode,
+								Value: "auto",
+							},
+							{
+								Name: constants.TorchEnvNodeRank,
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: constants.JobCompletionIndexFieldPath,
+									},
+								},
+							},
+						}...,
+					).
+					DependsOn(constants.Node,
+						[]jobsetv1alpha2.DependsOn{
+							{
+								Name:   constants.DatasetInitializer,
+								Status: jobsetv1alpha2.DependencyComplete,
+							},
+							{
+								Name:   constants.ModelInitializer,
+								Status: jobsetv1alpha2.DependencyComplete,
+							},
+						}...,
+					).
+					Obj(),
+			},
+		},
+		"succeeded to build Jobset with TorchTune values from the TrainJob (QLoRA)": {
+			trainingRuntime: testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "torchtune-llama3.2-1b").RuntimeSpec(
+				testingutil.MakeTrainingRuntimeSpecWrapper(testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "torchtune-llama3.2-1b").Spec).
+					WithMLPolicy(
+						testingutil.MakeMLPolicyWrapper().
+							WithNumNodes(1).
+							WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+								TorchPolicy(ptr.To(intstr.FromString("auto")), nil).
+								Obj(),
+							).
+							Obj(),
+					).
+					JobSetSpec(
+						testingutil.MakeJobSetWrapper("", "").
+							DependsOn(constants.Node,
+								[]jobsetv1alpha2.DependsOn{
+									{
+										Name:   constants.DatasetInitializer,
+										Status: jobsetv1alpha2.DependencyComplete,
+									},
+									{
+										Name:   constants.ModelInitializer,
+										Status: jobsetv1alpha2.DependencyComplete,
+									},
+								}...,
+							).
+							Obj().
+							Spec,
+					).
+					Container(
+						constants.Node,
+						constants.Node,
+						"test:runtime",
+						[]string{
+							"tune",
+							"run",
+							"--rdzv_endpoint=localhost:29500",
+							constants.TorchTuneFullFinetuneDistributed,
+							"--config",
+							"llama3_2/1B_full",
+							"dataset=torchtune.datasets.instruct_dataset",
+							"dataset.source=parquet",
+							"dataset.data_dir=/workspace/dataset/data",
+							"output_dir=/workspace/output",
+							"tokenizer.path=/workspace/model/original/tokenizer.model",
+							"checkpointer.checkpoint_dir=/workspace/model",
+						},
+						[]string{"runtime"},
+						resRequests,
+					).
+					Obj(),
+			).Obj(),
+			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				UID("uid").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "torchtune-llama3.2-1b").
+				Trainer(
+					testingutil.MakeTrainJobTrainerWrapper().
+						Container(
+							"test:trainjob",
+							[]string{"tune", "run"},
+							[]string{
+								"dataset.data_dir=/workspace/dataset/data",
+								"model.apply_lora_to_mlp=True",
+								"model.lora_attn_modules=\"[q_proj,k_proj,v_proj,output_proj]\"",
+								"--trainer-use-qlora",
+								"dataset=torchtune.datasets.instruct_dataset",
+								"dataset.source=parquet",
+							},
+							resRequests,
+						).
+						NumNodes(1).
+						NumProcPerNode(intstr.FromString("auto")).
+						ResourcesPerNode(corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")}).
+						Obj(),
+				).
+				Obj(),
+			wantObjs: []runtime.Object{
+				testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
+					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
+					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Node, constants.Launcher).
+					Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer).
+					Completions(1, constants.DatasetInitializer, constants.ModelInitializer).
+					NumNodes(1).
+					Container(
+						constants.Node,
+						constants.Node,
+						"test:trainjob",
+						[]string{
+							"tune",
+							"run",
+							constants.TorchTuneLoRAFinetuneSingleDevice,
+							"--config",
+							"llama3_2/1B_qlora_single_device",
+							"output_dir=/workspace/output",
+							"tokenizer.path=/workspace/model/original/tokenizer.model",
+							"checkpointer.checkpoint_dir=/workspace/model",
+						},
+						[]string{
+							"dataset.data_dir=/workspace/dataset/data",
+							"model.apply_lora_to_mlp=True",
+							"model.lora_attn_modules=\"[q_proj,k_proj,v_proj,output_proj]\"",
+							"dataset=torchtune.datasets.instruct_dataset",
+							"dataset.source=parquet",
+						},
+						corev1.ResourceList{
+							"nvidia.com/gpu": resource.MustParse("1"),
+						},
+					).
+					ContainerTrainerPorts([]corev1.ContainerPort{{ContainerPort: constants.ContainerTrainerPort}}).
+					Env(constants.Node, constants.Node,
+						[]corev1.EnvVar{
+							{
+								Name:  constants.TorchEnvNumNodes,
+								Value: "1",
+							},
+							{
+								Name:  constants.TorchEnvNumProcPerNode,
+								Value: "auto",
 							},
 							{
 								Name: constants.TorchEnvNodeRank,

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -216,7 +216,6 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 	return nil
 }
 
-
 func getNumProcPerNode(nppNode intstr.IntOrString, resourcesPerNode corev1.ResourceList) intstr.IntOrString {
 	var (
 		shouldUseCPU           func(resources corev1.ResourceList) bool

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -254,7 +254,6 @@ func getRecipeAndConfig(numNodes int32, numProcPerNode intstr.IntOrString, resou
 	suffix := constants.TorchTuneFullFinetuneMultiDevicesConfigSuffix
 	gpuQ, ok := resourcePerNode["nvidia.com/gpu"]
 	if numNodes == 1 && (numProcPerNode.Type == intstr.Int && numProcPerNode.IntVal == 1 || ok && gpuQ.Value() == 1) {
-		fmt.Printf("model: %s, numProcPerNode: %v, gpuQ: %v, args: %v\n", model, numProcPerNode, gpuQ.Value(), args)
 		if isUseLoraFinetune(args) {
 			recipe = constants.TorchTuneLoRAFinetuneSingleDevice
 			suffix = constants.TorchTuneLoRAFinetuneSingleDeviceConfigSuffix

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -88,40 +88,8 @@ func (t *Torch) Validate(_ context.Context, runtimeInfo *runtime.Info, _, newObj
 		// Check supported pretrained models for torchtune.
 		// TODO(Electronic-Waste): Add more validation for torchtune when we support more arguments.
 		if slices.Equal(newObj.Spec.Trainer.Command, constants.TorchTuneEntrypoint) {
-			runtimeRefNamePath := specPath.Child("runtimeRef").Child("name")
-			model := getModelFromRuntimeRef(newObj.Spec.RuntimeRef.Name)
-
-			if !constants.TorchTuneSupportedPretrainedModels.Has(model) {
-				allErrs = append(allErrs, field.Invalid(runtimeRefNamePath, newObj.Spec.RuntimeRef.Name, fmt.Sprintf("must have a supported pretrained model, invalid model configured: %v", model)))
-			}
-
-			numNodesRefPath := specPath.Child("trainer").Child("numNodes")
-			numNodes := *newObj.Spec.Trainer.NumNodes
-			if numNodes > 1 && model != constants.TORCHTUNE_MODEL_LLAMA3_3_70B {
-				allErrs = append(allErrs, field.Invalid(numNodesRefPath, numNodes, fmt.Sprintf("must be 1 for %v model", model)))
-			}
-
-			numProcPerNodeRefPath := specPath.Child("trainer").Child("numProcPerNode")
-			numProcPerNode := *newObj.Spec.Trainer.NumProcPerNode
-			resourcesPerNode := ptr.Deref(extractResourcePerNodeFromRuntime(runtimeInfo), corev1.ResourceRequirements{})
-			if jobTrainer := newObj.Spec.Trainer; jobTrainer != nil && jobTrainer.ResourcesPerNode != nil {
-				resourcesPerNode = ptr.Deref(jobTrainer.ResourcesPerNode, corev1.ResourceRequirements{})
-			}
-			_, config := getRecipeAndConfig(numNodes, numProcPerNode, getNumGPUPerNode(&resourcesPerNode), newObj)
-			if strings.Contains(config, constants.TorchTuneQLoRAFinetuneDistributedConfigSuffix) {
-				if model == constants.TORCHTUNE_MODEL_QWEN2_5_1_5B {
-					allErrs = append(allErrs, field.Invalid(runtimeRefNamePath, newObj.Spec.RuntimeRef.Name, fmt.Sprintf("QLoRA is not supported for %v model", model)))
-				}
-				resourcePerNodeRefPath := specPath.Child("trainer").Child("resourcesPerNode")
-				if !strings.Contains(config, constants.TorchTuneQLoRAFinetuneSingleDeviceConfigSuffix) &&
-					(model == constants.TORCHTUNE_MODEL_LLAMA3_2_1B || model == constants.TORCHTUNE_MODEL_LLAMA3_2_3B) {
-					allErrs = append(
-						allErrs,
-						field.Invalid(numProcPerNodeRefPath, numProcPerNode, fmt.Sprintf("must be auto or 1 for %v model when using QLoRA", model)),
-						field.Invalid(resourcePerNodeRefPath, newObj.Spec.Trainer.ResourcesPerNode, fmt.Sprintf("must have gpu resource with value 1 for %v model when using QLoRA", model)),
-					)
-				}
-			}
+			_, torchTuneErrs := validateTorchTune(runtimeInfo, newObj)
+			allErrs = append(allErrs, torchTuneErrs...)
 		}
 	}
 	return nil, allErrs
@@ -276,35 +244,6 @@ func calculateNumProcPerNode(
 	return intstr.FromInt32(defaultCPU), false
 }
 
-// getRecipeAndConfig returns the recipe and config file name based on the number of nodes,
-// number of processes per node, gpu count, resource per node, model name, and command line arguments.
-func getRecipeAndConfig(numNodes int32, numProcPerNode intstr.IntOrString, gpuQ int, trainJob *trainer.TrainJob) (string, string) {
-	recipe := constants.TorchTuneFullFinetuneDistributed
-	suffix := constants.TorchTuneFullFinetuneMultiDevicesConfigSuffix
-	if numNodes == 1 && (numProcPerNode.Type == intstr.Int && numProcPerNode.IntVal == 1 || gpuQ == 1) {
-		if isUseQLoraFinetune(trainJob.Spec.Trainer.Args) {
-			recipe = constants.TorchTuneLoRAFinetuneSingleDevice
-			suffix = constants.TorchTuneQLoRAFinetuneSingleDeviceConfigSuffix
-		} else if isLoraConfigEnabled(trainJob.Spec.Trainer.Args) {
-			recipe = constants.TorchTuneLoRAFinetuneSingleDevice
-			suffix = constants.TorchTuneLoRAFinetuneSingleDeviceConfigSuffix
-		} else {
-			recipe = constants.TorchTuneFullFinetuneSingleDevice
-			suffix = constants.TorchTuneFullFinetuneSingleDeviceConfigSuffix
-		}
-	} else if numNodes == 1 && isUseQLoraFinetune(trainJob.Spec.Trainer.Args) {
-		recipe = constants.TorchTuneLoRAFinetuneDistributed
-		suffix = constants.TorchTuneQLoRAFinetuneDistributedConfigSuffix
-	} else if numNodes == 1 && isLoraConfigEnabled(trainJob.Spec.Trainer.Args) {
-		recipe = constants.TorchTuneLoRAFinetuneDistributed
-		suffix = constants.TorchTuneLoRAFinetuneDistributedConfigSuffix
-	} else if numNodes > 1 {
-		suffix = constants.TorchTuneFullFinetuneMultiNodesConfigSuffix
-	}
-
-	return recipe, fmt.Sprintf("%s%s", getModelFromRuntimeRef(trainJob.Spec.RuntimeRef.Name), suffix)
-}
-
 // getNumGPUPerNode returns the GPU count if found.
 func getNumGPUPerNode(res *corev1.ResourceRequirements) int {
 	if res != nil {
@@ -326,32 +265,7 @@ func numGPU(resourcePerNode corev1.ResourceList) int {
 	return 0
 }
 
-// isLoraConfigEnabled checks if we enables LoraConfig.
-func isLoraConfigEnabled(args []string) bool {
-	for _, arg := range args {
-		if strings.Contains(arg, constants.TorchTuneLoraAttnModules) {
-			return true
-		}
-	}
-	return false
-}
-
-// isUseQLoraFinetune checks if QLoRA fine-tuning should be used.
-func isUseQLoraFinetune(args []string) bool {
-	hasQuantizeBase := false
-	for _, arg := range args {
-		switch {
-		case strings.Contains(arg, constants.TorchTuneUseDora):
-			// If Dora is enabled, no need to continue
-			return false
-		case strings.Contains(arg, constants.TorchTuneQuantizeBase):
-			hasQuantizeBase = true
-		}
-	}
-	return hasQuantizeBase
-}
-
-// extractResourcePerNodeFromRuntime extracts the resource per node from the TorchTune Trainer Node.
+// extractResourcePerNodeFromRuntime extracts the resource per node from the Trainer Node.
 func extractResourcePerNodeFromRuntime(info *runtime.Info) *corev1.ResourceRequirements {
 	if jobSetSpec, ok := runtime.TemplateSpecApply[jobsetv1alpha2ac.JobSetSpecApplyConfiguration](info); ok {
 		for _, rJob := range jobSetSpec.ReplicatedJobs {
@@ -375,40 +289,4 @@ func extractResourcePerNodeFromRuntime(info *runtime.Info) *corev1.ResourceRequi
 		}
 	}
 	return nil
-}
-
-// extractOverridesFromRuntime extracts overrides from the TorchTune Trainer Node.
-func extractOverridesFromRuntime(info *runtime.Info) []string {
-	overrides := []string{}
-	jobSetSpec, ok := runtime.TemplateSpecApply[jobsetv1alpha2ac.JobSetSpecApplyConfiguration](info)
-	if !ok {
-		return overrides
-	}
-
-	for _, rJob := range jobSetSpec.ReplicatedJobs {
-		jobMetadata := rJob.Template.ObjectMetaApplyConfiguration
-		if jobMetadata == nil || jobMetadata.Labels == nil {
-			continue
-		}
-		if ancestor, ok := jobMetadata.Labels[constants.LabelTrainJobAncestor]; ok && ancestor == constants.AncestorTrainer {
-			for _, container := range rJob.Template.Spec.Template.Spec.Containers {
-				if container.Name != nil && *container.Name == constants.Node {
-					for _, command := range container.Command {
-						if constants.TorchTuneImmutableConfigs.Has(strings.Split(command, "=")[0]) {
-							overrides = append(overrides, command)
-						}
-					}
-				}
-			}
-		}
-	}
-	return overrides
-}
-
-func getModelFromRuntimeRef(runtimeRefName string) string {
-	fields := strings.Split(runtimeRefName, "-")
-	if len(fields) != 3 {
-		return ""
-	}
-	return fmt.Sprintf("%s/%s", strings.ReplaceAll(fields[1], ".", "_"), strings.ToUpper(fields[2]))
 }

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -220,6 +220,7 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 			newCommand = append(newCommand, extractOverridesFromRuntime(info)...)
 
 			trainJob.Spec.Trainer.Command = append(trainJob.Spec.Trainer.Command, newCommand...)
+			trainJob.Spec.Trainer.Args = removeFilteredArgs(trainJob.Spec.Trainer.Args)
 		}
 		// Add container port for the headless service.
 		apply.UpsertPort(&trainerContainer.Ports, *corev1ac.ContainerPort().WithContainerPort(constants.ContainerTrainerPort))
@@ -267,8 +268,26 @@ func getRecipeAndConfig(numNodes int32, numProcPerNode intstr.IntOrString, model
 	return recipe, fmt.Sprintf("%s%s", model, suffix)
 }
 
+// isUseLoraFinetune checks if the --trainer-use-lora flag is present in the command line arguments.
+// It returns true if the flag is found, otherwise false.
 func isUseLoraFinetune(args []string) bool {
+	for _, arg := range args {
+		if arg == constants.TorchTuneTrainerUseLoRA {
+			return true
+		}
+	}
 	return false
+}
+
+// removeFilteredArgs removes the filtered args from the provided args slice.
+func removeFilteredArgs(args []string) []string {
+	filteredArgs := []string{}
+	for _, arg := range args {
+		if !constants.TorchTuneFilteredArgs.Has(arg) {
+			filteredArgs = append(filteredArgs, arg)
+		}
+	}
+	return filteredArgs
 }
 
 // extractOverridesFromRuntime extracts overrides from the TorchTune Trainer Node.

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -124,7 +124,6 @@ func (t *Torch) Validate(_ context.Context, runtimeInfo *runtime.Info, _, newObj
 			}
 		}
 	}
-
 	return nil, allErrs
 }
 
@@ -402,7 +401,6 @@ func extractOverridesFromRuntime(info *runtime.Info) []string {
 			}
 		}
 	}
-
 	return overrides
 }
 
@@ -411,6 +409,5 @@ func getModelFromRuntimeRef(runtimeRefName string) string {
 	if len(fields) != 3 {
 		return ""
 	}
-
 	return fmt.Sprintf("%s/%s", strings.ReplaceAll(fields[1], ".", "_"), strings.ToUpper(fields[2]))
 }

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -206,7 +206,6 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 			newCommand = append(newCommand, extractOverridesFromRuntime(info)...)
 
 			trainJob.Spec.Trainer.Command = append(trainJob.Spec.Trainer.Command, newCommand...)
-			trainJob.Spec.Trainer.Args = removeFilteredArgs(trainJob.Spec.Trainer.Args)
 		}
 		// Add container port for the headless service.
 		apply.UpsertPort(&trainerContainer.Ports, *corev1ac.ContainerPort().WithContainerPort(constants.ContainerTrainerPort))
@@ -355,20 +354,6 @@ func isUseQLoraFinetune(args []string) bool {
 		}
 	}
 	return hasQuantizeBase
-}
-
-// removeFilteredArgs removes the filtered args from the provided args slice.
-func removeFilteredArgs(args []string) []string {
-	if !isUseQLoraFinetune(args) {
-		return args
-	}
-	filteredArgs := []string{}
-	for _, arg := range args {
-		if !strings.Contains(arg, constants.TorchTuneQuantizeBase) {
-			filteredArgs = append(filteredArgs, arg)
-		}
-	}
-	return filteredArgs
 }
 
 // extractGPUCountFromRuntime extracts the GPU count from the TorchTune Trainer Node.

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -198,7 +198,7 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 			// Rendezvous backend is only enabled for multi-nodes or multi-devices training.
 			var newCommand []string
 			numNodes := ptr.Deref(ptr.Deref(trainerPS, runtime.PodSet{}).Count, 1)
-			gpuQ, ok := trainJob.Spec.Trainer.ResourcesPerNode.Limits["nvidia.com/gpu"]
+			gpuQ, ok := trainJob.Spec.Trainer.ResourcesPerNode.Requests["nvidia.com/gpu"]
 			if numNodes > 1 || !(numProcPerNode.Type == intstr.Int && numProcPerNode.IntVal == 1) && !(ok && gpuQ.Value() == 1) {
 				newCommand = append(newCommand,
 					fmt.Sprintf("%s=%s-%s-0-0.%s:%d",
@@ -212,7 +212,7 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 			recipe, config := getRecipeAndConfig(
 				numNodes,
 				numProcPerNode,
-				trainJob.Spec.Trainer.ResourcesPerNode.Limits,
+				trainJob.Spec.Trainer.ResourcesPerNode.Requests,
 				getModelFromRuntimeRef(trainJob.Spec.RuntimeRef.Name),
 				trainJob.Spec.Trainer.Args,
 			)
@@ -254,6 +254,7 @@ func getRecipeAndConfig(numNodes int32, numProcPerNode intstr.IntOrString, resou
 	suffix := constants.TorchTuneFullFinetuneMultiDevicesConfigSuffix
 	gpuQ, ok := resourcePerNode["nvidia.com/gpu"]
 	if numNodes == 1 && (numProcPerNode.Type == intstr.Int && numProcPerNode.IntVal == 1 || ok && gpuQ.Value() == 1) {
+		fmt.Printf("model: %s, numProcPerNode: %v, gpuQ: %v, args: %v\n", model, numProcPerNode, gpuQ.Value(), args)
 		if isUseLoraFinetune(args) {
 			recipe = constants.TorchTuneLoRAFinetuneSingleDevice
 			suffix = constants.TorchTuneLoRAFinetuneSingleDeviceConfigSuffix

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -369,18 +369,19 @@ func isLoraConfigEnabled(args []string) bool {
 	return false
 }
 
-// isUseQLora checks if we use QLoRA fine-tuning.
+// isUseQLoraFinetune checks if QLoRA fine-tuning should be used.
 func isUseQLoraFinetune(args []string) bool {
-	quantizeBaseEnabled, useDoraEnabled := false, false
+	hasQuantizeBase := false
 	for _, arg := range args {
-		if strings.Contains(arg, constants.TorchTuneQuantizeBase) {
-			quantizeBaseEnabled = true
-		}
-		if strings.Contains(arg, constants.TorchTuneUseDora) {
-			useDoraEnabled = true
+		switch {
+		case strings.Contains(arg, constants.TorchTuneUseDora):
+			// If Dora is enabled, no need to continue
+			return false
+		case strings.Contains(arg, constants.TorchTuneQuantizeBase):
+			hasQuantizeBase = true
 		}
 	}
-	return quantizeBaseEnabled && !useDoraEnabled
+	return hasQuantizeBase
 }
 
 // removeFilteredArgs removes the filtered args from the provided args slice.

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -119,8 +119,8 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 	}
 	gpuQ := getNumGPUPerNode(&resourcesPerNode)
 	// If numProcPerNode is "cpu" or no GPU is set in resource, we calculate numProcPerNode based on CPU.
-	if numProcPerNode.String() == "cpu" || gpuQ == 0 {
-		numProcPerNode = getNumProcPerNodeFromCPU(numProcPerNode, resourcesPerNode)
+	if numProcPerNode.String() == "cpu" || numProcPerNode.String() == "auto" && gpuQ == 0 {
+		numProcPerNode = intstr.FromInt(max(1, getNumCPUPerNode(&resourcesPerNode)))
 	}
 
 	// Update envs for Info object.
@@ -188,13 +188,6 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 	}
 	info.SyncPodSetsToTemplateSpec()
 	return nil
-}
-
-func getNumProcPerNodeFromCPU(nppNode intstr.IntOrString, resourcesPerNode corev1.ResourceRequirements) intstr.IntOrString {
-	if nppNode.String() == "auto" || nppNode.String() == "cpu" {
-		return intstr.FromInt(max(1, getNumCPUPerNode(&resourcesPerNode)))
-	}
-	return nppNode
 }
 
 // getNumCPUPerNode calculates the number of CPU processes per node based on the provided resources.

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -142,11 +142,11 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 	}
 
 	// Determine numProcPerNode based on the resourcesPerNode.
+	resourcesPerNode := ptr.Deref(extractResourcePerNodeFromRuntime(info), corev1.ResourceList{})
 	if jobTrainer := trainJob.Spec.Trainer; jobTrainer != nil && jobTrainer.ResourcesPerNode != nil {
-		numProcPerNode = getNumProcPerNode(numProcPerNode, jobTrainer.ResourcesPerNode.Requests)
-	} else if resourcesPerNode := extractResourcePerNodeFromRuntime(info); resourcesPerNode != nil {
-		numProcPerNode = getNumProcPerNode(numProcPerNode, *resourcesPerNode)
+		resourcesPerNode = jobTrainer.ResourcesPerNode.Requests
 	}
+	numProcPerNode = getNumProcPerNode(numProcPerNode, resourcesPerNode)
 
 	// Update envs for Info object.
 	var trainerContainer *runtime.Container

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -261,8 +261,8 @@ func getNumProcPerNode(nppNode intstr.IntOrString, info *runtime.Info, jobTraine
 		nppNode, usedCPU = calculateNumProcPerNode(fallbackNumProcPerNode, jobTrainer.ResourcesPerNode.Requests, shouldUseCPU)
 	}
 	// Check default GPU resources allocated in runtime if GPU is not used yet.
-	if gpuQ, ok := extractGPUCountFromRuntime(info); usedCPU && ok {
-		nppNode = intstr.FromInt(gpuQ)
+	if _, ok := extractGPUCountFromRuntime(info); usedCPU && ok {
+		nppNode = fallbackNumProcPerNode
 	}
 	return nppNode
 }

--- a/pkg/runtime/framework/plugins/torch/torch_test.go
+++ b/pkg/runtime/framework/plugins/torch/torch_test.go
@@ -1636,14 +1636,14 @@ func TestValidate(t *testing.T) {
 				).
 				RuntimeRef(
 					trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind),
-					"torchtune-llama3.2-7b",
+					"torchtune-llama3.2-3b",
 				).
 				Obj(),
 			wantError: field.ErrorList{
 				field.Invalid(
 					field.NewPath("spec").Child("trainer").Child("numNodes"),
 					int32(2),
-					fmt.Sprintf("must be 1 for %v model", "llama3_2/7B"),
+					fmt.Sprintf("must be 1 for %v model", "llama3_2/3B"),
 				),
 			},
 		},

--- a/pkg/runtime/framework/plugins/torch/torch_test.go
+++ b/pkg/runtime/framework/plugins/torch/torch_test.go
@@ -1664,7 +1664,10 @@ func TestValidate(t *testing.T) {
 					Container(
 						"ghcr.io/kubeflow/trainer/torchtune-trainer",
 						[]string{"tune", "run"},
-						[]string{constants.TorchTuneTrainerUseQLoRA},
+						[]string{
+							"model.lora_attn_modules=[q_proj, v_proj, output_proj]",
+							"model.quantize_base=True",
+						},
 						corev1.ResourceList{},
 					).
 					Obj(),
@@ -1699,7 +1702,10 @@ func TestValidate(t *testing.T) {
 					Container(
 						"ghcr.io/kubeflow/trainer/torchtune-trainer",
 						[]string{"tune", "run"},
-						[]string{constants.TorchTuneTrainerUseQLoRA},
+						[]string{
+							"model.lora_attn_modules=[q_proj, v_proj, output_proj]",
+							"model.quantize_base=True",
+						},
 						corev1.ResourceList{
 							"example.com/gpu": resource.MustParse("2"),
 						},

--- a/pkg/runtime/framework/plugins/torch/torch_test.go
+++ b/pkg/runtime/framework/plugins/torch/torch_test.go
@@ -117,7 +117,7 @@ func TestTorch(t *testing.T) {
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvNumProcPerNode),
-									Value: ptr.To("auto"),
+									Value: ptr.To("1"),
 								},
 								{
 									Name: ptr.To(constants.TorchEnvNodeRank),

--- a/pkg/runtime/framework/plugins/torch/torchtune.go
+++ b/pkg/runtime/framework/plugins/torch/torchtune.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2025 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package torch
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	jobsetv1alpha2ac "sigs.k8s.io/jobset/client-go/applyconfiguration/jobset/v1alpha2"
+
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	"github.com/kubeflow/trainer/v2/pkg/constants"
+	"github.com/kubeflow/trainer/v2/pkg/runtime"
+)
+
+func validateTorchTune(runtimeInfo *runtime.Info,  newObj *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
+	var allErrs field.ErrorList
+	specPath := field.NewPath("spec")
+
+	runtimeRefNamePath := specPath.Child("runtimeRef").Child("name")
+	model := getModelFromRuntimeRef(newObj.Spec.RuntimeRef.Name)
+
+	if !constants.TorchTuneSupportedPretrainedModels.Has(model) {
+		allErrs = append(allErrs, field.Invalid(runtimeRefNamePath, newObj.Spec.RuntimeRef.Name, fmt.Sprintf("must have a supported pretrained model, invalid model configured: %v", model)))
+	}
+
+	numNodesRefPath := specPath.Child("trainer").Child("numNodes")
+	numNodes := *newObj.Spec.Trainer.NumNodes
+	if numNodes > 1 && model != constants.TORCHTUNE_MODEL_LLAMA3_3_70B {
+		allErrs = append(allErrs, field.Invalid(numNodesRefPath, numNodes, fmt.Sprintf("must be 1 for %v model", model)))
+	}
+
+	numProcPerNodeRefPath := specPath.Child("trainer").Child("numProcPerNode")
+	numProcPerNode := *newObj.Spec.Trainer.NumProcPerNode
+	resourcesPerNode := ptr.Deref(extractResourcePerNodeFromRuntime(runtimeInfo), corev1.ResourceRequirements{})
+	if jobTrainer := newObj.Spec.Trainer; jobTrainer != nil && jobTrainer.ResourcesPerNode != nil {
+		resourcesPerNode = ptr.Deref(jobTrainer.ResourcesPerNode, corev1.ResourceRequirements{})
+	}
+	_, config := getRecipeAndConfig(numNodes, numProcPerNode, getNumGPUPerNode(&resourcesPerNode), newObj)
+	if strings.Contains(config, constants.TorchTuneQLoRAFinetuneDistributedConfigSuffix) {
+		if model == constants.TORCHTUNE_MODEL_QWEN2_5_1_5B {
+			allErrs = append(allErrs, field.Invalid(runtimeRefNamePath, newObj.Spec.RuntimeRef.Name, fmt.Sprintf("QLoRA is not supported for %v model", model)))
+		}
+		resourcePerNodeRefPath := specPath.Child("trainer").Child("resourcesPerNode")
+		if !strings.Contains(config, constants.TorchTuneQLoRAFinetuneSingleDeviceConfigSuffix) &&
+			(model == constants.TORCHTUNE_MODEL_LLAMA3_2_1B || model == constants.TORCHTUNE_MODEL_LLAMA3_2_3B) {
+			allErrs = append(
+				allErrs,
+				field.Invalid(numProcPerNodeRefPath, numProcPerNode, fmt.Sprintf("must be auto or 1 for %v model when using QLoRA", model)),
+				field.Invalid(resourcePerNodeRefPath, newObj.Spec.Trainer.ResourcesPerNode, fmt.Sprintf("must have gpu resource with value 1 for %v model when using QLoRA", model)),
+			)
+		}
+	}
+	return nil, allErrs
+}
+
+// getRecipeAndConfig returns the recipe and config file name based on the number of nodes,
+// number of processes per node, gpu count, resource per node, model name, and command line arguments.
+func getRecipeAndConfig(numNodes int32, numProcPerNode intstr.IntOrString, gpuQ int, trainJob *trainer.TrainJob) (string, string) {
+	recipe := constants.TorchTuneFullFinetuneDistributed
+	suffix := constants.TorchTuneFullFinetuneMultiDevicesConfigSuffix
+	if numNodes == 1 && (numProcPerNode.Type == intstr.Int && numProcPerNode.IntVal == 1 || gpuQ == 1) {
+		if isUseQLoraFinetune(trainJob.Spec.Trainer.Args) {
+			recipe = constants.TorchTuneLoRAFinetuneSingleDevice
+			suffix = constants.TorchTuneQLoRAFinetuneSingleDeviceConfigSuffix
+		} else if isLoraConfigEnabled(trainJob.Spec.Trainer.Args) {
+			recipe = constants.TorchTuneLoRAFinetuneSingleDevice
+			suffix = constants.TorchTuneLoRAFinetuneSingleDeviceConfigSuffix
+		} else {
+			recipe = constants.TorchTuneFullFinetuneSingleDevice
+			suffix = constants.TorchTuneFullFinetuneSingleDeviceConfigSuffix
+		}
+	} else if numNodes == 1 && isUseQLoraFinetune(trainJob.Spec.Trainer.Args) {
+		recipe = constants.TorchTuneLoRAFinetuneDistributed
+		suffix = constants.TorchTuneQLoRAFinetuneDistributedConfigSuffix
+	} else if numNodes == 1 && isLoraConfigEnabled(trainJob.Spec.Trainer.Args) {
+		recipe = constants.TorchTuneLoRAFinetuneDistributed
+		suffix = constants.TorchTuneLoRAFinetuneDistributedConfigSuffix
+	} else if numNodes > 1 {
+		suffix = constants.TorchTuneFullFinetuneMultiNodesConfigSuffix
+	}
+
+	return recipe, fmt.Sprintf("%s%s", getModelFromRuntimeRef(trainJob.Spec.RuntimeRef.Name), suffix)
+}
+
+// isLoraConfigEnabled checks if we enables LoraConfig.
+func isLoraConfigEnabled(args []string) bool {
+	for _, arg := range args {
+		if strings.Contains(arg, constants.TorchTuneLoraAttnModules) {
+			return true
+		}
+	}
+	return false
+}
+
+// isUseQLoraFinetune checks if QLoRA fine-tuning should be used.
+func isUseQLoraFinetune(args []string) bool {
+	hasQuantizeBase := false
+	for _, arg := range args {
+		switch {
+		case strings.Contains(arg, constants.TorchTuneUseDora):
+			// If Dora is enabled, no need to continue
+			return false
+		case strings.Contains(arg, constants.TorchTuneQuantizeBase):
+			hasQuantizeBase = true
+		}
+	}
+	return hasQuantizeBase
+}
+
+// extractOverridesFromRuntime extracts overrides from the TorchTune Trainer Node.
+func extractOverridesFromRuntime(info *runtime.Info) []string {
+	overrides := []string{}
+	jobSetSpec, ok := runtime.TemplateSpecApply[jobsetv1alpha2ac.JobSetSpecApplyConfiguration](info)
+	if !ok {
+		return overrides
+	}
+
+	for _, rJob := range jobSetSpec.ReplicatedJobs {
+		jobMetadata := rJob.Template.ObjectMetaApplyConfiguration
+		if jobMetadata == nil || jobMetadata.Labels == nil {
+			continue
+		}
+		if ancestor, ok := jobMetadata.Labels[constants.LabelTrainJobAncestor]; ok && ancestor == constants.AncestorTrainer {
+			for _, container := range rJob.Template.Spec.Template.Spec.Containers {
+				if container.Name != nil && *container.Name == constants.Node {
+					for _, command := range container.Command {
+						if constants.TorchTuneImmutableConfigs.Has(strings.Split(command, "=")[0]) {
+							overrides = append(overrides, command)
+						}
+					}
+				}
+			}
+		}
+	}
+	return overrides
+}
+
+func getModelFromRuntimeRef(runtimeRefName string) string {
+	fields := strings.Split(runtimeRefName, "-")
+	if len(fields) != 3 {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s", strings.ReplaceAll(fields[1], ".", "_"), strings.ToUpper(fields[2]))
+}

--- a/pkg/runtime/framework/plugins/torch/torchtune.go
+++ b/pkg/runtime/framework/plugins/torch/torchtune.go
@@ -32,7 +32,7 @@ import (
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
 )
 
-func validateTorchTune(runtimeInfo *runtime.Info,  newObj *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
+func validateTorchTune(runtimeInfo *runtime.Info, newObj *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
 	var allErrs field.ErrorList
 	specPath := field.NewPath("spec")
 

--- a/pkg/util/testing/wrapper.go
+++ b/pkg/util/testing/wrapper.go
@@ -644,13 +644,6 @@ func (t *TrainJobTrainerWrapper) NumProcPerNode(numProcPerNode intstr.IntOrStrin
 	return t
 }
 
-func (t *TrainJobTrainerWrapper) ResourcesPerNode(resourcePerNode corev1.ResourceList) *TrainJobTrainerWrapper {
-	t.Trainer.ResourcesPerNode = &corev1.ResourceRequirements{
-		Requests: resourcePerNode,
-	}
-	return t
-}
-
 func (t *TrainJobTrainerWrapper) Container(image string, command []string, args []string, resRequests corev1.ResourceList) *TrainJobTrainerWrapper {
 	t.Trainer.Image = &image
 	t.Trainer.Command = command

--- a/pkg/util/testing/wrapper.go
+++ b/pkg/util/testing/wrapper.go
@@ -644,6 +644,13 @@ func (t *TrainJobTrainerWrapper) NumProcPerNode(numProcPerNode intstr.IntOrStrin
 	return t
 }
 
+func (t *TrainJobTrainerWrapper) ResourcesPerNode(resourcePerNode corev1.ResourceList) *TrainJobTrainerWrapper {
+	t.Trainer.ResourcesPerNode = &corev1.ResourceRequirements{
+		Requests: resourcePerNode,
+	}
+	return t
+}
+
 func (t *TrainJobTrainerWrapper) Container(image string, command []string, args []string, resRequests corev1.ResourceList) *TrainJobTrainerWrapper {
 	t.Trainer.Image = &image
 	t.Trainer.Command = command


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR adds support for LoRA/QLoRA/DoRA in LLM Trainer V2.

I tested it with scripts:

```py
from kubeflow.trainer import *

client = TrainerClient()

# QLoRA
client.train(
    runtime=client.get_runtime(name="torchtune-llama3.2-1b"),
    initializer=Initializer(
        dataset=HuggingFaceDatasetInitializer(
            storage_uri="hf://tatsu-lab/alpaca/data"
        ),
        model=HuggingFaceModelInitializer(
            storage_uri="hf://meta-llama/Llama-3.2-1B-Instruct",
            access_token="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",
        )
    ),
    trainer=BuiltinTrainer(
        config=TorchTuneConfig(
            dataset_preprocess_config=TorchTuneInstructDataset(
                source=DataFormat.PARQUET,
            ),
            peft_config=LoraConfig(
                apply_lora_to_mlp=True,
                lora_attn_modules=["q_proj", "k_proj", "v_proj", "output_proj"],
                quantize_base=True,
            ),
            resources_per_node={
                "gpu": 1,
            }
        )
    )
)
```

Results:

```
Setting manual seed to local seed 2668943352. Local seed is seed + rank = 2668943352 + 0
Model is initialized with precision torch.bfloat16.
Memory stats after model init:
        GPU peak memory allocation: 1.21 GiB
        GPU peak memory reserved: 1.25 GiB
        GPU peak memory active: 1.21 GiB
Tokenizer is initialized from file.
Optimizer and loss are initialized.
Loss is initialized.
Writing logs to /workspace/output/logs/log_1758120939.txt
Generating train split: 52002 examples [00:00, 275879.07 examples/s]
Learning rate scheduler is initialized.
 Profiling disabled.
 Profiler config after instantiation: {'enabled': False}
1|1625|Loss: 1.6104315519332886: 100%|██████████| 1625/1625 [32:52<00:00,  1.26s/it]Starting checkpoint save...
Model checkpoint of size 2.30 GiB saved to /workspace/output/epoch_0/model-00001-of-00001.safetensors
Adapter checkpoint of size 0.08 GiB saved to /workspace/output/epoch_0/adapter_model.pt
Adapter checkpoint of size 0.08 GiB saved to /workspace/output/epoch_0/adapter_model.safetensors
Adapter checkpoint of size 0.00 GiB saved to /workspace/output/epoch_0/adapter_config.json
Saving final epoch checkpoint.
The full model checkpoint, including all weights and configurations, has been saved successfully.You can now use this checkpoint for further training or inference.
Checkpoint saved in 5.90 seconds.
1|1625|Loss: 1.6104315519332886: 100%|██████████| 1625/1625 [32:57<00:00,  1.22s/it]
```

/cc @kubeflow/kubeflow-trainer-team @kubeflow/wg-training-leads @kramaranya @szaher @deepanker13 @franciscojavierarceo @varodrig @rudeigerc 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2505

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
