### PR TITLE
fix: rename JAX and Torch runtime plugin tests to descriptive names

### DIFF
--- a/pkg/runtime/framework/plugins/jax/jax_test.go
+++ b/pkg/runtime/framework/plugins/jax/jax_test.go
@@ -37,7 +37,7 @@ import (
 	utiltesting "github.com/kubeflow/trainer/v2/pkg/util/testing"
 )
 
-func TestJax(t *testing.T) {
+func TestJAXEnforceMLPolicy(t *testing.T) {
 	cases := map[string]struct {
 		info              *runtime.Info
 		trainJob          *trainer.TrainJob

--- a/pkg/runtime/framework/plugins/torch/torch_test.go
+++ b/pkg/runtime/framework/plugins/torch/torch_test.go
@@ -41,7 +41,7 @@ import (
 	utiltesting "github.com/kubeflow/trainer/v2/pkg/util/testing"
 )
 
-func TestTorch(t *testing.T) {
+func TestTorchEnforceMLPolicy(t *testing.T) {
 	cases := map[string]struct {
 		info              *runtime.Info
 		trainJob          *trainer.TrainJob
@@ -1396,7 +1396,7 @@ func TestTorch(t *testing.T) {
 	}
 }
 
-func TestValidate(t *testing.T) {
+func TestTorchValidate(t *testing.T) {
 	cases := map[string]struct {
 		info         *runtime.Info
 		oldObj       *trainer.TrainJob


### PR DESCRIPTION
### Description of Changes

Renames JAX and Torch runtime plugin unit tests to follow the naming
convention used across Trainer framework plugins.

Changes:
- TestJax → TestJAXEnforceMLPolicy
- TestTorch → TestTorchEnforceMLPolicy
- TestValidate → TestTorchValidate 

This makes the test names more descriptive and consistent with
existing plugin tests such as XGBoost.

### Related Issues

Fixes #3280


### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).