### PR TITLE
feat(docs): proposal for adding TTLSecondsAfterFinished and ActiveDeadlineSeconds fields to TrainJob CRD

### DIFF
--- a/docs/proposals/2899-resource-timeouts/README.md
+++ b/docs/proposals/2899-resource-timeouts/README.md
@@ -1,4 +1,4 @@
-# KEP-2899: Add ActiveDeadlineSeconds to Trainer APIs
+# KEP-2899: Add Resource Timeouts APIs to the Trainer
 
 ## Summary
 
@@ -232,7 +232,7 @@ to implement this enhancement.
 
 ### TTLSecondsAfterFinished
 
-We postpone the implementation of `TTLSecondsAfterFinished` on the `TrainingRuntimeSpec` to avoid user confusion in the v2.2 release. In a future iteration, we plan to implement it to allow platform admins to configure automatic cleanup policies as defaults for all TrainJobs using a runtime. 
+We postpone the implementation of `TTLSecondsAfterFinished` on the `TrainingRuntimeSpec` to avoid user confusion in the v2.2 release. In a future iteration, we plan to implement it to allow platform admins to configure automatic cleanup policies as defaults for all TrainJobs using a runtime.
 
 ## Implementation History
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Fixes #2899 
PR https://github.com/kubeflow/trainer/pull/3258
