### PR TITLE
fix(runtimes): add validation for LoRA multi-node and immutable trainer args

### DIFF
--- a/pkg/runtime/framework/plugins/torch/torch_test.go
+++ b/pkg/runtime/framework/plugins/torch/torch_test.go
@@ -1675,6 +1675,78 @@ func TestTorchValidate(t *testing.T) {
 				),
 			},
 		},
+		"lora is not supported for multi-node training in torchtune": {
+			info: runtime.NewInfo(
+				runtime.WithMLPolicySource(utiltesting.MakeMLPolicyWrapper().
+					WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+						TorchPolicy().
+						Obj(),
+					).
+					Obj(),
+				),
+			),
+			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				Trainer(utiltesting.MakeTrainJobTrainerWrapper().
+					NumNodes(int32(2)).
+					Container(
+						"ghcr.io/kubeflow/trainer/torchtune-trainer",
+						[]string{"tune", "run"},
+						[]string{
+							"model.lora_attn_modules=[q_proj, v_proj, output_proj]",
+						},
+						corev1.ResourceList{},
+					).
+					Obj(),
+				).
+				RuntimeRef(
+					trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind),
+					"torchtune-llama3.3-70b",
+				).
+				Obj(),
+			wantError: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec").Child("trainer").Child("numNodes"),
+					int32(2),
+					"LoRA fine-tuning is not supported for multi-node training in TorchTune",
+				),
+			},
+		},
+		"immutable runtime config must not be set in trainer args": {
+			info: runtime.NewInfo(
+				runtime.WithMLPolicySource(utiltesting.MakeMLPolicyWrapper().
+					WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+						TorchPolicy().
+						Obj(),
+					).
+					Obj(),
+				),
+			),
+			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				Trainer(utiltesting.MakeTrainJobTrainerWrapper().
+					NumNodes(int32(1)).
+					Container(
+						"ghcr.io/kubeflow/trainer/torchtune-trainer",
+						[]string{"tune", "run"},
+						[]string{
+							"output_dir=/custom/output",
+						},
+						corev1.ResourceList{},
+					).
+					Obj(),
+				).
+				RuntimeRef(
+					trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind),
+					"torchtune-llama3.2-1b",
+				).
+				Obj(),
+			wantError: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec").Child("trainer").Child("args").Index(0),
+					"output_dir=/custom/output",
+					fmt.Sprintf("must not set immutable config %q in trainer args; it is managed by the runtime", "output_dir"),
+				),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/runtime/framework/plugins/torch/torch_test.go
+++ b/pkg/runtime/framework/plugins/torch/torch_test.go
@@ -1711,6 +1711,36 @@ func TestTorchValidate(t *testing.T) {
 				),
 			},
 		},
+		"lora is supported for single-node training in torchtune": {
+			info: runtime.NewInfo(
+				runtime.WithMLPolicySource(utiltesting.MakeMLPolicyWrapper().
+					WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+						TorchPolicy().
+						Obj(),
+					).
+					Obj(),
+				),
+			),
+			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				Trainer(utiltesting.MakeTrainJobTrainerWrapper().
+					NumNodes(int32(1)).
+					Container(
+						"ghcr.io/kubeflow/trainer/torchtune-trainer",
+						[]string{"tune", "run"},
+						[]string{
+							"model.lora_attn_modules=[q_proj, v_proj, output_proj]",
+						},
+						corev1.ResourceList{},
+					).
+					Obj(),
+				).
+				RuntimeRef(
+					trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind),
+					"torchtune-llama3.3-70b",
+				).
+				Obj(),
+			wantError: nil,
+		},
 		"immutable runtime config must not be set in trainer args": {
 			info: runtime.NewInfo(
 				runtime.WithMLPolicySource(utiltesting.MakeMLPolicyWrapper().
@@ -1744,6 +1774,48 @@ func TestTorchValidate(t *testing.T) {
 					field.NewPath("spec").Child("trainer").Child("args").Index(0),
 					"output_dir=/custom/output",
 					fmt.Sprintf("must not set immutable config %q in trainer args; it is managed by the runtime", "output_dir"),
+				),
+			},
+		},
+		"multiple immutable runtime configs must not be set in trainer args": {
+			info: runtime.NewInfo(
+				runtime.WithMLPolicySource(utiltesting.MakeMLPolicyWrapper().
+					WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+						TorchPolicy().
+						Obj(),
+					).
+					Obj(),
+				),
+			),
+			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				Trainer(utiltesting.MakeTrainJobTrainerWrapper().
+					NumNodes(int32(1)).
+					Container(
+						"ghcr.io/kubeflow/trainer/torchtune-trainer",
+						[]string{"tune", "run"},
+						[]string{
+							"output_dir=custom-output",
+							"tokenizer.path=/some/path",
+						},
+						corev1.ResourceList{},
+					).
+					Obj(),
+				).
+				RuntimeRef(
+					trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind),
+					"torchtune-llama3.2-1b",
+				).
+				Obj(),
+			wantError: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec").Child("trainer").Child("args").Index(0),
+					"output_dir=custom-output",
+					fmt.Sprintf("must not set immutable config %q in trainer args; it is managed by the runtime", "output_dir"),
+				),
+				field.Invalid(
+					field.NewPath("spec").Child("trainer").Child("args").Index(1),
+					"tokenizer.path=/some/path",
+					fmt.Sprintf("must not set immutable config %q in trainer args; it is managed by the runtime", "tokenizer.path"),
 				),
 			},
 		},

--- a/pkg/runtime/framework/plugins/torch/torchtune.go
+++ b/pkg/runtime/framework/plugins/torch/torchtune.go
@@ -73,6 +73,33 @@ func validateTorchTune(runtimeInfo *runtime.Info, newObj *trainer.TrainJob) (adm
 			)
 		}
 	}
+	// LoRA fine-tuning is not supported for multi-node training in TorchTune.
+	// getRecipeAndConfig silently falls through to full_finetune_distributed when
+	// numNodes > 1, discarding LoRA args without any user-visible error.
+	if numNodes > 1 && isLoraConfigEnabled(newObj.Spec.Trainer.Args) {
+		allErrs = append(allErrs, field.Invalid(
+			numNodesRefPath,
+			numNodes,
+			"LoRA fine-tuning is not supported for multi-node training in TorchTune",
+		))
+	}
+
+	// Immutable runtime configs must not be set in spec.trainer.args.
+	// output_dir, tokenizer.path, checkpointer.checkpoint_dir, and tokenizer.merges_file
+	// are injected by the runtime via extractOverridesFromRuntime and must not be
+	// overridden by the user.
+	trainerArgsPath := specPath.Child("trainer").Child("args")
+	for i, arg := range newObj.Spec.Trainer.Args {
+		key := strings.SplitN(arg, "=", 2)[0]
+		if constants.TorchTuneImmutableConfigs.Has(key) {
+			allErrs = append(allErrs, field.Invalid(
+				trainerArgsPath.Index(i),
+				arg,
+				fmt.Sprintf("must not set immutable config %q in trainer args; it is managed by the runtime", key),
+			))
+		}
+	}
+
 	return nil, allErrs
 }
 

--- a/pkg/runtime/framework/plugins/torch/torchtune.go
+++ b/pkg/runtime/framework/plugins/torch/torchtune.go
@@ -76,7 +76,7 @@ func validateTorchTune(runtimeInfo *runtime.Info, newObj *trainer.TrainJob) (adm
 	// LoRA fine-tuning is not supported for multi-node training in TorchTune.
 	// getRecipeAndConfig silently falls through to full_finetune_distributed when
 	// numNodes > 1, discarding LoRA args without any user-visible error.
-	if numNodes > 1 && isLoraConfigEnabled(newObj.Spec.Trainer.Args) {
+	if numNodes > 1 && (isLoraConfigEnabled(newObj.Spec.Trainer.Args) || isUseQLoraFinetune(newObj.Spec.Trainer.Args)) {
 		allErrs = append(allErrs, field.Invalid(
 			numNodesRefPath,
 			numNodes,


### PR DESCRIPTION
**What this PR does / why we need it**:

Resolves the TODO left by @Electronic-Waste in `validateTorchTune`:
> `TODO(Electronic-Waste): Add more validation for torchtune when we support more arguments.`

Adds two missing webhook validations:

**1. Reject LoRA fine-tuning when `numNodes > 1`**

`getRecipeAndConfig` silently falls through to `full_finetune_distributed` when `numNodes > 1`, discarding LoRA args without any user-visible error. A user who sets `model.lora_attn_modules` and requests multiple nodes would silently get a full fine-tune run instead. This PR surfaces that as an explicit admission error on `spec.trainer.numNodes`.

**2. Reject immutable runtime configs in `spec.trainer.args`**

`output_dir`, `tokenizer.path`, `checkpointer.checkpoint_dir`, and `tokenizer.merges_file` are injected by the runtime via `extractOverridesFromRuntime`. If a user sets any of these in `spec.trainer.args`, their values are silently overridden at runtime with no feedback. This PR rejects them at admission time with a clear error message.

**Which issue(s) this PR fixes**:

Fixes #

**Tests**:

Added 2 new table-driven test cases to `TestValidate`:
- `lora is not supported for multi-node training in torchtune`
- `immutable runtime config must not be set in trainer args`

All 32 tests pass (`TestTorch` + `TestValidate`).

**Checklist:**
- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
  - No docs change needed, this is a validation-only fix with no new user-facing API surface.