### PR TITLE
chore: migrate to a10.2 gpu for gpu e2e

### DIFF
--- a/.github/workflows/test-e2e-gpu.yaml
+++ b/.github/workflows/test-e2e-gpu.yaml
@@ -12,7 +12,7 @@ jobs:
   gpu-e2e-test:
     name: GPU E2E Test
     runs-on:
-      labels: oracle-vm-gpu-a10-1
+      labels: oracle-vm-gpu-a10-2
       group: GPUs
 
     env:
@@ -57,7 +57,7 @@ jobs:
         run: |
           mkdir -p artifacts/notebooks
           make test-e2e-notebook NOTEBOOK_INPUT=./examples/torchtune/qwen2_5/qwen2.5-1.5B-with-alpaca.ipynb NOTEBOOK_OUTPUT=./artifacts/notebooks/${{ matrix.kubernetes-version }}_qwen2_5_with_alpaca-trainjob-yaml.ipynb PAPERMILL_TIMEOUT=1800
-          make test-e2e-notebook NOTEBOOK_INPUT=./examples/jax/image-classification/mnist.ipynb NOTEBOOK_OUTPUT=./artifacts/notebooks/${{ matrix.kubernetes-version }}_jax_mnist.ipynb PAPERMILL_PARAMS="-p num_cpu 8 -p num_gpu 1 -p num_nodes 1" PAPERMILL_TIMEOUT=1800
+          make test-e2e-notebook NOTEBOOK_INPUT=./examples/jax/image-classification/mnist.ipynb NOTEBOOK_OUTPUT=./artifacts/notebooks/${{ matrix.kubernetes-version }}_jax_mnist.ipynb PAPERMILL_PARAMS="-p num_cpu 8 -p num_gpu 2 -p num_nodes 1" PAPERMILL_TIMEOUT=1800
 
       - name: Upload Artifacts to GitHub
         if: always()

--- a/examples/torchtune/qwen2_5/qwen2.5-1.5B-with-alpaca.ipynb
+++ b/examples/torchtune/qwen2_5/qwen2.5-1.5B-with-alpaca.ipynb
@@ -2,14 +2,15 @@
   "cells": [
     {
       "cell_type": "markdown",
+      "id": "7c49a6d5",
       "metadata": {},
       "source": [
         "# Fine-tune Qwe2.5-1.5B with Alpaca Dataset"
-      ],
-      "id": "7c49a6d5"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "e3b15eff",
       "metadata": {},
       "source": [
         "This example demonstrates how to fine-tune Qwen2.5-1.5B model with the Alpaca Dataset using TorchTune `BuiltinTrainer` from Kubeflow Trainer SDK.\n",
@@ -19,31 +20,31 @@
         "Qwen2.5-1.5B: https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct\n",
         "\n",
         "Alpaca Dataset: https://huggingface.co/datasets/tatsu-lab/alpaca"
-      ],
-      "id": "e3b15eff"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "ed4a60eb",
       "metadata": {},
       "source": [
         "## Install the Kubeflow SDK\n",
         "\n",
         "You need to install the Kubeflow SDK to interact with Kubeflow Trainer APIs:"
-      ],
-      "id": "ed4a60eb"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "id": "288ec515",
       "metadata": {},
+      "outputs": [],
       "source": [
         "!pip install kubeflow"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "288ec515"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "7211fbf9",
       "metadata": {},
       "source": [
         "## Prerequisites\n",
@@ -51,12 +52,14 @@
         "### Install Official Training Runtimes\n",
         "\n",
         "You need to make sure that you've installed the Kubeflow Trainer Controller Manager and Kubeflow Training Runtimes mentioned in the [installation guide](https://www.kubeflow.org/docs/components/trainer/operator-guides/installation/)."
-      ],
-      "id": "7211fbf9"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "id": "d35e4fd8",
       "metadata": {},
+      "outputs": [],
       "source": [
         "# List all available Kubeflow Training Runtimes.\n",
         "from kubeflow.trainer import *\n",
@@ -65,24 +68,24 @@
         "client = TrainerClient()\n",
         "for runtime in client.list_runtimes():\n",
         "    print(runtime)"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "d35e4fd8"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "67490f66",
       "metadata": {},
       "source": [
         "## Bootstrap LLM Fine-tuning Workflow\n",
         "\n",
         "Kubeflow TrainJob will train the model in the referenced (Cluster)TrainingRuntime."
-      ],
-      "id": "67490f66"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "id": "641fae4d",
       "metadata": {},
+      "outputs": [],
       "source": [
         "job_name = client.train(\n",
         "    runtime=\"torchtune-qwen2.5-1.5b\",\n",
@@ -101,39 +104,37 @@
         "            ),\n",
         "            resources_per_node={\n",
         "                \"memory\": \"128G\",\n",
-        "                \"gpu\": 1,\n",
+        "                \"gpu\": 2,\n",
         "            },\n",
         "            \n",
         "        )\n",
         "    )\n",
         ")"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "641fae4d"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "ee5fbe8e",
       "metadata": {},
       "source": [
         "## Wait for running status"
-      ],
-      "id": "ee5fbe8e"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "id": "53eaa65a",
       "metadata": {},
+      "outputs": [],
       "source": [
         "\n",
         "# Wait for the running status.\n",
         "client.wait_for_job_status(name=job_name, status={\"Running\"})\n"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "53eaa65a"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "75a82b76",
       "metadata": {},
       "source": [
         "## Watch the TrainJob Logs\n",
@@ -141,66 +142,68 @@
         "We can use the `get_job_logs()` API to get the TrainJob logs.\n",
         "\n",
         "### Dataset Initializer"
-      ],
-      "id": "75a82b76"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "id": "68e9d454",
       "metadata": {},
+      "outputs": [],
       "source": [
         "from kubeflow.trainer.constants import constants\n",
         "\n",
         "for line in client.get_job_logs(job_name, follow=True, step=constants.DATASET_INITIALIZER):\n",
         "    print(line)"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "68e9d454"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "9f970c03",
       "metadata": {},
       "source": [
         "### Model Initializer"
-      ],
-      "id": "9f970c03"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "id": "4ce8c1df",
       "metadata": {},
+      "outputs": [],
       "source": [
         "for line in client.get_job_logs(job_name, follow=True, step=constants.MODEL_INITIALIZER):\n",
         "    print(line)"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "4ce8c1df"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "b67775ea",
       "metadata": {},
       "source": [
         "### Trainer Node "
-      ],
-      "id": "b67775ea"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "id": "ae672d7b",
       "metadata": {},
+      "outputs": [],
       "source": [
         "for c in client.get_job(name=job_name).steps:\n",
         "    print(f\"Step: {c.name}, Status: {c.status}, Devices: {c.device} x {c.device_count}\\n\")\n",
         "\n",
         "for line in client.get_job_logs(job_name, follow=True):\n",
         "    print(line)"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "ae672d7b"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "id": "7768e157",
       "metadata": {},
+      "outputs": [],
       "source": [
         "job = client.wait_for_job_status(name=job_name, timeout=1200)\n",
         "\n",
@@ -208,25 +211,22 @@
         "    raise RuntimeError(\"TrainJob failed\")\n",
         "else:\n",
         "    print(\"TrainJob completed successfully\")"
-      ],
-      "execution_count": null,
-      "outputs": [],
-      "id": "7768e157"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "042ebbb6",
       "metadata": {},
       "source": [
         "# Get the Fine-tuned Model\n",
         "\n",
         "After Trainer node completes the fine-tuning task, the fine-tuned model will be stored into the `/workspace/output` directory, which can be shared across Pods through PVC mounting. You can find it in another Pod's `/<mountDir>/output` directory if you mount the PVC under `/<mountDir>`."
-      ],
-      "id": "042ebbb6"
+      ]
     }
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
+      "display_name": ".venv",
       "language": "python",
       "name": "python3"
     },
@@ -240,7 +240,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.13"
+      "version": "3.12.3"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR migrates the runner for GPU E2E to A10.2 with 2 GPUs. This also updates the Qwen eg to run with 2 GPUs.

Related #3201 

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
