### PR TITLE
chore: changed latest to dev in trainer manifests

### DIFF
--- a/manifests/overlays/manager/kustomization.yaml
+++ b/manifests/overlays/manager/kustomization.yaml
@@ -28,6 +28,6 @@ secretGenerator:
 configMapGenerator:
   - name: kubeflow-trainer-public
     literals:
-      - kubeflow_trainer_version=latest
+      - kubeflow_trainer_version=dev
     options:
       disableNameSuffixHash: true


### PR DESCRIPTION
Changed  - kubeflow_trainer_version=latest to  - kubeflow_trainer_version=dev
in accordance with the guidance given by @andreyvelich

