### PR TITLE
chore: unit tests for runtime registry and RuntimeInfo error handling

### DIFF
--- a/pkg/runtime/core/registry_test.go
+++ b/pkg/runtime/core/registry_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/runtime/core/registry_test.go
+++ b/pkg/runtime/core/registry_test.go
@@ -1,0 +1,43 @@
+package core
+
+import "testing"
+
+func TestNewRuntimeRegistry(t *testing.T) {
+	registry := NewRuntimeRegistry()
+
+	if registry == nil {
+		t.Fatalf("expected registry to be non-nil")
+	}
+
+	// Expect exactly two registered runtimes
+	if len(registry) != 2 {
+		t.Fatalf("expected 2 runtime registrars, got %d", len(registry))
+	}
+
+	// TrainingRuntime must exist
+	tr, ok := registry[TrainingRuntimeGroupKind]
+	if !ok {
+		t.Fatalf("expected TrainingRuntimeGroupKind to be registered")
+	}
+	if tr.factory == nil {
+		t.Fatalf("expected TrainingRuntime factory to be non-nil")
+	}
+
+	// ClusterTrainingRuntime must exist
+	ctr, ok := registry[ClusterTrainingRuntimeGroupKind]
+	if !ok {
+		t.Fatalf("expected ClusterTrainingRuntimeGroupKind to be registered")
+	}
+	if ctr.factory == nil {
+		t.Fatalf("expected ClusterTrainingRuntime factory to be non-nil")
+	}
+
+	// ClusterTrainingRuntime should depend on TrainingRuntime
+	if len(ctr.dependencies) != 1 || ctr.dependencies[0] != TrainingRuntimeGroupKind {
+		t.Fatalf(
+			"expected ClusterTrainingRuntime to depend on %q, got %v",
+			TrainingRuntimeGroupKind,
+			ctr.dependencies,
+		)
+	}
+}

--- a/pkg/runtime/core/registry_test.go
+++ b/pkg/runtime/core/registry_test.go
@@ -1,43 +1,80 @@
+/*
+Copyright 2024 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package core
 
 import "testing"
 
 func TestNewRuntimeRegistry(t *testing.T) {
-	registry := NewRuntimeRegistry()
+	tests := map[string]struct {
+		validate func(t *testing.T, registry Registry)
+	}{
+		"registry is initialized": {
+			validate: func(t *testing.T, registry Registry) {
+				if registry == nil {
+					t.Fatalf("expected registry to be non-nil")
+				}
+			},
+		},
+		"TrainingRuntime is registered correctly": {
+			validate: func(t *testing.T, registry Registry) {
+				tr, ok := registry[TrainingRuntimeGroupKind]
+				if !ok {
+					t.Fatalf("expected TrainingRuntimeGroupKind to be registered")
+				}
+				if tr.factory == nil {
+					t.Fatalf("expected TrainingRuntime factory to be non-nil")
+				}
+				if tr.dependencies != nil {
+					t.Fatalf("expected TrainingRuntime to have no dependencies, got %v", tr.dependencies)
+				}
+			},
+		},
+		"ClusterTrainingRuntime is registered correctly": {
+			validate: func(t *testing.T, registry Registry) {
+				ctr, ok := registry[ClusterTrainingRuntimeGroupKind]
+				if !ok {
+					t.Fatalf("expected ClusterTrainingRuntimeGroupKind to be registered")
+				}
+				if ctr.factory == nil {
+					t.Fatalf("expected ClusterTrainingRuntime factory to be non-nil")
+				}
+			},
+		},
+		"ClusterTrainingRuntime depends on TrainingRuntime": {
+			validate: func(t *testing.T, registry Registry) {
+				ctr := registry[ClusterTrainingRuntimeGroupKind]
 
-	if registry == nil {
-		t.Fatalf("expected registry to be non-nil")
+				if len(ctr.dependencies) != 1 {
+					t.Fatalf("expected 1 dependency, got %v", ctr.dependencies)
+				}
+				if ctr.dependencies[0] != TrainingRuntimeGroupKind {
+					t.Fatalf(
+						"expected dependency %q, got %v",
+						TrainingRuntimeGroupKind,
+						ctr.dependencies,
+					)
+				}
+			},
+		},
 	}
 
-	// Expect exactly two registered runtimes
-	if len(registry) != 2 {
-		t.Fatalf("expected 2 runtime registrars, got %d", len(registry))
-	}
-
-	// TrainingRuntime must exist
-	tr, ok := registry[TrainingRuntimeGroupKind]
-	if !ok {
-		t.Fatalf("expected TrainingRuntimeGroupKind to be registered")
-	}
-	if tr.factory == nil {
-		t.Fatalf("expected TrainingRuntime factory to be non-nil")
-	}
-
-	// ClusterTrainingRuntime must exist
-	ctr, ok := registry[ClusterTrainingRuntimeGroupKind]
-	if !ok {
-		t.Fatalf("expected ClusterTrainingRuntimeGroupKind to be registered")
-	}
-	if ctr.factory == nil {
-		t.Fatalf("expected ClusterTrainingRuntime factory to be non-nil")
-	}
-
-	// ClusterTrainingRuntime should depend on TrainingRuntime
-	if len(ctr.dependencies) != 1 || ctr.dependencies[0] != TrainingRuntimeGroupKind {
-		t.Fatalf(
-			"expected ClusterTrainingRuntime to depend on %q, got %v",
-			TrainingRuntimeGroupKind,
-			ctr.dependencies,
-		)
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			registry := NewRuntimeRegistry()
+			tt.validate(t, registry)
+		})
 	}
 }

--- a/pkg/runtime/core/registry_test.go
+++ b/pkg/runtime/core/registry_test.go
@@ -37,7 +37,7 @@ func TestNewRuntimeRegistry(t *testing.T) {
 				if tr.factory == nil {
 					t.Fatalf("expected TrainingRuntime factory to be non-nil")
 				}
-				if tr.dependencies != nil {
+				if len(tr.dependencies) != 0 {
 					t.Fatalf("expected TrainingRuntime to have no dependencies, got %v", tr.dependencies)
 				}
 			},
@@ -55,10 +55,10 @@ func TestNewRuntimeRegistry(t *testing.T) {
 		},
 		"ClusterTrainingRuntime depends on TrainingRuntime": {
 			validate: func(t *testing.T, registry Registry) {
-				ctr := registry[ClusterTrainingRuntimeGroupKind]
+				ctr, ok := registry[ClusterTrainingRuntimeGroupKind]
 
-				if len(ctr.dependencies) != 1 {
-					t.Fatalf("expected 1 dependency, got %v", ctr.dependencies)
+				if !ok {
+					t.Fatalf("expected ClusterTrainingRuntimeGroupKind to be registered")
 				}
 				if ctr.dependencies[0] != TrainingRuntimeGroupKind {
 					t.Fatalf(

--- a/pkg/runtime/core/registry_test.go
+++ b/pkg/runtime/core/registry_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Kubeflow Authors.
+Copyright The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Kubeflow Authors.
+Copyright The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -2130,7 +2130,7 @@ test-job-node-0-1.test-job slots=8
 	}
 }
 
-func TestTrainingRuntime_RuntimeInfo_UnsupportedTemplate(t *testing.T) {
+func TestRuntimeInfo(t *testing.T) {
 	tests := map[string]struct {
 		templateType string
 	}{

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -2135,7 +2135,7 @@ func TestTrainingRuntime_RuntimeInfo_UnsupportedTemplate(t *testing.T) {
 
 	_, err := rt.RuntimeInfo(
 		trainJob,
-		"invalid-template-type", 
+		"invalid-template-type",
 		nil,
 		nil,
 	)

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -2128,19 +2129,38 @@ test-job-node-0-1.test-job slots=8
 		})
 	}
 }
+
 func TestTrainingRuntime_RuntimeInfo_UnsupportedTemplate(t *testing.T) {
-	rt := &TrainingRuntime{}
+	tests := map[string]struct {
+		templateType string
+	}{
+		"invalid template type returns error": {
+			templateType: "invalid-template-type",
+		},
+	}
 
-	trainJob := &trainer.TrainJob{}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Using zero-value TrainingRuntime is safe here because RuntimeInfo
+			// returns early for unsupported template types before accessing internal fields.
+			rt := &TrainingRuntime{}
 
-	_, err := rt.RuntimeInfo(
-		trainJob,
-		"invalid-template-type",
-		nil,
-		nil,
-	)
+			trainJob := &trainer.TrainJob{}
 
-	if err == nil {
-		t.Fatalf("expected error for unsupported runtimeTemplateSpec, got nil")
+			_, err := rt.RuntimeInfo(
+				trainJob,
+				tt.templateType,
+				nil,
+				nil,
+			)
+
+			if err == nil {
+				t.Fatalf("expected error for unsupported runtimeTemplateSpec, got nil")
+			}
+
+			if !strings.Contains(err.Error(), "unsupported runtimeTemplateSpec") {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
 	}
 }

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -2128,3 +2128,19 @@ test-job-node-0-1.test-job slots=8
 		})
 	}
 }
+func TestTrainingRuntime_RuntimeInfo_UnsupportedTemplate(t *testing.T) {
+	rt := &TrainingRuntime{}
+
+	trainJob := &trainer.TrainJob{}
+
+	_, err := rt.RuntimeInfo(
+		trainJob,
+		"invalid-template-type", 
+		nil,
+		nil,
+	)
+
+	if err == nil {
+		t.Fatalf("expected error for unsupported runtimeTemplateSpec, got nil")
+	}
+}

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -19,8 +19,8 @@ package core
 import (
 	"context"
 	"fmt"
-	"testing"
 	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"


### PR DESCRIPTION
This PR adds a couple of focused unit tests in the runtime core package.

1) Added unit tests for 'NewRuntimeRegistry' to verify runtime registration and dependency wiring.
2) Added a small unit test for 'TrainingRuntime.RuntimeInfo' to cover the unsupported 'runtimeTemplateSpec' error path.

### Why this change
While looking at test coverage in 'pkg/runtime/core', I noticed that:
- 'registry.go' did not have direct unit test coverage.
- The error-handling branch in 'RuntimeInfo' was not exercised by existing tests, which mostly cover happy paths.

These tests aim to cover those gaps without touching production code or adding integration complexity.

### Scope
- Test-only changes
- No behavior changes
- No production code modifications


related: #3152 

### Verification
```bash
go test ./pkg/runtime/core/...

