### PR TITLE
fix: align torch-distributed-with-cache runtime logic with unit tests

### DIFF
--- a/charts/kubeflow-trainer/templates/runtimes/data-cache/torch-distributed-with-cache.yaml
+++ b/charts/kubeflow-trainer/templates/runtimes/data-cache/torch-distributed-with-cache.yaml
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */ -}}
 
-{{- if and .Values.dataCache.enabled .Values.dataCache.runtimes.torchDistributed.enabled }}
+{{- if and .Values.runtimes.torchDistributedWithCache.enabled (not .Values.dataCache.enabled) }}
+{{- fail "runtimes.torchDistributedWithCache.enabled requires dataCache.enabled to be true" }}
+{{- end }}
+
+{{- if and .Values.dataCache.enabled .Values.runtimes.torchDistributedWithCache.enabled }}
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:
@@ -45,7 +49,7 @@ spec:
                     image: {{ printf "ghcr.io/kubeflow/trainer/dataset-initializer:%s" (include "trainer.defaultImageTag" .) }}
                     env:
                       - name: CACHE_IMAGE
-                        value: {{ include "trainer.runtimeImage" (list .Values.dataCache.cacheImage .) | quote }}
+                        value: {{ include "trainer.runtimeImage" (list .Values.runtimes.torchDistributedWithCache.cacheImage .) | quote }}
                       - name: TRAIN_JOB_NAME
                         valueFrom:
                           fieldRef:

--- a/charts/kubeflow-trainer/tests/runtimes/torch_distributed_with_cache_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torch_distributed_with_cache_test.yaml
@@ -16,7 +16,7 @@
 
 suite: Test torch-distributed-with-cache ClusterTrainingRuntime
 templates:
-  - templates/runtimes/torch-distributed-with-cache.yaml
+  - templates/runtimes/data-cache/torch-distributed-with-cache.yaml
 release:
   name: kubeflow-trainer
   namespace: kubeflow-trainer


### PR DESCRIPTION
This PR fixes inconsistencies in the `torch-distributed-with-cache` runtime template that were surfaced after enabling Helm unit tests in CI.

Changes include:

- Add explicit `fail` validation when `runtimes.torchDistributedWithCache.enabled` is true but `dataCache.enabled` is false.
- Align template condition to use `runtimes.torchDistributedWithCache.enabled` instead of the incorrect nested path.
- Correct `cacheImage` reference to use `runtimes.torchDistributedWithCache.cacheImage`.
- Ensure custom cache image tags are respected during rendering.

All Helm unit tests now pass successfully.
