### PR TITLE
feat: Helm test workflow

### DIFF
--- a/.github/workflows/test-helm.yaml
+++ b/.github/workflows/test-helm.yaml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 jobs:
-  tests:
+  test:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Following the recent review feedback, this PR moves Helm unit tests into a dedicated workflow (`test-helm.yaml`).

The goal is to keep the Code Quality workflow focused strictly on linting, while Helm-related tests run separately. This keeps responsibilities clear and makes it easier to extend Helm testing in the future (for example, adding Helm E2E tests).

This change follows the discussion in #3224 

This PR supersedes #3166.
