### PR TITLE
chore(operator): Remove Unstructured objects caching

### DIFF
--- a/cmd/trainer-controller-manager/main.go
+++ b/cmd/trainer-controller-manager/main.go
@@ -28,7 +28,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlpkg "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -95,13 +94,6 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "Unable to load configuration")
 		os.Exit(1)
-	}
-
-	// Set client cache options
-	options.Client = client.Options{
-		Cache: &client.CacheOptions{
-			Unstructured: true,
-		},
 	}
 
 	setupLog.Info("Creating manager")


### PR DESCRIPTION
**What this PR does / why we need it**:

Caching of Unstructured objects was put in place to work-around the absence of native support for SSA in controller-runtime, but this can now be removed after #2877.

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
