### PR TITLE
fix(test): Ignore version increment in Helm Chart lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ helm-unittest: helm-unittest-plugin ## Run Helm chart unittests.
 
 .PHONY: helm-lint
 helm-lint: ## Run Helm chart lint test.
-	docker run --rm --workdir /workspace --user "$(shell id -u):$(shell id -g)" --volume "$$(pwd):/workspace" quay.io/helmpack/chart-testing:$(HELM_CHART_TESTING_VERSION) ct lint --target-branch $(TARGET_BRANCH) --validate-maintainers=false
+	docker run --rm --workdir /workspace --user "$(shell id -u):$(shell id -g)" --volume "$$(pwd):/workspace" quay.io/helmpack/chart-testing:$(HELM_CHART_TESTING_VERSION) ct lint --target-branch $(TARGET_BRANCH) --validate-maintainers=false --check-version-increment=false
 
 .PHONY: helm-docs
 helm-docs: helm-docs-plugin ## Generates markdown documentation for helm charts from requirements and values files.


### PR DESCRIPTION
This should fix this error we are getting on every PR:
```
Linting chart "kubeflow-trainer => (version: \"2.1.0\", path: \"charts/kubeflow-trainer\")"
Checking chart "kubeflow-trainer => (version: \"2.1.0\", path: \"charts/kubeflow-trainer\")" for a version bump...
Error: failed linting charts: failed processing charts
Old chart version: 2.1.0
New chart version: 2.1.0
```

cc @kubeflow/kubeflow-trainer-team @jaiakash @Goku2099