### PR TITLE
fix(sdk): always add queue label regardless of queue existence

### DIFF
--- a/sdk/python/kubeflow/training/api/training_client.py
+++ b/sdk/python/kubeflow/training/api/training_client.py
@@ -598,12 +598,11 @@ class TrainingClient(object):
             )
 
         # Handle Kueue queue validation and labeling
-        if queue_name is not None:
-            queue_exists = self._check_queue_exists(queue_name, namespace)
-            if queue_exists is not False:
-                if job.metadata.labels is None:
-                    job.metadata.labels = {}
-                job.metadata.labels[constants.LOCAL_QUEUE_LABEL] = queue_name
+        if queue_name and queue_name.strip():
+            self._check_queue_exists(queue_name, namespace)
+            if job.metadata.labels is None:
+                job.metadata.labels = {}
+            job.metadata.labels[constants.LOCAL_QUEUE_LABEL] = queue_name
 
         # Create the Training Job.
         try:

--- a/sdk/python/kubeflow/training/api/training_client_test.py
+++ b/sdk/python/kubeflow/training/api/training_client_test.py
@@ -698,6 +698,21 @@ test_data_create_job = [
         ),
     ),
     (
+        "valid flow with empty queue name",
+        {
+            "name": TEST_NAME,
+            "namespace": TEST_NAME,
+            "base_image": TEST_IMAGE,
+            "num_workers": 1,
+            "queue_name": "",
+        },
+        SUCCESS,
+        create_job(
+            num_workers=1,
+            labels=None,
+        ),
+    ),
+    (
         "valid flow with non-existent queue",
         {
             "name": TEST_NAME,
@@ -709,7 +724,7 @@ test_data_create_job = [
         SUCCESS,
         create_job(
             num_workers=1,
-            labels=None,
+            labels={constants.LOCAL_QUEUE_LABEL: "non-existent-queue"},
         ),
     ),
     (


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
`create_job()` skips adding the `kueue.x-k8s.io/queue-name` label when the specified local-queue doesn't exist, preventing Kueue from ever managing the job. Removed the conditional gate so the label is always added when `queue_name` is provided.


### Changes:
- Removed the `if queue_exists is not False` condition that gated label addition, `_check_queue_exists()` is still called for its side effects (warning logs, error handling)
- Updated the "valid flow with non-existent queue" test case to expect the queue label

**Which issue(s) this PR fixes**:
Fixes #2775 
