### PR TITLE
fix(ci): correct duplicate step name in `test-go.yaml`

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           make fmt
           git diff --exit-code || (echo 'Please run "make fmt" to verify gofmt' && exit 1);
-      - name: Check go fmt
+      - name: Check go vet
         run: |
           make vet
           git diff --exit-code || (echo 'Please run "make vet" to verify govet' && exit 1);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Renamed the duplicate `Check go fmt` step to `Check go vet` in `test-go.yaml`, since it runs make vet


**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
