### PR TITLE
chore: Add welcome workflow for new contributors

### DIFF
--- a/.github/workflows/welcome-new-contributors.yaml
+++ b/.github/workflows/welcome-new-contributors.yaml
@@ -45,7 +45,7 @@ jobs:
             **Here's what happens next:**
 
             - If you haven't already, please check out our [Contributing Guide](https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md) for repo-specific guidelines and the [Kubeflow Contributor Guide](https://www.kubeflow.org/docs/about/contributing/) for general community standards.
-            - Our team will review your PR soon!
+            - Our team will review your PR soon! cc @kubeflow/kubeflow-trainer-team
 
             **Join the community:**
             - **Slack**: Join our [#kubeflow-trainer](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels) Slack channel.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a GitHub Action workflow to automatically welcome first-time contributors when they open their first issue or pull request.

- Uses `actions/first-interaction@v3`.
- Adapted the message content from `kubeflow/sdk` but updated references to point to `kubeflow/trainer` resources (Contributing Guide, Slack channel).
- Configured permissions to `contents: read` for security.
- Verified the workflow functionality in a sandbox repository.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #3016

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing (N/A - CI workflow only)