### PR TITLE
chore(deps): Bump Trivy version to v0.69.2

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -13,8 +13,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # v0.34.1
         with:
+          version: v0.69.2
           scan-type: "fs"
           ignore-unfixed: true
           format: "sarif"


### PR DESCRIPTION
Trivy action is failing due to this: https://github.com/aquasecurity/trivy-action/issues/512

We should manually bump to version to v0.69.2

/assign @kubeflow/kubeflow-trainer-team @robert-bell @akshaychitneni 

