### PR TITLE
fix(docker): support multi-arch build for kubectl-delivery image

### DIFF
--- a/build/images/kubectl-delivery/Dockerfile
+++ b/build/images/kubectl-delivery/Dockerfile
@@ -1,10 +1,12 @@
 FROM alpine:3.17 AS build
 
+ARG TARGETARCH
+
 # Install kubectl.
 ENV K8S_VERSION v1.30.7
 
 RUN apk add --no-cache wget
-RUN wget -q https://dl.k8s.io/release/${K8S_VERSION}/bin/linux/amd64/kubectl
+RUN wget -q https://dl.k8s.io/release/${K8S_VERSION}/bin/linux/${TARGETARCH}/kubectl
 RUN chmod +x ./kubectl
 RUN mv ./kubectl /bin/kubectl
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR enables multi-architecture build support (e.g., for linux/arm64) for the kubectl-delivery image in the v1 codebase.

Currently, the Dockerfile has the architecture hardcoded to `amd64`. This prevents users on ARM-based systems from building or using this image with the v1 trainer.

**Changes**:
- Added `ARG TARGETARCH`.
- Replaced hardcoded amd64 with `${TARGETARCH}` in the download URL.

**Testing**: I have verified the build locally using docker buildx:
`docker buildx build --platform linux/amd64,linux/arm64 -t kubectl-delivery:multiarch .`
