### PR TITLE
fix: invalid CEL validation in trainer CRDs for Kubernetes 1.30

### DIFF
--- a/manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
@@ -10986,11 +10986,6 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
-                          x-kubernetes-validations:
-                          - message: namespace cannot be set for VolumeClaimPolicies
-                              templates
-                            rule: self.templates.all(t, !has(t.metadata.namespace)
-                              || size(t.metadata.namespace) == 0)
                         maxItems: 50
                         type: array
                         x-kubernetes-list-type: atomic

--- a/manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
@@ -10986,11 +10986,6 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
-                          x-kubernetes-validations:
-                          - message: namespace cannot be set for VolumeClaimPolicies
-                              templates
-                            rule: self.templates.all(t, !has(t.metadata.namespace)
-                              || size(t.metadata.namespace) == 0)
                         maxItems: 50
                         type: array
                         x-kubernetes-list-type: atomic


### PR DESCRIPTION
I was able to reproduce the CRD apply failure on Kubernetes v1.30.0, where CEL validation fails due to referencing 'metadata.namespac' in a schema context where it is not defined.
As suggested in the issue discussion, this PR removes the invalid 'x-kubernetes-validations' rule from the trainer CRDs, which restores successful CRD apply on K8s 1.30.
Verified locally using Kind v1.30.0.
fix #3154 