### PR TITLE
chore: add unit tests for configuration loading and controller options

### DIFF
--- a/pkg/config/config_controller_test.go
+++ b/pkg/config/config_controller_test.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"testing"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
+)
+
+func TestAddTo_ControllerOptions(t *testing.T) {
+	opts := ctrl.Options{}
+
+	metricsAddr := ":9090"
+	secure := true
+	healthAddr := ":8081"
+
+	cfg := &configapi.Configuration{
+		Metrics: configapi.ControllerMetrics{
+			BindAddress:   metricsAddr,
+			SecureServing: &secure,
+		},
+		Health: configapi.ControllerHealth{
+			HealthProbeBindAddress: healthAddr,
+		},
+	}
+
+	addTo(&opts, cfg, false)
+
+	if opts.Metrics.BindAddress != metricsAddr {
+		t.Errorf("expected metrics bind address %s, got %s",
+			metricsAddr, opts.Metrics.BindAddress)
+	}
+
+	if !opts.Metrics.SecureServing {
+		t.Errorf("expected secure serving to be enabled")
+	}
+
+	if opts.HealthProbeBindAddress != healthAddr {
+		t.Errorf("expected health probe bind address %s, got %s",
+			healthAddr, opts.HealthProbeBindAddress)
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"testing"
+
+	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
+)
+
+func TestIsCertManagementEnabled_Default(t *testing.T) {
+	cfg := &configapi.Configuration{}
+
+	// Cert management should be enabled by default
+	if !IsCertManagementEnabled(cfg) {
+		t.Errorf("expected cert management to be enabled by default")
+	}
+}
+func TestIsCertManagementEnabled_Disabled(t *testing.T) {
+	enabled := false
+
+	cfg := &configapi.Configuration{
+		CertManagement: &configapi.CertManagement{
+			Enable: &enabled,
+		},
+	}
+
+	if IsCertManagementEnabled(cfg) {
+		t.Errorf("expected cert management to be disabled when explicitly set to false")
+	}
+}

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"testing"
+
+	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
+)
+
+func TestValidate_ValidConfig(t *testing.T) {
+	cfg := &configapi.Configuration{}
+
+	errs := validate(cfg)
+
+	if len(errs) != 0 {
+		t.Errorf("expected no validation errors, got %d", len(errs))
+	}
+}


### PR DESCRIPTION


### What was added
- Unit tests for configuration default behavior
- Unit tests for configuration validation
- Unit test verifying controller-runtime options are applied from config

### Notes
- Tests are pure unit tests (no Kubernetes cluster required)
- No production logic changes

Fixes #3081
