### PR TITLE
feat(runtime): support Image and Command in PodSet Container

### DIFF
--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -289,6 +289,26 @@ func (j *JobSet) Build(ctx context.Context, info *runtime.Info, trainJob *traine
 				container.VolumeMounts...,
 			)
 		}
+		for containerIdx, container := range ps.InitContainers {
+			if len(container.Command) > 0 {
+				jobSetSpec.ReplicatedJobs[psIdx].Template.Spec.Template.Spec.InitContainers[containerIdx].Command = container.Command
+			}
+			if container.Image != "" {
+				jobSetSpec.ReplicatedJobs[psIdx].Template.Spec.Template.Spec.InitContainers[containerIdx].Image = &container.Image
+			}
+			apply.UpsertEnvVars(
+				&jobSetSpec.ReplicatedJobs[psIdx].Template.Spec.Template.Spec.InitContainers[containerIdx].Env,
+				container.Env...,
+			)
+			apply.UpsertPort(
+				&jobSetSpec.ReplicatedJobs[psIdx].Template.Spec.Template.Spec.InitContainers[containerIdx].Ports,
+				container.Ports...,
+			)
+			apply.UpsertVolumeMounts(
+				&jobSetSpec.ReplicatedJobs[psIdx].Template.Spec.Template.Spec.InitContainers[containerIdx].VolumeMounts,
+				container.VolumeMounts...,
+			)
+		}
 	}
 
 	// Init the JobSet apply configuration from the runtime template spec

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -159,6 +159,8 @@ func toPodSetContainer(containerApply ...corev1ac.ContainerApplyConfiguration) i
 		for _, cApply := range containerApply {
 			container := Container{
 				Name:         ptr.Deref(cApply.Name, ""),
+				Image:        ptr.Deref(cApply.Image, ""),
+				Command:      cApply.Command,
 				Env:          cApply.Env,
 				Ports:        cApply.Ports,
 				VolumeMounts: cApply.VolumeMounts,

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -162,6 +162,8 @@ func TestNewInfo(t *testing.T) {
 					).
 					WithInitContainers(corev1ac.Container().
 						WithName("preparation").
+						WithImage("busybox:latest").
+						WithCommand("/bin/sh", "-c", "echo hello").
 						WithResources(corev1ac.ResourceRequirements().
 							WithRequests(corev1.ResourceList{
 								corev1.ResourceCPU: resource.MustParse("15"),
@@ -321,7 +323,9 @@ func TestNewInfo(t *testing.T) {
 								}},
 							}},
 							InitContainers: []Container{{
-								Name: "preparation",
+								Name:    "preparation",
+								Image:   "busybox:latest",
+								Command: []string{"/bin/sh", "-c", "echo hello"},
 							}},
 							SinglePodRequests: corev1.ResourceList{
 								corev1.ResourceCPU: resource.MustParse("40"),


### PR DESCRIPTION
## What this PR does

Fixes #3177

Populates `Image` and `Command` fields in [toPodSetContainer](cci:1://file:///C:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/trainer/pkg/runtime/runtime.go:156:0-172:1) from `ContainerApplyConfiguration`, and adds an `InitContainers` sync loop in the JobSet [Build()](cci:1://file:///C:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/trainer/pkg/runtime/framework/plugins/jobset/jobset.go:241:0-337:1) method to propagate `Image`, `Command`, `Env`, `Ports`, and `VolumeMounts` from `PodSet.InitContainers` back to the JobSet spec.

### Root Cause

Two gaps prevented PodSet from being used for InitContainer customization:

1. **[toPodSetContainer](cci:1://file:///C:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/trainer/pkg/runtime/runtime.go:156:0-172:1) in [runtime.go](cci:7://file:///C:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/trainer/pkg/runtime/runtime.go:0:0-0:0)** — Created [Container](cci:2://file:///C:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/trainer/pkg/runtime/runtime.go:79:0-86:1) structs but skipped `Image` and `Command`, only copying [Name](cci:1://file:///C:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/trainer/pkg/runtime/framework/plugins/jobset/jobset.go:83:0-85:1), `Env`, `Ports`, `VolumeMounts`. The [Container](cci:2://file:///C:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/trainer/pkg/runtime/runtime.go:79:0-86:1) struct already had `Image` and `Command` fields, but they were never populated from `ContainerApplyConfiguration`.

2. **[Build()](cci:1://file:///C:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/trainer/pkg/runtime/framework/plugins/jobset/jobset.go:241:0-337:1) in [jobset.go](cci:7://file:///C:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/trainer/pkg/runtime/framework/plugins/jobset/jobset.go:0:0-0:0)** — Synced `Image`, `Command`, `Env`, `Ports`, and `VolumeMounts` from `PodSet.Containers` back to the JobSet spec, but had no equivalent sync loop for `PodSet.InitContainers`.

### Changes

| File | Change |
|------|--------|
| [pkg/runtime/runtime.go](cci:7://file:///C:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/trainer/pkg/runtime/runtime.go:0:0-0:0) | Populate `Image` and `Command` in [toPodSetContainer](cci:1://file:///C:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/trainer/pkg/runtime/runtime.go:156:0-172:1) from `ContainerApplyConfiguration` |
| [pkg/runtime/framework/plugins/jobset/jobset.go](cci:7://file:///C:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/trainer/pkg/runtime/framework/plugins/jobset/jobset.go:0:0-0:0) | Add `InitContainers` sync loop in [Build()](cci:1://file:///C:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/trainer/pkg/runtime/framework/plugins/jobset/jobset.go:241:0-337:1) mirroring the existing `Containers` sync |
| [pkg/runtime/runtime_test.go](cci:7://file:///C:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/trainer/pkg/runtime/runtime_test.go:0:0-0:0) | Update [TestNewInfo](cci:1://file:///C:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/trainer/pkg/runtime/runtime_test.go:34:0-446:1) to set `Image`/`Command` on an InitContainer input and assert roundtrip |

### Context

This unblocks the Flux Framework integration ([#3064](https://github.com/kubeflow/trainer/pull/3064)) from using PodSet for InitContainer customization, as discussed in:
- [#3064 (comment)](https://github.com/kubeflow/trainer/pull/3064#issuecomment-3815049315)
- [#3064 (review discussion)](https://github.com/kubeflow/trainer/pull/3064#discussion_r2766829969)

### Testing

- All `./pkg/runtime/...` unit tests pass (`runtime`, `framework/core`, `framework/plugins/jobset`, `indexer`)
- [TestNewInfo](cci:1://file:///C:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/trainer/pkg/runtime/runtime_test.go:34:0-446:1) updated to verify InitContainer `Image`/`Command` propagation

### Contributor Checklist

- [x] DCO sign-off included (`Signed-off-by: Siddhant Jain <siddhantjainofficial26@gmail.com>`)
- [x] Unit tests updated and passing
- [x] No unrelated files in diff
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification
- [x] Changes match master's existing patterns (InitContainers sync mirrors Containers sync)
