### PR TITLE
feat: add validation for reserved MPI environment variables

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -216,6 +216,9 @@ var (
 	// TorchRunReservedEnvNames is torchrun reserved env names
 	TorchRunReservedEnvNames = sets.New(TorchEnvNumNodes, TorchEnvNumProcPerNode, TorchEnvNodeRank, TorchEnvMasterAddr, TorchEnvMasterPort)
 
+	// MPIReservedEnvNames is MPI reserved env names that users must not set manually.
+	MPIReservedEnvNames = sets.New(OpenMPIEnvHostFileLocation, OpenMPIEnvKeyRSHArgs, OpenMPIEnvKeepFQDNHostNames, OpenMPIEnvDefaultSlots)
+
 	// ResourceInUseFinalizer is a finalizer for managed resources which is used by other resources.
 	ResourceInUseFinalizer = fmt.Sprintf("%s/resource-in-use", trainer.GroupVersion.Group)
 


### PR DESCRIPTION
This PR implements validation logic in the MPI runtime plugin to prevent users from manually setting internal MPI environment variables in `TrainJob.spec.trainer.env`. 

Currently, users can accidentally set environment variables like `OMPI_MCA_orte_default_hostfile` which conflicts with the operator's internal configuration. This can cause the MPI launcher to fail to discover workers correctly, leading to training failures that are difficult to debug.

### Changes

1. **Define the Forbidden List** (`pkg/constants/constants.go`):
   - Added `MPIReservedEnvNames` constant containing the reserved MPI environment variables:
     - `OMPI_MCA_orte_default_hostfile`
     - `OMPI_MCA_plm_rsh_args`
     - `OMPI_MCA_orte_keep_fqdn_hostnames`
     - `OMPI_MCA_orte_set_default_slots`

2. **Enforce the Rule** (`pkg/runtime/framework/plugins/mpi/mpi.go`):
   - Updated the `Validate` function to check user-provided environment variables
   - Rejects job creation with a clear error message when reserved envs are detected
   - Follows the same pattern used in the Torch plugin for `TorchRunReservedEnvNames`

3. **Unit Tests** (`pkg/runtime/framework/plugins/mpi/mpi_test.go`):
   - Added test case for single reserved env detection
   - Added test case for multiple reserved envs detection
   - Added test case confirming non-reserved envs are still allowed

## Which issue(s) this PR fixes

Fixes #3126

## Checklist

- [x] Code follows the existing patterns in the codebase (mirrors Torch plugin validation)
- [x] Unit tests added and passing
- [x] `go vet` passes
- [x] `go fmt` passes
- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing