### PR TITLE
[WIP] fix(ci): Fix the container local execution tests

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -43,6 +43,30 @@ jobs:
           echo "Install Kubeflow SDK with Docker support for local Notebooks"
           pip install "kubeflow[docker] @ git+https://github.com/kubeflow/sdk.git@main"
 
+      - name: Reset Docker default runtime to runc
+        run: |
+          # Oracle VM runners have nvidia as default runtime, which fails for CPU-only containers
+          # Reset to runc to make sure local container tests are running.
+
+          sudo tee /etc/docker/daemon.json > /dev/null <<EOF
+          {
+            "default-runtime": "runc",
+            "runtimes": {
+              "runc": {
+                "path": "runc"
+              },
+              "nvidia": {
+                "path": "nvidia-container-runtime"
+              }
+            }
+          }
+          EOF
+
+          # systemctl restart docker
+          # sleep 5
+          echo "Run docker info"
+          docker info
+
       - name: Setup cluster
         run: |
           make test-e2e-setup-cluster K8S_VERSION=${{ matrix.kubernetes-version }}


### PR DESCRIPTION
We should fix our E2Es for container execution:


```
Failed to create training job tede6bc9997c: 500 Server Error for http+docker://localhost/v1.48/containers/6a1d83045db8522920bd6240a51004b638d4c314888b02403c5618cef8eec8f8/start: Internal Server Error ("failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running prestart hook #0: exit status 1, stdout: , stderr: Auto-detected mode as 'legacy'
nvidia-container-cli: initialization error: nvml error: driver not loaded")
Full traceback:
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/docker/api/client.py", line 275, in _raise_for_status
    response.raise_for_status()
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/requests/models.py", line 1026, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: http+docker://localhost/v1.48/containers/6a1d83045db8522920bd6240a51004b638d4c314888b02403c5618cef8eec8f8/start

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/kubeflow/trainer/backends/container/backend.py", line 385, in train
    container_id = self._adapter.create_and_start_container(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/kubeflow/trainer/backends/container/adapters/docker.py", line 92, in create_and_start_container
    container = self.client.containers.run(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/docker/models/containers.py", line 883, in run
    container.start()
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/docker/models/containers.py", line 420, in start
    return self.client.api.start(self.id, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/docker/utils/decorators.py", line 19, in wrapped
    return f(self, resource_id, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/docker/api/container.py", line 1136, in start
    self._raise_for_status(res)
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/docker/api/client.py", line 277, in _raise_for_status
    raise create_api_error_from_http_exception(e) from e
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/docker/errors.py", line 39, in create_api_error_from_http_exception
    raise cls(e, response=response, explanation=explanation) from e
docker.errors.APIError: 500 Server Error for http+docker://localhost/v1.48/containers/6a1d83045db8522920bd6240a51004b638d4c314888b02403c5618cef8eec8f8/start: Internal Server Error ("failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running prestart hook #0: exit status 1, stdout: , stderr: Auto-detected mode as 'legacy'
nvidia-container-cli: initialization error: nvml error: driver not loaded")
```