### PR TITLE
fix(ci): Fix kube-api-linter install

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,18 +1,23 @@
 # golangci-lint configuration file
 # see: https://golangci-lint.run/usage/configuration/
 
-# Settings of specific linters
-linters-settings:
-  gci:
-    sections:
-      - standard # Standard section: captures all standard packages.
-      - default # Default section: contains all imports that could not be matched to another section type.
-      - prefix(github.com/kubeflow/trainer/v2) # Custom section: groups all imports with the specified Prefix.
-      - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
-      - dot # Dot section: contains all dot imports.
-    skip-generated: true # Skip generated files.
+version: "2"
 
-# Settings for enabling and disabling linters
-linters:
+run:
+  go: "1.24"
+  allow-parallel-runners: true
+
+issues:
+  max-same-issues: 0
+
+formatters:
   enable:
     - gci
+  settings:
+    gci:
+      sections:
+        - standard # Standard section: captures all standard packages.
+        - default # Default section: contains all imports that could not be matched to another section type.
+        - prefix(github.com/kubeflow/trainer) # Custom section: groups all imports with the specified Prefix.
+        - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
+        - dot # Dot section: contains all dot imports.

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ KIND ?= $(LOCALBIN)/kind
 HELM ?= $(LOCALBIN)/helm
 HELM_DOCS ?= $(LOCALBIN)/helm-docs
 YQ ?= $(LOCALBIN)/yq
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 GOLANGCI_LINT_KAL ?= $(LOCALBIN)/golangci-lint-kube-api-linter
 
 ##@ General
@@ -82,13 +83,9 @@ kind: ## Download Kind binary if required.
 helm: ## Download helm locally if required.
 	GOBIN=$(LOCALBIN) go install helm.sh/helm/v3/cmd/helm@$(HELM_VERSION)
 
-GOLANGCI_LINT=$(shell which golangci-lint)
-.PHONY: golangci-lint
-golangci-lint-install: ## Run golangci-lint to verify Go files.
-ifeq ($(GOLANGCI_LINT),)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.64.8
-	$(info golangci-lint has been installed)
-endif
+.PHONY: golangci-lint-install
+golangci-lint-install: ## Download golangci-lint locally if required.
+	@GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.1
 
 .PHONY: golangci-lint-kal
 golangci-lint-kal: ## Build golangci-lint-kal from custom configuration.
@@ -165,7 +162,7 @@ vet: ## Run go vet against the code.
 
 .PHONY: golangci-lint
 golangci-lint: golangci-lint-install golangci-lint-kal ## Run golangci-lint to verify Go files.
-	golangci-lint run --timeout 5m --go 1.24 ./...
+	$(GOLANGCI_LINT) run --timeout 5m ./...
 	$(GOLANGCI_LINT_KAL) run -v --config $(PROJECT_DIR)/.golangci-kal.yml
 
 # Instructions to run tests.

--- a/hack/swagger/main.go
+++ b/hack/swagger/main.go
@@ -89,10 +89,10 @@ func main() {
 }
 
 func swaggify(name string) string {
-	name = strings.Replace(name, "github.com/kubeflow/trainer/v2/pkg/apis/", "", -1)
-	name = strings.Replace(name, "sigs.k8s.io/jobset/api/", "", -1)
-	name = strings.Replace(name, "volcano.sh/apis/pkg/apis/", "", -1)
-	name = strings.Replace(name, "k8s.io", "io.k8s", -1)
-	name = strings.Replace(name, "/", ".", -1)
+	name = strings.ReplaceAll(name, "github.com/kubeflow/trainer/v2/pkg/apis/", "")
+	name = strings.ReplaceAll(name, "sigs.k8s.io/jobset/api/", "")
+	name = strings.ReplaceAll(name, "volcano.sh/apis/pkg/apis/", "")
+	name = strings.ReplaceAll(name, "k8s.io", "io.k8s")
+	name = strings.ReplaceAll(name, "/", ".")
 	return name
 }

--- a/pkg/runtime/framework/plugins/coscheduling/coscheduling.go
+++ b/pkg/runtime/framework/plugins/coscheduling/coscheduling.go
@@ -45,8 +45,7 @@ import (
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework"
-	index "github.com/kubeflow/trainer/v2/pkg/runtime/indexer"
-	runtimeindexer "github.com/kubeflow/trainer/v2/pkg/runtime/indexer"
+	"github.com/kubeflow/trainer/v2/pkg/runtime/indexer"
 )
 
 type CoScheduling struct {
@@ -173,18 +172,18 @@ func (h *PodGroupRuntimeClassHandler) Generic(context.Context, event.TypedGeneri
 
 func (h *PodGroupRuntimeClassHandler) queueSuspendedTrainJobs(ctx context.Context, runtimeClass *nodev1.RuntimeClass, q workqueue.TypedRateLimitingInterface[reconcile.Request]) error {
 	var trainingRuntimes trainer.TrainingRuntimeList
-	if err := h.client.List(ctx, &trainingRuntimes, client.MatchingFields{index.TrainingRuntimeContainerRuntimeClassKey: runtimeClass.Name}); err != nil {
+	if err := h.client.List(ctx, &trainingRuntimes, client.MatchingFields{indexer.TrainingRuntimeContainerRuntimeClassKey: runtimeClass.Name}); err != nil {
 		return err
 	}
 	var clusterTrainingRuntimes trainer.ClusterTrainingRuntimeList
-	if err := h.client.List(ctx, &clusterTrainingRuntimes, client.MatchingFields{index.ClusterTrainingRuntimeContainerRuntimeClassKey: runtimeClass.Name}); err != nil {
+	if err := h.client.List(ctx, &clusterTrainingRuntimes, client.MatchingFields{indexer.ClusterTrainingRuntimeContainerRuntimeClassKey: runtimeClass.Name}); err != nil {
 		return err
 	}
 
 	var trainJobs []trainer.TrainJob
 	for _, trainingRuntime := range trainingRuntimes.Items {
 		var trainJobsWithTrainingRuntime trainer.TrainJobList
-		err := h.client.List(ctx, &trainJobsWithTrainingRuntime, client.MatchingFields{runtimeindexer.TrainJobRuntimeRefKey: trainingRuntime.Name})
+		err := h.client.List(ctx, &trainJobsWithTrainingRuntime, client.MatchingFields{indexer.TrainJobRuntimeRefKey: trainingRuntime.Name})
 		if err != nil {
 			return err
 		}
@@ -192,7 +191,7 @@ func (h *PodGroupRuntimeClassHandler) queueSuspendedTrainJobs(ctx context.Contex
 	}
 	for _, clusterTrainingRuntime := range clusterTrainingRuntimes.Items {
 		var trainJobsWithClTrainingRuntime trainer.TrainJobList
-		err := h.client.List(ctx, &trainJobsWithClTrainingRuntime, client.MatchingFields{runtimeindexer.TrainJobClusterRuntimeRefKey: clusterTrainingRuntime.Name})
+		err := h.client.List(ctx, &trainJobsWithClTrainingRuntime, client.MatchingFields{indexer.TrainJobClusterRuntimeRefKey: clusterTrainingRuntime.Name})
 		if err != nil {
 			return err
 		}

--- a/pkg/runtime/framework/plugins/volcano/volcano.go
+++ b/pkg/runtime/framework/plugins/volcano/volcano.go
@@ -51,8 +51,7 @@ import (
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework"
-	index "github.com/kubeflow/trainer/v2/pkg/runtime/indexer"
-	runtimeindexer "github.com/kubeflow/trainer/v2/pkg/runtime/indexer"
+	"github.com/kubeflow/trainer/v2/pkg/runtime/indexer"
 )
 
 type Volcano struct {
@@ -246,18 +245,18 @@ func (h *PodGroupRuntimeClassHandler) Generic(context.Context, event.TypedGeneri
 
 func (h *PodGroupRuntimeClassHandler) queueSuspendedTrainJobs(ctx context.Context, runtimeClass *nodev1.RuntimeClass, q workqueue.TypedRateLimitingInterface[reconcile.Request]) error {
 	var trainingRuntimes trainer.TrainingRuntimeList
-	if err := h.client.List(ctx, &trainingRuntimes, client.MatchingFields{index.TrainingRuntimeContainerRuntimeClassKey: runtimeClass.Name}); err != nil {
+	if err := h.client.List(ctx, &trainingRuntimes, client.MatchingFields{indexer.TrainingRuntimeContainerRuntimeClassKey: runtimeClass.Name}); err != nil {
 		return err
 	}
 	var clusterTrainingRuntimes trainer.ClusterTrainingRuntimeList
-	if err := h.client.List(ctx, &clusterTrainingRuntimes, client.MatchingFields{index.ClusterTrainingRuntimeContainerRuntimeClassKey: runtimeClass.Name}); err != nil {
+	if err := h.client.List(ctx, &clusterTrainingRuntimes, client.MatchingFields{indexer.ClusterTrainingRuntimeContainerRuntimeClassKey: runtimeClass.Name}); err != nil {
 		return err
 	}
 
 	var trainJobs []trainer.TrainJob
 	for _, trainingRuntime := range trainingRuntimes.Items {
 		var trainJobsWithTrainingRuntime trainer.TrainJobList
-		err := h.client.List(ctx, &trainJobsWithTrainingRuntime, client.MatchingFields{runtimeindexer.TrainJobRuntimeRefKey: trainingRuntime.Name})
+		err := h.client.List(ctx, &trainJobsWithTrainingRuntime, client.MatchingFields{indexer.TrainJobRuntimeRefKey: trainingRuntime.Name})
 		if err != nil {
 			return err
 		}
@@ -265,7 +264,7 @@ func (h *PodGroupRuntimeClassHandler) queueSuspendedTrainJobs(ctx context.Contex
 	}
 	for _, clusterTrainingRuntime := range clusterTrainingRuntimes.Items {
 		var trainJobsWithClTrainingRuntime trainer.TrainJobList
-		err := h.client.List(ctx, &trainJobsWithClTrainingRuntime, client.MatchingFields{runtimeindexer.TrainJobClusterRuntimeRefKey: clusterTrainingRuntime.Name})
+		err := h.client.List(ctx, &trainJobsWithClTrainingRuntime, client.MatchingFields{indexer.TrainJobClusterRuntimeRefKey: clusterTrainingRuntime.Name})
 		if err != nil {
 			return err
 		}

--- a/pkg/util/testing/client.go
+++ b/pkg/util/testing/client.go
@@ -56,7 +56,7 @@ func (b *builderIndexer) IndexField(_ context.Context, obj client.Object, field 
 	if obj == nil || field == "" || extractValue == nil {
 		return fmt.Errorf("error from test indexer")
 	}
-	b.ClientBuilder = b.ClientBuilder.WithIndex(obj, field, extractValue)
+	b.ClientBuilder = b.WithIndex(obj, field, extractValue)
 	return nil
 }
 

--- a/pkg/util/testing/compare.go
+++ b/pkg/util/testing/compare.go
@@ -46,13 +46,11 @@ var (
 )
 
 func MPISecretDataComparer(a, b map[string][]byte) bool {
-	isKeysEqual := true
-	if (a != nil && b != nil) &&
-		((len(a[constants.MPISSHPublicKey]) > 0) != (len(b[constants.MPISSHPublicKey]) > 0) ||
-			(len(a[corev1.SSHAuthPrivateKey]) > 0) != (len(b[corev1.SSHAuthPrivateKey]) > 0)) {
-		isKeysEqual = false
-	}
-	return isKeysEqual && cmp.Equal(a, b, cmpopts.IgnoreMapEntries(func(k string, _ []byte) bool {
+	areKeysEqual := (a == nil || b != nil) ||
+		((len(a[constants.MPISSHPublicKey]) > 0) == (len(b[constants.MPISSHPublicKey]) > 0) &&
+			(len(a[corev1.SSHAuthPrivateKey]) > 0) == (len(b[corev1.SSHAuthPrivateKey]) > 0))
+
+	return areKeysEqual && cmp.Equal(a, b, cmpopts.IgnoreMapEntries(func(k string, _ []byte) bool {
 		return k == constants.MPISSHPublicKey || k == corev1.SSHAuthPrivateKey
 	}))
 }

--- a/pkg/util/testing/wrapper.go
+++ b/pkg/util/testing/wrapper.go
@@ -520,18 +520,18 @@ func (j *JobSetWrapper) PodPriorityClassName(value string) *JobSetWrapper {
 }
 
 func (j *JobSetWrapper) Label(key, value string) *JobSetWrapper {
-	if j.ObjectMeta.Labels == nil {
-		j.ObjectMeta.Labels = make(map[string]string, 1)
+	if j.Labels == nil {
+		j.Labels = make(map[string]string, 1)
 	}
-	j.ObjectMeta.Labels[key] = value
+	j.Labels[key] = value
 	return j
 }
 
 func (j *JobSetWrapper) Annotation(key, value string) *JobSetWrapper {
-	if j.ObjectMeta.Annotations == nil {
-		j.ObjectMeta.Annotations = make(map[string]string, 1)
+	if j.Annotations == nil {
+		j.Annotations = make(map[string]string, 1)
 	}
-	j.ObjectMeta.Annotations[key] = value
+	j.Annotations[key] = value
 	return j
 }
 
@@ -665,10 +665,10 @@ func (t *TrainJobTrainerWrapper) NumProcPerNode(numProcPerNode intstr.IntOrStrin
 }
 
 func (t *TrainJobTrainerWrapper) Container(image string, command []string, args []string, resRequests corev1.ResourceList) *TrainJobTrainerWrapper {
-	t.Trainer.Image = &image
-	t.Trainer.Command = command
-	t.Trainer.Args = args
-	t.Trainer.ResourcesPerNode = &corev1.ResourceRequirements{
+	t.Image = &image
+	t.Command = command
+	t.Args = args
+	t.ResourcesPerNode = &corev1.ResourceRequirements{
 		Requests: resRequests,
 	}
 	return t
@@ -694,12 +694,12 @@ func MakeTrainJobInitializerWrapper() *TrainJobInitializerWrapper {
 }
 
 func (t *TrainJobInitializerWrapper) DatasetInitializer(datasetInitializer *trainer.DatasetInitializer) *TrainJobInitializerWrapper {
-	t.Initializer.Dataset = datasetInitializer
+	t.Dataset = datasetInitializer
 	return t
 }
 
 func (t *TrainJobInitializerWrapper) ModelInitializer(modelInitializer *trainer.ModelInitializer) *TrainJobInitializerWrapper {
-	t.Initializer.Model = modelInitializer
+	t.Model = modelInitializer
 	return t
 }
 
@@ -901,18 +901,18 @@ func MakeTrainingRuntimeWrapper(namespace, name string) *TrainingRuntimeWrapper 
 }
 
 func (r *TrainingRuntimeWrapper) Label(key, value string) *TrainingRuntimeWrapper {
-	if r.ObjectMeta.Labels == nil {
-		r.ObjectMeta.Labels = make(map[string]string, 1)
+	if r.Labels == nil {
+		r.Labels = make(map[string]string, 1)
 	}
-	r.ObjectMeta.Labels[key] = value
+	r.Labels[key] = value
 	return r
 }
 
 func (r *TrainingRuntimeWrapper) Annotation(key, value string) *TrainingRuntimeWrapper {
-	if r.ObjectMeta.Annotations == nil {
-		r.ObjectMeta.Annotations = make(map[string]string, 1)
+	if r.Annotations == nil {
+		r.Annotations = make(map[string]string, 1)
 	}
-	r.ObjectMeta.Annotations[key] = value
+	r.Annotations[key] = value
 	return r
 }
 
@@ -1289,17 +1289,17 @@ func MakeSchedulerPluginsPodGroup(namespace, name string) *SchedulerPluginsPodGr
 }
 
 func (p *SchedulerPluginsPodGroupWrapper) MinMember(members int32) *SchedulerPluginsPodGroupWrapper {
-	p.PodGroup.Spec.MinMember = members
+	p.Spec.MinMember = members
 	return p
 }
 
 func (p *SchedulerPluginsPodGroupWrapper) MinResources(resources corev1.ResourceList) *SchedulerPluginsPodGroupWrapper {
-	p.PodGroup.Spec.MinResources = resources
+	p.Spec.MinResources = resources
 	return p
 }
 
 func (p *SchedulerPluginsPodGroupWrapper) SchedulingTimeout(timeout int32) *SchedulerPluginsPodGroupWrapper {
-	p.PodGroup.Spec.ScheduleTimeoutSeconds = &timeout
+	p.Spec.ScheduleTimeoutSeconds = &timeout
 	return p
 }
 
@@ -1339,27 +1339,27 @@ func MakeVolcanoPodGroup(namespace, name string) *VolcanoPodGroupWrapper {
 }
 
 func (p *VolcanoPodGroupWrapper) MinMember(members int32) *VolcanoPodGroupWrapper {
-	p.PodGroup.Spec.MinMember = members
+	p.Spec.MinMember = members
 	return p
 }
 
 func (p *VolcanoPodGroupWrapper) MinResources(resources *corev1.ResourceList) *VolcanoPodGroupWrapper {
-	p.PodGroup.Spec.MinResources = resources
+	p.Spec.MinResources = resources
 	return p
 }
 
 func (p *VolcanoPodGroupWrapper) Queue(queue string) *VolcanoPodGroupWrapper {
-	p.PodGroup.Spec.Queue = queue
+	p.Spec.Queue = queue
 	return p
 }
 
 func (p *VolcanoPodGroupWrapper) PriorityClassName(pc string) *VolcanoPodGroupWrapper {
-	p.PodGroup.Spec.PriorityClassName = pc
+	p.Spec.PriorityClassName = pc
 	return p
 }
 
 func (p *VolcanoPodGroupWrapper) NetworkTopology(mode volcanov1beta1.NetworkTopologyMode, highestTier int) *VolcanoPodGroupWrapper {
-	p.PodGroup.Spec.NetworkTopology = &volcanov1beta1.NetworkTopologySpec{
+	p.Spec.NetworkTopology = &volcanov1beta1.NetworkTopologySpec{
 		Mode:               mode,
 		HighestTierAllowed: &highestTier,
 	}
@@ -1374,7 +1374,7 @@ func (p *VolcanoPodGroupWrapper) ControllerReference(gvk schema.GroupVersionKind
 			UID:       types.UID(uid),
 		},
 	}, gvk)
-	p.PodGroup.OwnerReferences = append(p.PodGroup.OwnerReferences, owner)
+	p.OwnerReferences = append(p.OwnerReferences, owner)
 	return p
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

CI currently fails during golangci-lint execution and the installation of kube-api-linter.

This PR upgrades golangci-lint to the latest version to get https://github.com/golangci/golangci-lint/issues/6205.

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
