### PR TITLE
chore(runtimes): Bump Torch to 2.9.1 version

### DIFF
--- a/cmd/runtimes/deepspeed/requirements.txt
+++ b/cmd/runtimes/deepspeed/requirements.txt
@@ -1,5 +1,5 @@
 # Keep the same version as for Torch runtime.
-torch==2.7.1
+torch==2.9.1
 # DeepSpeed libraries.
 deepspeed==0.18.4
 mpi4py==4.1.1

--- a/examples/pytorch/image-classification/mnist.ipynb
+++ b/examples/pytorch/image-classification/mnist.ipynb
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install torch==2.7.1\n",
+    "!pip install torch==2.9.1\n",
     "!pip install torchvision==0.22.1"
    ]
   },

--- a/hack/e2e-setup-cluster.sh
+++ b/hack/e2e-setup-cluster.sh
@@ -93,7 +93,7 @@ kubectl apply --server-side -k manifests/overlays/runtimes || (
 )
 
 # TODO (andreyvelich): We should build runtime images before adding them.
-TORCH_RUNTIME_IMAGE=pytorch/pytorch:2.7.1-cuda12.8-cudnn9-runtime
+TORCH_RUNTIME_IMAGE=pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime
 DEEPSPEED_RUNTIME_IMAGE=ghcr.io/kubeflow/trainer/deepspeed-runtime:latest
 
 # Load Torch runtime image in KinD

--- a/hack/e2e-setup-gpu-cluster.sh
+++ b/hack/e2e-setup-gpu-cluster.sh
@@ -160,7 +160,7 @@ kubectl apply --server-side -k "${E2E_RUNTIMES_DIR}" || (
 )
 
 # TODO (andreyvelich): Discuss how we want to pre-load runtime images to the Kind cluster.
-TORCH_RUNTIME_IMAGE=pytorch/pytorch:2.7.1-cuda12.8-cudnn9-runtime
+TORCH_RUNTIME_IMAGE=pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime
 ${CONTAINER_RUNTIME} pull ${TORCH_RUNTIME_IMAGE}
 load_image_to_kind ${TORCH_RUNTIME_IMAGE} ${GPU_CLUSTER_NAME}
 

--- a/manifests/base/runtimes/data-cache/torch_distributed_with_cache.yaml
+++ b/manifests/base/runtimes/data-cache/torch_distributed_with_cache.yaml
@@ -46,7 +46,7 @@ spec:
               spec:
                 containers:
                   - name: node
-                    image: pytorch/pytorch:2.7.1-cuda12.8-cudnn9-runtime
+                    image: pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime
                     env:
                       - name: TRAIN_JOB_NAME
                         valueFrom:

--- a/manifests/base/runtimes/torch_distributed.yaml
+++ b/manifests/base/runtimes/torch_distributed.yaml
@@ -22,4 +22,4 @@ spec:
                 spec:
                   containers:
                     - name: node
-                      image: pytorch/pytorch:2.7.1-cuda12.8-cudnn9-runtime
+                      image: pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime


### PR DESCRIPTION
I updated PyTorch version to 2.9.1

/assign @kubeflow/kubeflow-trainer-team 