### PR TITLE
fix: enable read-only root filesystem for trainer manager

### DIFF
--- a/manifests/base/manager/manager.yaml
+++ b/manifests/base/manager/manager.yaml
@@ -24,6 +24,7 @@ spec:
         - name: manager
           image: ghcr.io/kubeflow/trainer/trainer-controller-manager
           securityContext:
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             runAsNonRoot: true
             capabilities:


### PR DESCRIPTION
This PR fixes the no-read-only-root-fs kube-linter finding by enabling a read-only root filesystem for the kubeflow-trainer controller-manager container. I verified locally that this change removes the no-read-only-root-fs lint error. Combined with my earlier PR #3100, which switches liveness and readiness probes to named container ports, the kube-linter findings are reduced from 8 → 4. The remaining kube-linter findings I still see locally are:
1) latest-tag (image without an explicit tag)
2) non-existent-service-account (service account defined in separate manifests)
3) unset-cpu-requirements
4) unset-memory-requirements

I didn’t want to guess values or make policy decisions for these without discussion. Happy to address them or adjust the approach based on your preference.

##Fixes: #3096