### PR TITLE
fix(ci): Fix new contributors GH actions workflow lint errors

### DIFF
--- a/.github/workflows/welcome-new-contributors.yaml
+++ b/.github/workflows/welcome-new-contributors.yaml
@@ -9,9 +9,9 @@ on:
       - opened
 
 permissions:
-  contents: read       
-  issues: write        
-  pull-requests: write 
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   welcome:


### PR DESCRIPTION
**What this PR does / why we need it**:

CI fails because of lint errors after #3016.

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
