### PR TITLE
feat(runtimes): add AMD ROCm torch distributed runtime  ref #2335

### DIFF
--- a/manifests/base/runtimes/kustomization.yaml
+++ b/manifests/base/runtimes/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - torch_distributed.yaml
   - jax_distributed.yaml
   - xgboost_distributed.yaml
+  - torch_rocm_distributed.yaml
   - torchtune

--- a/manifests/base/runtimes/torch_rocm_distributed.yaml
+++ b/manifests/base/runtimes/torch_rocm_distributed.yaml
@@ -1,0 +1,25 @@
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: ClusterTrainingRuntime
+metadata:
+  name: torch-rocm-distributed
+  labels:
+    trainer.kubeflow.org/framework: torch
+spec:
+  mlPolicy:
+    numNodes: 1
+    torch:
+      numProcPerNode: auto
+  template:
+    spec:
+      replicatedJobs:
+        - name: node
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: trainer
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: node
+                      image: rocm/pytorch:rocm7.1.1_ubuntu24.04_py3.12_pytorch_release_2.10.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds AMD ROCm PyTorch distributed training runtime, enabling distributed training on AMD GPUs (e.g., MI300X accelerators).
This follows the same pattern as the existing NVIDIA torch runtime added in #2328, using the official `rocm/pytorch` image with a pinned version matching the PyTorch version used in the NVIDIA runtime (2.7.1).

**Which issue(s) this PR fixes** :

 #2335

**Checklist:**

- [  ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
