### PR TITLE
fix(runtimes): fix missing dependency in torchtune trainer image.

### DIFF
--- a/cmd/trainers/torchtune/Dockerfile
+++ b/cmd/trainers/torchtune/Dockerfile
@@ -2,6 +2,10 @@ FROM pytorch/pytorch:2.7.1-cuda12.8-cudnn9-runtime
 
 WORKDIR /workspace
 
+# Install build-essential for compiling any dependencies
+RUN apt update && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy the required Python modules
 COPY cmd/trainers/torchtune/requirements.txt .
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR fix the missing dependency in torchtune trainer image by installing `build-essentials`.

After fixing this error, the torchtune trainer works as expected on my development cluster:

```
Setting manual seed to local seed 1978145440. Local seed is seed + rank = 1978145440 + 0
Model is initialized with precision torch.bfloat16.
Memory stats after model init:
        GPU peak memory allocation: 2.33 GiB
        GPU peak memory reserved: 2.34 GiB
        GPU peak memory active: 2.33 GiB
Tokenizer is initialized from file.
In-backward optimizers are set up.
Loss is initialized.
Writing logs to /workspace/output/logs/log_1760171624.txt
Generating train split: 52002 examples [00:00, 243423.09 examples/s]
No learning rate scheduler configured. Using constant learning rate.
 Profiling disabled.
 Profiler config after instantiation: {'enabled': False}
1|674|Loss: 1.6298757791519165:   5%|▌      %
```

/cc @kubeflow/kubeflow-trainer-team 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2884

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
