### PR TITLE
fix(cache): validate cache_index schema collisions in worker dat…

### DIFF
--- a/pkg/data_cache/src/worker/worker_datasource.rs
+++ b/pkg/data_cache/src/worker/worker_datasource.rs
@@ -115,8 +115,7 @@ impl WorkerDataSource {
         // Validate that source schema does not already contain cache_index column
         if schema.field_with_name(CACHE_INDEX_COLUMN).is_ok() {
             return Err(format!(
-                "Source schema already contains a column named '{}'. \
-         This conflicts with the cache index column added by the data cache worker.",
+                "Source schema already contains a column named '{}'. This conflicts with the cache index column added by the data cache worker.",
                 CACHE_INDEX_COLUMN
             )
             .into());

--- a/pkg/data_cache/src/worker/worker_datasource.rs
+++ b/pkg/data_cache/src/worker/worker_datasource.rs
@@ -111,7 +111,19 @@ impl WorkerDataSource {
 
         let fields = schema.fields().clone();
         let mut builder = SchemaBuilder::from(&fields);
-        builder.push(Field::new(CACHE_INDEX_COLUMN, DataType::UInt64, false)); // TODO:// validate name collision
+
+        // Validate that source schema does not already contain cache_index column
+        if schema.field_with_name(CACHE_INDEX_COLUMN).is_ok() {
+            return Err(format!(
+                "Source schema already contains a column named '{}'. \
+         This conflicts with the cache index column added by the data cache worker.",
+                CACHE_INDEX_COLUMN
+            )
+            .into());
+        }
+
+        builder.push(Field::new(CACHE_INDEX_COLUMN, DataType::UInt64, false));
+
         let output_schema = Arc::new(Schema::new(builder.finish().fields));
         Ok(Self {
             file_urls,
@@ -511,5 +523,43 @@ async fn filter_and_create_stream(
         Err(e) => Ok(Box::pin(futures::stream::once(future::ready(Err(
             from_datafusion_error(e),
         ))))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_schema::{DataType, Field, Schema};
+
+    #[test]
+    fn fails_when_source_schema_contains_cache_index() {
+        // Build a schema that already has a cache_index column
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(CACHE_INDEX_COLUMN, DataType::UInt64, false),
+        ]);
+
+        // The check we added: if cache_index already exists, is_ok() returns true
+        let collision = schema.field_with_name(CACHE_INDEX_COLUMN).is_ok();
+        assert!(
+            collision,
+            "Should detect cache_index collision in source schema"
+        );
+    }
+
+    #[test]
+    fn passes_when_source_schema_has_no_cache_index() {
+        // Build a schema with no cache_index column
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+        ]);
+
+        // No collision — field_with_name returns Err, so is_ok() is false
+        let collision = schema.field_with_name(CACHE_INDEX_COLUMN).is_ok();
+        assert!(
+            !collision,
+            "Should not detect cache_index collision when column is absent"
+        );
     }
 }


### PR DESCRIPTION
What this PR does
Adds schema validation in `WorkerDataSource::try_new` to reject source tables that already define `cache_index`.

 Why
`cache_index` is appended by data-cache worker logic; collisions can lead to ambiguous schema behavior.

Scope
- Validation + error path in worker datasource
- Unit tests for collision / non-collision
- No projection/subset-scan changes (left for follow-up)

Testing
- `make test-rust`
- focused worker datasource tests


fixes #3174 
