### PR TITLE
chore(ci): Ignore Coveralls Errors

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -76,6 +76,7 @@ jobs:
 
       - name: Coveralls report
         uses: shogo82148/actions-goveralls@v1
+        continue-on-error: true
         with:
           path-to-profile: cover.out
           working-directory: ${{ env.GOPATH }}/src/github.com/kubeflow/trainer


### PR DESCRIPTION
It looks like Coveralls having an outage right now: https://status.coveralls.io/
I suggest we ignore such errors to unblock PRs.
We have similar setting for Kubeflow SDK: https://github.com/kubeflow/sdk/pull/33#discussion_r2347686508


/assign @astefanutti @tenzen-y @akshaychitneni @robert-bell 