### PR TITLE
fix(examples): Fix SSL certificate error for local MNIST example

### DIFF
--- a/examples/local/local-training-mnist.ipynb
+++ b/examples/local/local-training-mnist.ipynb
@@ -221,7 +221,7 @@
     "job_name = client.train(\n",
     "    trainer=CustomTrainer(\n",
     "        func=train_mnist,\n",
-    "        packages_to_install=[\"torch\", \"torchvision\"],\n",
+    "        packages_to_install=[\"pip-system-certs\", \"torch\", \"torchvision\"],\n",
     "    ),\n",
     "    runtime=torch_runtime,\n",
     ")"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #2970

This adds `pip-system-certs` to the packages to install in the local MNIST example so Python uses the OS CA certificates instead of the bundled ones.

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
