### PR TITLE
chore(docs): added kubecon 2025 trainer talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,14 @@ develop and fine-tune LLMs while leveraging the Kubeflow Trainer APIs: TrainJob 
 
 ## Kubeflow Trainer Introduction
 
-The following KubeCon + CloudNativeCon talks provide an overview of Kubeflow Trainer capabilities:
+Checkout following KubeCon + CloudNativeCon talks for Kubeflow Trainer capabilities:
 
 [![Kubeflow Trainer](https://img.youtube.com/vi/Lgy4ir1AhYw/0.jpg)](https://www.youtube.com/watch?v=Lgy4ir1AhYw)
-[![Fine Tuning with Trainer](https://img.youtube.com/vi/O7cNlaz3Hqs/0.jpg)](https://youtu.be/O7cNlaz3Hqs)
+
+Additional talks:
+
+- [From High Performance Computing To AI Workloads on Kubernetes: MPI Runtime in Kubeflow TrainJob](https://youtu.be/Fnb1a5Kaxgo)
+- [Streamline LLM Fine-tuning on Kubernetes With Kubeflow LLM Trainer](https://youtu.be/O7cNlaz3Hqs)
 
 
 ## Getting Started


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds KubeCon 2025 - North America video to readme.

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
