### PR TITLE
feat: set PET_RDZV_* environment variables for torchrun

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -134,6 +134,15 @@ const (
 	// TorchEnvMasterPort is the env name for the master node port.
 	TorchEnvMasterPort string = "PET_MASTER_PORT"
 
+	// TorchEnvRdzvBackend is the env name for the rendezvous backend.
+	TorchEnvRdzvBackend string = "PET_RDZV_BACKEND"
+
+	// TorchEnvRdzvEndpoint is the env name for the rendezvous endpoint.
+	TorchEnvRdzvEndpoint string = "PET_RDZV_ENDPOINT"
+
+	// TorchEnvRdzvId is the env name for the rendezvous ID.
+	TorchEnvRdzvId string = "PET_RDZV_ID"
+
 	// TorchTuneArgRdzvEndpoint is the arg name for the rendezvous endpoint.
 	TorchTuneArgRdzvEndpoint string = "--rdzv_endpoint"
 
@@ -214,7 +223,7 @@ var (
 	JobCompletionIndexFieldPath string = fmt.Sprintf("metadata.annotations['%s']", batchv1.JobCompletionIndexAnnotation)
 
 	// TorchRunReservedEnvNames is torchrun reserved env names
-	TorchRunReservedEnvNames = sets.New(TorchEnvNumNodes, TorchEnvNumProcPerNode, TorchEnvNodeRank, TorchEnvMasterAddr, TorchEnvMasterPort)
+	TorchRunReservedEnvNames = sets.New(TorchEnvNumNodes, TorchEnvNumProcPerNode, TorchEnvNodeRank, TorchEnvMasterAddr, TorchEnvMasterPort, TorchEnvRdzvBackend, TorchEnvRdzvEndpoint, TorchEnvRdzvId)
 
 	// ResourceInUseFinalizer is a finalizer for managed resources which is used by other resources.
 	ResourceInUseFinalizer = fmt.Sprintf("%s/resource-in-use", trainer.GroupVersion.Group)

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -1046,6 +1046,18 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 								Name:  constants.TorchEnvMasterPort,
 								Value: fmt.Sprintf("%d", constants.ContainerTrainerPort),
 							},
+							{
+								Name:  constants.TorchEnvRdzvBackend,
+								Value: "c10d",
+							},
+							{
+								Name:  constants.TorchEnvRdzvEndpoint,
+								Value: fmt.Sprintf("test-job-%s-0-0.test-job:%d", constants.Node, constants.ContainerTrainerPort),
+							},
+							{
+								Name:  constants.TorchEnvRdzvId,
+								Value: "test-job",
+							},
 						}...,
 					).
 					DependsOn(constants.Node,
@@ -1153,6 +1165,18 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							{
 								Name:  constants.TorchEnvMasterPort,
 								Value: fmt.Sprintf("%d", constants.ContainerTrainerPort),
+							},
+							{
+								Name:  constants.TorchEnvRdzvBackend,
+								Value: "c10d",
+							},
+							{
+								Name:  constants.TorchEnvRdzvEndpoint,
+								Value: fmt.Sprintf("test-job-%s-0-0.test-job:%d", constants.Node, constants.ContainerTrainerPort),
+							},
+							{
+								Name:  constants.TorchEnvRdzvId,
+								Value: "test-job",
 							},
 							{
 								Name:  "RUNTIME",

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -138,14 +138,25 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 		)
 
 		if !slices.Equal(trainJob.Spec.Trainer.Command, constants.TorchTuneEntrypoint) {
-			// Add PET_MASTER_ADDR and PET_MASTER_PORT envs for torchrun.
+			// Add PET_MASTER_ADDR, PET_MASTER_PORT, and rendezvous envs for torchrun.
+			masterAddr := fmt.Sprintf("%s-%s-0-0.%s", trainJob.Name, constants.Node, trainJob.Name)
+			masterPort := fmt.Sprintf("%d", constants.ContainerTrainerPort)
 			apply.UpsertEnvVars(&trainerContainer.Env,
 				*corev1ac.EnvVar().
 					WithName(constants.TorchEnvMasterAddr).
-					WithValue(fmt.Sprintf("%s-%s-0-0.%s", trainJob.Name, constants.Node, trainJob.Name)),
+					WithValue(masterAddr),
 				*corev1ac.EnvVar().
 					WithName(constants.TorchEnvMasterPort).
-					WithValue(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
+					WithValue(masterPort),
+				*corev1ac.EnvVar().
+					WithName(constants.TorchEnvRdzvBackend).
+					WithValue("c10d"),
+				*corev1ac.EnvVar().
+					WithName(constants.TorchEnvRdzvEndpoint).
+					WithValue(fmt.Sprintf("%s:%s", masterAddr, masterPort)),
+				*corev1ac.EnvVar().
+					WithName(constants.TorchEnvRdzvId).
+					WithValue(trainJob.Name),
 			)
 		} else {
 			// Mutate trainer command for torchtune.

--- a/pkg/runtime/framework/plugins/torch/torch_test.go
+++ b/pkg/runtime/framework/plugins/torch/torch_test.go
@@ -135,6 +135,18 @@ func TestTorch(t *testing.T) {
 									Name:  ptr.To(constants.TorchEnvMasterPort),
 									Value: ptr.To(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
 								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvBackend),
+									Value: ptr.To("c10d"),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvEndpoint),
+									Value: ptr.To(fmt.Sprintf("trainJob-node-0-0.trainJob:%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvId),
+									Value: ptr.To("trainJob"),
+								},
 							},
 						}},
 					}},
@@ -209,6 +221,18 @@ func TestTorch(t *testing.T) {
 									Name:  ptr.To(constants.TorchEnvMasterPort),
 									Value: ptr.To(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
 								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvBackend),
+									Value: ptr.To("c10d"),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvEndpoint),
+									Value: ptr.To(fmt.Sprintf("test-job-node-0-0.test-job:%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvId),
+									Value: ptr.To("test-job"),
+								},
 							},
 						}},
 					}},
@@ -280,6 +304,18 @@ func TestTorch(t *testing.T) {
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
 									Value: ptr.To(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvBackend),
+									Value: ptr.To("c10d"),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvEndpoint),
+									Value: ptr.To(fmt.Sprintf("test-job-node-0-0.test-job:%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvId),
+									Value: ptr.To("test-job"),
 								},
 							},
 						}},
@@ -355,6 +391,18 @@ func TestTorch(t *testing.T) {
 									Name:  ptr.To(constants.TorchEnvMasterPort),
 									Value: ptr.To(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
 								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvBackend),
+									Value: ptr.To("c10d"),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvEndpoint),
+									Value: ptr.To(fmt.Sprintf("test-job-node-0-0.test-job:%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvId),
+									Value: ptr.To("test-job"),
+								},
 							},
 						}},
 					}},
@@ -428,6 +476,18 @@ func TestTorch(t *testing.T) {
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
 									Value: ptr.To(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvBackend),
+									Value: ptr.To("c10d"),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvEndpoint),
+									Value: ptr.To(fmt.Sprintf("test-job-node-0-0.test-job:%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvId),
+									Value: ptr.To("test-job"),
 								},
 							},
 						}},
@@ -503,6 +563,18 @@ func TestTorch(t *testing.T) {
 									Name:  ptr.To(constants.TorchEnvMasterPort),
 									Value: ptr.To(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
 								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvBackend),
+									Value: ptr.To("c10d"),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvEndpoint),
+									Value: ptr.To(fmt.Sprintf("test-job-node-0-0.test-job:%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvId),
+									Value: ptr.To("test-job"),
+								},
 							},
 						}},
 					}},
@@ -577,6 +649,18 @@ func TestTorch(t *testing.T) {
 									Name:  ptr.To(constants.TorchEnvMasterPort),
 									Value: ptr.To(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
 								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvBackend),
+									Value: ptr.To("c10d"),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvEndpoint),
+									Value: ptr.To(fmt.Sprintf("test-job-node-0-0.test-job:%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvId),
+									Value: ptr.To("test-job"),
+								},
 							},
 						}},
 					}},
@@ -650,6 +734,18 @@ func TestTorch(t *testing.T) {
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
 									Value: ptr.To(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvBackend),
+									Value: ptr.To("c10d"),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvEndpoint),
+									Value: ptr.To(fmt.Sprintf("test-job-node-0-0.test-job:%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvId),
+									Value: ptr.To("test-job"),
 								},
 							},
 						}},
@@ -726,6 +822,18 @@ func TestTorch(t *testing.T) {
 									Name:  ptr.To(constants.TorchEnvMasterPort),
 									Value: ptr.To(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
 								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvBackend),
+									Value: ptr.To("c10d"),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvEndpoint),
+									Value: ptr.To(fmt.Sprintf("test-job-node-0-0.test-job:%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvId),
+									Value: ptr.To("test-job"),
+								},
 							},
 						}},
 					}},
@@ -800,6 +908,18 @@ func TestTorch(t *testing.T) {
 									Name:  ptr.To(constants.TorchEnvMasterPort),
 									Value: ptr.To(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
 								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvBackend),
+									Value: ptr.To("c10d"),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvEndpoint),
+									Value: ptr.To(fmt.Sprintf("test-job-node-0-0.test-job:%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvId),
+									Value: ptr.To("test-job"),
+								},
 							},
 						}},
 					}},
@@ -873,6 +993,18 @@ func TestTorch(t *testing.T) {
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
 									Value: ptr.To(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvBackend),
+									Value: ptr.To("c10d"),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvEndpoint),
+									Value: ptr.To(fmt.Sprintf("cpu-job-node-0-0.cpu-job:%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvId),
+									Value: ptr.To("cpu-job"),
 								},
 							},
 						}},
@@ -949,6 +1081,18 @@ func TestTorch(t *testing.T) {
 									Name:  ptr.To(constants.TorchEnvMasterPort),
 									Value: ptr.To(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
 								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvBackend),
+									Value: ptr.To("c10d"),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvEndpoint),
+									Value: ptr.To(fmt.Sprintf("cpu-gpu-job-node-0-0.cpu-gpu-job:%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvId),
+									Value: ptr.To("cpu-gpu-job"),
+								},
 							},
 						}},
 					}},
@@ -1022,6 +1166,18 @@ func TestTorch(t *testing.T) {
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
 									Value: ptr.To(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvBackend),
+									Value: ptr.To("c10d"),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvEndpoint),
+									Value: ptr.To(fmt.Sprintf("cpu-frac-job-node-0-0.cpu-frac-job:%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvId),
+									Value: ptr.To("cpu-frac-job"),
 								},
 							},
 						}},
@@ -1106,6 +1262,18 @@ func TestTorch(t *testing.T) {
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
 									Value: ptr.To(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvBackend),
+									Value: ptr.To("c10d"),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvEndpoint),
+									Value: ptr.To(fmt.Sprintf("gpu-job-node-0-0.gpu-job:%d", constants.ContainerTrainerPort)),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvRdzvId),
+									Value: ptr.To("gpu-job"),
 								},
 							},
 						}},

--- a/test/integration/controller/trainjob_controller_test.go
+++ b/test/integration/controller/trainjob_controller_test.go
@@ -359,6 +359,18 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 										Name:  constants.TorchEnvMasterPort,
 										Value: fmt.Sprintf("%d", constants.ContainerTrainerPort),
 									},
+									{
+										Name:  constants.TorchEnvRdzvBackend,
+										Value: "c10d",
+									},
+									{
+										Name:  constants.TorchEnvRdzvEndpoint,
+										Value: fmt.Sprintf("alpha-%s-0-0.alpha:%d", constants.Node, constants.ContainerTrainerPort),
+									},
+									{
+										Name:  constants.TorchEnvRdzvId,
+										Value: "alpha",
+									},
 								}...,
 							).
 							Obj(),
@@ -912,6 +924,18 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 									{
 										Name:  constants.TorchEnvMasterPort,
 										Value: fmt.Sprintf("%d", constants.ContainerTrainerPort),
+									},
+									{
+										Name:  constants.TorchEnvRdzvBackend,
+										Value: "c10d",
+									},
+									{
+										Name:  constants.TorchEnvRdzvEndpoint,
+										Value: fmt.Sprintf("alpha-%s-0-0.alpha:%d", constants.Node, constants.ContainerTrainerPort),
+									},
+									{
+										Name:  constants.TorchEnvRdzvId,
+										Value: "alpha",
 									},
 								}...,
 							).


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
- Adds PET_RDZV_BACKEND, PET_RDZV_ENDPOINT, and PET_RDZV_ID environment variables to the torchrun code path in the Torch plugin, enabling torchrun train.py to work with zero extra flags
- Adds corresponding constants (TorchEnvRdzvBackend, TorchEnvRdzvEndpoint, TorchEnvRdzvId) and registers them in TorchRunReservedEnvNames
- Updated all test expectations across torch_test.go, trainjob_controller_test.go, and trainingruntime_test.go to include the new env vars
 
The Torch plugin already sets PET_MASTER_ADDR and PET_MASTER_PORT, but torchrun also needs PET_RDZV_BACKEND, PET_RDZV_ENDPOINT, and PET_RDZV_ID to configure rendezvous. Without them, users have to manually pass --rdzv-backend, --rdzv-endpoint, and --rdzv-id flags. Adding these lets torchrun train.py work out of the box. 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes https://github.com/kubeflow/trainer/issues/3277

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
