### PR TITLE
chore(docs): Create symlink for CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
I would want us to temporarily setup symlink for `CLAUDE.md` before Claude Code natively supports `AGENTS.md`:
https://github.com/anthropics/claude-code/issues/6235


/assign @kubeflow/kubeflow-trainer-team 