### PR TITLE
fix(manifests): fix Prometheus metrics port mismatch

### DIFF
--- a/charts/kubeflow-trainer/templates/manager/service.yaml
+++ b/charts/kubeflow-trainer/templates/manager/service.yaml
@@ -26,8 +26,8 @@ spec:
     {{- include "trainer.manager.selectorLabels" . | nindent 4 }}
   ports:
   - name: monitoring-port
-    port: 8080
-    targetPort: 8080
+    port: 8443
+    targetPort: 8443
   - name: webhook-server
     port: 443
     protocol: TCP

--- a/manifests/base/manager/manager.yaml
+++ b/manifests/base/manager/manager.yaml
@@ -63,8 +63,8 @@ metadata:
 spec:
   ports:
     - name: monitoring-port
-      port: 8080
-      targetPort: 8080
+      port: 8443
+      targetPort: 8443
     - name: webhook-server
       port: 443
       protocol: TCP


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the Prometheus metrics port configuration.
The Service targetPort was set to 8080, but the controller manager's metrics server listens on port 8443 (with secure serving enabled). This caused "connection refused" errors when port-forwarding to access Prometheus metrics.

Changes:
- Update Service `targetPort` from 8080 to 8443 in base manifests
- Update Service targetPort from 8080 to 8443 in Helm chart
- Add `containerPort` declarations for metrics (8443), webhook (9443),  and health (8081) endpoints to make container ports explicit and self-documenting

## Tested in kind cluster
1.  via Service
```
kubectl port-forward -n kubeflow-system svc/kubeflow-trainer-controller-manager 8080:8080
Forwarding from 127.0.0.1:8080 -> 8443
Forwarding from [::1]:8080 -> 8443
```

```
# In another terminal:
curl -k https://localhost:8080/metrics | head -10
```
Output:
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0# HELP certwatcher_read_certificate_errors_total Total number of certificate read errors
# TYPE certwatcher_read_certificate_errors_total counter
certwatcher_read_certificate_errors_total 0
# HELP certwatcher_read_certificate_total Total number of certificate reads
# TYPE certwatcher_read_certificate_total counter
certwatcher_read_certificate_total 231
# HELP controller_runtime_active_workers Number of currently used workers per controller
# TYPE controller_runtime_active_workers gauge
controller_runtime_active_workers{controller="cert-rotator"} 0
controller_runtime_active_workers{controller="clustertrainingruntime_controller"} 0
100 48830    0 48830    0     0  1547k      0 --:--:-- --:--:-- --:--:-- 1589k
```

2. Via Deployment
```
kubectl port-forward -n kubeflow-system deployment/kubeflow-trainer-controller-manager 8080:8443
Forwarding from 127.0.0.1:8080 -> 8443
Forwarding from [::1]:8080 -> 8443
Handling connection for 8080
```
```
# In another terminal:
curl -k https://localhost:8080/metrics | head -10
```
Output:
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0# HELP certwatcher_read_certificate_errors_total Total number of certificate read errors
# TYPE certwatcher_read_certificate_errors_total counter
certwatcher_read_certificate_errors_total 0
# HELP certwatcher_read_certificate_total Total number of certificate reads
# TYPE certwatcher_read_certificate_total counter
certwatcher_read_certificate_total 244
# HELP controller_runtime_active_workers Number of currently used workers per controller
# TYPE controller_runtime_active_workers gauge
controller_runtime_active_workers{controller="cert-rotator"} 0
controller_runtime_active_workers{controller="clustertrainingruntime_controller"} 0
100 82390    0 82390    0     0  2662k      0 --:--:-- --:--:-- --:--:-- 2681k
```


##Fixes # [2547](https://github.com/kubeflow/trainer/issues/2547)  (will close the issue when PR gets merged)

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
