### PR TITLE
feat: add helm lint and helm unit tests to CI

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install Helm
         run: |


### PR DESCRIPTION
What this PR does

Adds a CI check using kube-linter to validate Kubernetes manifests and Helm charts.

This helps catch common configuration issues early and improves production readiness and security for Kubeflow deployments.

References:
- Issue #3096
- Related work in #3101
