### PR TITLE
Add missing ports to the container

### DIFF
--- a/manifests/base/manager/manager.yaml
+++ b/manifests/base/manager/manager.yaml
@@ -31,6 +31,13 @@ spec:
                 - ALL
             seccompProfile:
               type: RuntimeDefault
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+              name: monitoring-port
+            - containerPort: 9443
+              protocol: TCP
+              name: webhook-server
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert


### PR DESCRIPTION
The ports were missing and hence the corresponding service was not able to connect to the pods.

**What this PR does / why we need it**:
The ports were missing and hence the corresponding service was not able to connect to the containers. A quick fix is to add ports information inside the deployment manifest.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->


**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
