### PR TITLE
fix: align torchao with torch 2.9.1 to fix GPU e2e failure

### DIFF
--- a/cmd/trainers/torchtune/requirements.txt
+++ b/cmd/trainers/torchtune/requirements.txt
@@ -1,4 +1,4 @@
-torchao>=0.9.0
+torchao==0.15.0
 torchtune==0.6.1
 bitsandbytes>=0.41.1
 kagglehub>=0.4.0


### PR DESCRIPTION
## Summary

The GPU E2E notebook was failing with:

ImportError: cannot import name 'int4_weight_only' from 'torchao.quantization'

After investigating, the issue turned out to be a version mismatch between torch and torchao.

The torchtune runtime is built from `pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime`, which includes torch 2.9.1.  
Since `requirements.txt` allowed `torchao>=0.9.0`, pip was installing torchao 0.16.0, which is incompatible with torch 2.9.1. This caused the C++ extensions to be skipped and the `int4_weight_only` import to fail during notebook execution.

## Fix

Constrained torchao to a compatible version to prevent installation of incompatible releases.

## Validation

- Reproduced the failure locally using torch 2.9.1 + torchao 0.16.0.
- Verified that constraining torchao resolves the import issue.
- Confirmed that `int4_weight_only` imports successfully after the change.

This should fix the GPU E2E notebook failure.
