### PR TITLE
feat: Add a public function to create runtime info objects

### DIFF
--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -37,6 +37,7 @@ type Runtime interface {
 	// https://github.com/kubernetes/kubernetes/pull/129313 becomes available
 
 	NewObjects(ctx context.Context, trainJob *trainer.TrainJob) ([]any, error)
+	RuntimeInfo(trainJob *trainer.TrainJob, runtimeTemplateSpec any, mlPolicy *trainer.MLPolicy, podGroupPolicy *trainer.PodGroupPolicy) (*Info, error)
 	TerminalCondition(ctx context.Context, trainJob *trainer.TrainJob) (*metav1.Condition, error)
 	EventHandlerRegistrars() []ReconcilerBuilder
 	ValidateObjects(ctx context.Context, old, new *trainer.TrainJob) (admission.Warnings, field.ErrorList)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
In order to integrate Trainer with Kueue, we need to retrieve job level properties without having to lookup the generated JobSet


**Which issue(s) this PR fixes** 
Fixes #2836 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
