### PR TITLE
fix: stop preloading runtime images into kind cluster

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -43,10 +43,6 @@ jobs:
           echo "Install Kubeflow SDK with Docker support for local Notebooks"
           pip install "kubeflow[docker] @ git+https://github.com/kubeflow/sdk.git@main"
 
-      - name: Pre-pull DeepSpeed runtime image (force amd64)
-        run: |
-          docker pull --platform=linux/amd64 ghcr.io/kubeflow/trainer/deepspeed-runtime:latest
-
       - name: Setup cluster
         run: |
           make test-e2e-setup-cluster K8S_VERSION=${{ matrix.kubernetes-version }}

--- a/hack/e2e-setup-cluster.sh
+++ b/hack/e2e-setup-cluster.sh
@@ -97,16 +97,6 @@ TORCH_RUNTIME_IMAGE=pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime
 DEEPSPEED_RUNTIME_IMAGE=ghcr.io/kubeflow/trainer/deepspeed-runtime:latest
 JAX_RUNTIME_IMAGE=nvcr.io/nvidia/jax:25.10-py3
 
-# Load Torch runtime image in KinD
-${CONTAINER_RUNTIME} pull ${TORCH_RUNTIME_IMAGE}
-load_image_to_kind ${TORCH_RUNTIME_IMAGE}
-
-# Load DeepSpeed runtime image in KinD
-${CONTAINER_RUNTIME} pull ${DEEPSPEED_RUNTIME_IMAGE}
-load_image_to_kind ${DEEPSPEED_RUNTIME_IMAGE}
-
-# Load JAX runtime image in KinD
-${CONTAINER_RUNTIME} pull ${JAX_RUNTIME_IMAGE}
-load_image_to_kind ${JAX_RUNTIME_IMAGE}
+echo "Skipping runtime image preloading. Images will be pulled by Kubernetes during trainjob execution."
 
 print_cluster_info


### PR DESCRIPTION
## Summary

This PR removes runtime image preloading from the Kind e2e setup script.
Previously, runtime images (DeepSpeed, Torch, JAX) were loaded into the Kind cluster using `kind load docker-image`. Since these images are multi-arch, this could lead to containerd digest mismatches during import.

Additionally, we do not currently execute the DeepSpeed notebook in E2E, so preloading its image is unnecessary.

## Change

- Removed runtime image preloading from Kind setup
- Runtime images are now pulled directly by Kubernetes during TrainJob execution

No changes to test logic or timeouts.