### PR TITLE
fix: Defer kubernetes imports to method level for use with local mode

### DIFF
--- a/pkg/initializers/dataset/cache_test.py
+++ b/pkg/initializers/dataset/cache_test.py
@@ -187,8 +187,8 @@ def test_download_dataset(test_name, test_case):
 
     with patch(
         "pkg.initializers.dataset.cache.get_namespace", return_value="test-namespace"
-    ), patch("kubernetes.config") as mock_config, patch(
-        "kubernetes.client"
+    ), patch("pkg.initializers.dataset.cache.config") as mock_config, patch(
+        "pkg.initializers.dataset.cache.client"
     ) as mock_client:
 
         # Setup mocks for Kubernetes client

--- a/pkg/initializers/dataset/main_test.py
+++ b/pkg/initializers/dataset/main_test.py
@@ -57,10 +57,10 @@ def test_dataset_main(test_name, test_case, mock_env_vars):
     mock_s3_instance = MagicMock()
 
     with patch(
-        "pkg.initializers.dataset.__main__.HuggingFace",
+        "pkg.initializers.dataset.huggingface.HuggingFace",
         return_value=mock_hf_instance,
     ) as mock_hf, patch(
-        "pkg.initializers.dataset.__main__.S3",
+        "pkg.initializers.dataset.s3.S3",
         return_value=mock_s3_instance,
     ) as mock_s3:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Following on from this Kubeflow SDK [PR](https://github.com/kubeflow/sdk/pull/188) adding Initializers to local podman/docker mode, these imports need to be deffered to the method level so that kubernetes config is not required in these local environments, these changes do not break existing functionality.


**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
