### PR TITLE
fix(test): Fix Data Cache runtime in Helm Charts

### DIFF
--- a/charts/kubeflow-trainer/README.md
+++ b/charts/kubeflow-trainer/README.md
@@ -70,7 +70,7 @@ dataCache:
   cacheImage:
     tag: "v2.0.0"
   runtimes:
-    torchDistributed:
+    torchDistributedWithCache:
       enabled: true
 ```
 
@@ -133,8 +133,8 @@ See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall) for command docum
 | dataCache.cacheImage.registry | string | `"ghcr.io"` | Data cache image registry |
 | dataCache.cacheImage.repository | string | `"kubeflow/trainer/data-cache"` | Data cache image repository |
 | dataCache.cacheImage.tag | string | `""` | Data cache image tag. Defaults to chart version if empty. |
-| dataCache.runtimes.torchDistributed | object | `{"enabled":false}` | PyTorch distributed training with data cache support |
-| dataCache.runtimes.torchDistributed.enabled | bool | `false` | Enable deployment of torch-distributed-with-cache runtime |
+| dataCache.runtimes.torchDistributedWithCache | object | `{"enabled":false}` | PyTorch distributed training with data cache support |
+| dataCache.runtimes.torchDistributedWithCache.enabled | bool | `false` | Enable deployment of torch-distributed-with-cache runtime |
 | runtimes | object | `{"deepspeedDistributed":{"enabled":false,"image":{"registry":"ghcr.io","repository":"kubeflow/trainer/deepspeed-runtime","tag":""}},"defaultEnabled":false,"jaxDistributed":{"enabled":false},"mlxDistributed":{"enabled":false,"image":{"registry":"ghcr.io","repository":"kubeflow/trainer/mlx-runtime","tag":""}},"torchDistributed":{"enabled":false},"torchtuneDistributed":{"image":{"registry":"ghcr.io","repository":"kubeflow/trainer/torchtune-trainer","tag":""},"llama3_2_1B":{"enabled":false},"llama3_2_3B":{"enabled":false},"qwen2_5_1_5B":{"enabled":false}}}` | ClusterTrainingRuntimes configuration These are optional runtime templates that can be deployed with the Helm chart. Each runtime provides a blueprint for different ML frameworks and configurations. |
 | runtimes.defaultEnabled | bool | `false` | Enable all default runtimes (torch, deepspeed, mlx, jax, torchtune) when set to true. Individual runtime settings will be ignored if this is enabled. |
 | runtimes.torchDistributed | object | `{"enabled":false}` | PyTorch distributed training runtime (no custom images required) |

--- a/charts/kubeflow-trainer/README.md.gotmpl
+++ b/charts/kubeflow-trainer/README.md.gotmpl
@@ -88,7 +88,7 @@ dataCache:
   cacheImage:
     tag: "v2.0.0"
   runtimes:
-    torchDistributed:
+    torchDistributedWithCache:
       enabled: true
 ```
 

--- a/charts/kubeflow-trainer/templates/runtimes/data-cache/torch-distributed-with-cache.yaml
+++ b/charts/kubeflow-trainer/templates/runtimes/data-cache/torch-distributed-with-cache.yaml
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */ -}}
 
-{{- if and .Values.runtimes.torchDistributedWithCache.enabled (not .Values.dataCache.enabled) }}
-{{- fail "runtimes.torchDistributedWithCache.enabled requires dataCache.enabled to be true" }}
+{{- if and .Values.dataCache.runtimes.torchDistributedWithCache.enabled (not .Values.dataCache.enabled) }}
+{{- fail "dataCache.runtimes.torchDistributedWithCache.enabled requires dataCache.enabled to be true" }}
 {{- end }}
 
-{{- if and .Values.dataCache.enabled .Values.runtimes.torchDistributedWithCache.enabled }}
+{{- if and .Values.dataCache.enabled .Values.dataCache.runtimes.torchDistributedWithCache.enabled }}
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:
@@ -49,7 +49,7 @@ spec:
                     image: {{ printf "ghcr.io/kubeflow/trainer/dataset-initializer:%s" (include "trainer.defaultImageTag" .) }}
                     env:
                       - name: CACHE_IMAGE
-                        value: {{ include "trainer.runtimeImage" (list .Values.runtimes.torchDistributedWithCache.cacheImage .) | quote }}
+                        value: {{ include "trainer.runtimeImage" (list .Values.dataCache.cacheImage .) | quote }}
                       - name: TRAIN_JOB_NAME
                         valueFrom:
                           fieldRef:

--- a/charts/kubeflow-trainer/tests/runtimes/torch_distributed_with_cache_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torch_distributed_with_cache_test.yaml
@@ -21,17 +21,17 @@ release:
   name: kubeflow-trainer
   namespace: kubeflow-trainer
 tests:
-  - it: Should not render ClusterTrainingRuntime when runtimes.torchDistributedWithCache.enabled is false
+  - it: Should not render ClusterTrainingRuntime when dataCache.runtimes.torchDistributedWithCache.enabled is false
     set:
       dataCache:
         enabled: true
-      runtimes:
-        torchDistributedWithCache:
-          enabled: false
-          cacheImage:
-            registry: ghcr.io
-            repository: kubeflow/trainer/data-cache
-            tag: ""
+        cacheImage:
+          registry: ghcr.io
+          repository: kubeflow/trainer/data-cache
+          tag: ""
+        runtimes:
+          torchDistributedWithCache:
+            enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -40,28 +40,28 @@ tests:
     set:
       dataCache:
         enabled: false
-      runtimes:
-        torchDistributedWithCache:
-          enabled: true
-          cacheImage:
-            registry: ghcr.io
-            repository: kubeflow/trainer/data-cache
-            tag: ""
+        cacheImage:
+          registry: ghcr.io
+          repository: kubeflow/trainer/data-cache
+          tag: "v1.0.0"
+        runtimes:
+          torchDistributedWithCache:
+            enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: "runtimes.torchDistributedWithCache.enabled requires dataCache.enabled to be true"
+          errorMessage: "dataCache.runtimes.torchDistributedWithCache.enabled requires dataCache.enabled to be true"
 
   - it: Should render ClusterTrainingRuntime when enabled and dataCache is enabled
     set:
       dataCache:
         enabled: true
-      runtimes:
-        torchDistributedWithCache:
-          enabled: true
-          cacheImage:
-            registry: ghcr.io
-            repository: kubeflow/trainer/data-cache
-            tag: ""
+        cacheImage:
+          registry: ghcr.io
+          repository: kubeflow/trainer/data-cache
+          tag: "v1.0.0"
+        runtimes:
+          torchDistributedWithCache:
+            enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -75,13 +75,13 @@ tests:
     set:
       dataCache:
         enabled: true
-      runtimes:
-        torchDistributedWithCache:
-          enabled: true
-          cacheImage:
-            registry: ghcr.io
-            repository: kubeflow/trainer/data-cache
-            tag: ""
+        cacheImage:
+          registry: ghcr.io
+          repository: kubeflow/trainer/data-cache
+          tag: "v1.0.0"
+        runtimes:
+          torchDistributedWithCache:
+            enabled: true
     asserts:
       - equal:
           path: metadata.labels["trainer.kubeflow.org/framework"]
@@ -91,13 +91,13 @@ tests:
     set:
       dataCache:
         enabled: true
-      runtimes:
-        torchDistributedWithCache:
-          enabled: true
-          cacheImage:
-            registry: ghcr.io
-            repository: kubeflow/trainer/data-cache
-            tag: ""
+        cacheImage:
+          registry: ghcr.io
+          repository: kubeflow/trainer/data-cache
+          tag: "v1.0.0"
+        runtimes:
+          torchDistributedWithCache:
+            enabled: true
     asserts:
       - equal:
           path: spec.template.spec.replicatedJobs[0].template.spec.template.spec.serviceAccountName
@@ -107,13 +107,13 @@ tests:
     set:
       dataCache:
         enabled: true
-      runtimes:
-        torchDistributedWithCache:
-          enabled: true
-          cacheImage:
-            registry: ghcr.io
-            repository: kubeflow/trainer/data-cache
-            tag: "v1.0.0"
+        cacheImage:
+          registry: ghcr.io
+          repository: kubeflow/trainer/data-cache
+          tag: "v1.0.0"
+        runtimes:
+          torchDistributedWithCache:
+            enabled: true
     asserts:
       - matchRegex:
           path: spec.template.spec.replicatedJobs[0].template.spec.template.spec.containers[0].env[0].value
@@ -123,13 +123,13 @@ tests:
     set:
       dataCache:
         enabled: true
-      runtimes:
-        torchDistributedWithCache:
-          enabled: true
-          cacheImage:
-            registry: ghcr.io
-            repository: kubeflow/trainer/data-cache
-            tag: ""
+        cacheImage:
+          registry: ghcr.io
+          repository: kubeflow/trainer/data-cache
+          tag: "v1.0.0"
+        runtimes:
+          torchDistributedWithCache:
+            enabled: true
     asserts:
       - equal:
           path: spec.template.spec.replicatedJobs[1].dependsOn[0].name

--- a/charts/kubeflow-trainer/values.yaml
+++ b/charts/kubeflow-trainer/values.yaml
@@ -157,7 +157,7 @@ dataCache:
     tag: ""
   runtimes:
     # -- PyTorch distributed training with data cache support
-    torchDistributed:
+    torchDistributedWithCache:
       # -- Enable deployment of torch-distributed-with-cache runtime
       enabled: false
 


### PR DESCRIPTION
This should fix the Helm Charts tests.

Error:
```
[INFO] Chart.yaml: icon is recommended
Error:  templates/: template: kubeflow-trainer/templates/runtimes/data-cache/torch-distributed-with-cache.yaml:17:18: executing "kubeflow-trainer/templates/runtimes/data-cache/torch-distributed-with-cache.yaml" at <.Values.runtimes.torchDistributedWithCache.enabled>: nil pointer evaluating interface {}.enabled

Error: 1 chart(s) linted, 1 chart(s) failed
Error: failed linting charts: failed processing charts

------------------------------------------------------------------------------------------------------------------------
 ✖︎ kubeflow-trainer => (version: "2.1.0", path: "charts/kubeflow-trainer") > failed waiting for process: exit status 1
```

cc @kubeflow/kubeflow-trainer-team @Goku2099 @astefanutti @jaiakash @akshaychitneni @khushiiagrawal

