### PR TITLE
feat(docs): KEP-2779: Track TrainJob progress and expose training metrics

### DIFF
--- a/docs/proposals/2779-trainjob-progress/README.md
+++ b/docs/proposals/2779-trainjob-progress/README.md
@@ -395,14 +395,14 @@ The same changes will be made to the TrainJob as in the [push-based design](#crd
 
 ##### Sidecar container injection
 
-To enable monitoring and sidecar injection, users must add the label `trainer.kubeflow.org/trainjob-monitoring-step: trainer` to one of the replicated jobs in their (Cluster)TrainingRuntime. This will cause the control plane to:
+To enable monitoring and sidecar injection, users must add the annotation `trainer.kubeflow.org/trainjob-monitoring-step: trainer` to one of the replicated jobs in their (Cluster)TrainingRuntime. This will cause the control plane to:
 - inject a [sidecar container](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/) into **one** of the trainer pods
 - inject a shared `emptyDir` volume between the sidecar and all other containers in that pod.
-- create a new service `<train-job-name>-trainer-monitoring` pointing at the sidecar http server. The control plane will add the label `trainer.kubeflow.org/trainjob-monitoring-pod: true` to the pod which will be used in the service selector.
+- create a new service `<train-job-name>-trainer-monitoring` pointing at the sidecar http server. The control plane will add the label `trainer.kubeflow.org/trainjob-monitoring-pod: <train-job-name>` to the pod which will be used in the service selector.
 
 The sidecar will contain a lightweight http server packaged as a new image published with the Kubeflow Trainer release. The server reads the current metrics directly from a file in the shared volume when handling each request.
 
-Users can optionally add the labels `trainer.kubeflow.org/monitoring-port: <port-number>` (defaults to `28080`) and `trainer.kubeflow.org/monitoring-interval: <duration>` (defaults to `30s`) to replicated job in their (Cluster)TrainingRuntime to configure the sidecar container port and scrape interval.
+Users can optionally add the annotations `trainer.kubeflow.org/monitoring-port: <port-number>` (defaults to `28080`) and `trainer.kubeflow.org/monitoring-interval: <duration>` (defaults to `30s`) to replicated job in their (Cluster)TrainingRuntime to configure the sidecar container port and scrape interval.
 
 Additional details:
 - The control plane will set the sidecar `terminationMessagePath` to the location of the shared file to allow the final metrics to be collected. See [Scraping the metrics](#scraping-the-metrics).
@@ -421,7 +421,7 @@ spec:
         - name: node
           template:
             metadata:
-              labels:
+              annotations:
                 trainer.kubeflow.org/trainjob-monitoring-step: trainer
                 trainer.kubeflow.org/trainjob-monitoring-port: 28080
                 trainer.kubeflow.org/trainjob-monitoring-interval: 30s


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This is a KEP for adding real-time progress and exposing training metrics on TrainJob.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Part of #2779 
