### PR TITLE
feat(controller): support Pod recreation after scheduler preemption

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -33,6 +33,10 @@ const (
 	// JobSetKind is the Kind name for the JobSet.
 	JobSetKind string = "JobSet"
 
+	// LabelTrainJobName is the label set on pods to identify the owning TrainJob.
+	// This is used by the preemption restart feature to find pods belonging to a TrainJob.
+	LabelTrainJobName string = "trainer.kubeflow.org/trainjob-name"
+
 	// LabelTrainJobAncestor is the label to identify relationship between
 	// TrainJob and Pod template in the Runtime. The following labels are supported:
 	// trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer  - trainJob.spec.initializer.dataset

--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -43,7 +43,9 @@ import (
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
+	"github.com/kubeflow/trainer/v2/pkg/features"
 	jobruntimes "github.com/kubeflow/trainer/v2/pkg/runtime"
+	"github.com/kubeflow/trainer/v2/pkg/util/preemption"
 	"github.com/kubeflow/trainer/v2/pkg/util/trainjob"
 )
 
@@ -88,6 +90,7 @@ func NewTrainJobReconciler(client client.Client, recorder events.EventRecorder, 
 	}
 }
 
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update;patch
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;watch;update;patch
 // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainjobs,verbs=get;list;watch;update;patch
@@ -118,6 +121,16 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		err = fmt.Errorf("unsupported runtime: %s", runtimeRefGK)
 		setFailedCondition(&trainJob, fmt.Sprintf("unsupported runtime: %s", runtimeRefGK), trainer.TrainJobRuntimeNotSupportedReason)
 	} else if !trainjob.IsTrainJobFinished(&trainJob) {
+		// Handle preempted pods: when the PreemptionRestart feature gate is enabled,
+		// detect pods that have been preempted by the scheduler and delete them so
+		// they can be recreated by the JobSet controller.
+		if features.Enabled(features.PreemptionRestart) {
+			if preemptErr := r.handlePreemptedPods(ctx, &trainJob); preemptErr != nil {
+				log.Error(preemptErr, "Failed to handle preempted pods")
+				err = errors.Join(err, preemptErr)
+			}
+		}
+
 		err = r.reconcileObjects(ctx, runtime, &trainJob)
 		if err != nil {
 			// TODO (astefanutti): the error should be surfaced in the TrainJob status to indicate
@@ -254,4 +267,104 @@ func (r *TrainJobReconciler) SetupWithManager(mgr ctrl.Manager, options controll
 		}
 	}
 	return b.Complete(r)
+}
+
+// handlePreemptedPods lists all pods owned by the TrainJob and deletes any that have been
+// preempted by the scheduler (indicated by DisruptionTarget condition with reason
+// PreemptionByScheduler). This allows the JobSet controller to recreate the pods,
+// effectively restarting the preempted replicas instead of marking the job as failed.
+//
+// The max preemption restart limit is enforced via the PreemptionRestartCountAnnotation
+// on the TrainJob. If the limit is exceeded, preempted pods are not deleted and the
+// job is allowed to fail naturally.
+func (r *TrainJobReconciler) handlePreemptedPods(ctx context.Context, trainJob *trainer.TrainJob) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	// List all pods owned by this TrainJob.
+	var podList corev1.PodList
+	if err := r.client.List(ctx, &podList,
+		client.InNamespace(trainJob.Namespace),
+		client.MatchingLabels{
+			constants.LabelTrainJobName: trainJob.Name,
+		},
+	); err != nil {
+		return fmt.Errorf("listing pods for TrainJob: %w", err)
+	}
+
+	preemptedPods := preemption.FilterPreemptedPods(podList.Items)
+	if len(preemptedPods) == 0 {
+		return nil
+	}
+
+	log.V(1).Info("Detected preempted pods", "count", len(preemptedPods))
+
+	// Check the preemption restart count against the max limit.
+	currentRestartCount := getTrainJobPreemptionRestartCount(trainJob)
+	maxRestarts := int32(preemption.DefaultMaxPreemptionRestarts)
+	if maxRestarts > 0 && currentRestartCount >= maxRestarts {
+		log.Info("TrainJob has exceeded max preemption restarts, allowing failure",
+			"currentRestarts", currentRestartCount, "maxRestarts", maxRestarts)
+		r.recorder.Eventf(trainJob, nil, corev1.EventTypeWarning, "PreemptionRestartLimitExceeded", "Reconciling",
+			"TrainJob %s/%s exceeded max preemption restarts (%d), allowing job to fail",
+			trainJob.Namespace, trainJob.Name, maxRestarts)
+		return nil
+	}
+
+	// Delete preempted pods so they can be recreated by the JobSet controller.
+	var errs []error
+	for i := range preemptedPods {
+		pod := &preemptedPods[i]
+		log.Info("Deleting preempted pod for recreation",
+			"pod", klog.KObj(pod), "restartCount", currentRestartCount+1)
+		if err := r.client.Delete(ctx, pod); client.IgnoreNotFound(err) != nil {
+			errs = append(errs, fmt.Errorf("deleting preempted pod %s: %w", pod.Name, err))
+			continue
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	// Update the preemption restart count annotation on the TrainJob.
+	if err := incrementTrainJobPreemptionRestartCount(ctx, r.client, trainJob); err != nil {
+		return fmt.Errorf("updating preemption restart count: %w", err)
+	}
+
+	r.recorder.Eventf(trainJob, nil, corev1.EventTypeWarning, "PreemptedPodsDeleted", "Reconciling",
+		"Deleted %d preempted pod(s) for TrainJob %s/%s (restart %d/%d)",
+		len(preemptedPods), trainJob.Namespace, trainJob.Name, currentRestartCount+1, maxRestarts)
+
+	return nil
+}
+
+// getTrainJobPreemptionRestartCount returns the current preemption restart count
+// from the TrainJob's annotations.
+func getTrainJobPreemptionRestartCount(trainJob *trainer.TrainJob) int32 {
+	if trainJob.Annotations == nil {
+		return 0
+	}
+	val, ok := trainJob.Annotations[preemption.PreemptionRestartCountAnnotation]
+	if !ok {
+		return 0
+	}
+	count, err := fmt.Sscanf(val, "%d")
+	if err != nil || count == 0 {
+		return 0
+	}
+	var result int32
+	fmt.Sscanf(val, "%d", &result)
+	return result
+}
+
+// incrementTrainJobPreemptionRestartCount increments the preemption restart count
+// annotation on the TrainJob.
+func incrementTrainJobPreemptionRestartCount(ctx context.Context, c client.Client, trainJob *trainer.TrainJob) error {
+	patch := client.MergeFrom(trainJob.DeepCopy())
+	currentCount := getTrainJobPreemptionRestartCount(trainJob)
+	if trainJob.Annotations == nil {
+		trainJob.Annotations = make(map[string]string)
+	}
+	trainJob.Annotations[preemption.PreemptionRestartCountAnnotation] = fmt.Sprintf("%d", currentCount+1)
+	return c.Patch(ctx, trainJob, patch)
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -30,13 +30,25 @@ func init() {
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultFeatureGates))
 }
 
+const (
+	// PreemptionRestart enables automatic Pod recreation when preempted by scheduler.
+	// When enabled, pods preempted by Volcano or other schedulers (indicated by
+	// DisruptionTarget condition with reason PreemptionByScheduler) will be automatically
+	// deleted and recreated instead of counting as permanent failures.
+	// This is useful for Volcano gang-scheduling scenarios where low-priority jobs
+	// may be reclaimed to make room for higher-priority jobs.
+	PreemptionRestart featuregate.Feature = "PreemptionRestart"
+)
+
 // defaultFeatureGates consists of all known Trainer-specific feature keys.
 // To add a new feature, define a key for it above and add it here. The features will be
 // available throughout Trainer binaries.
 //
 // Entries are separated from each other with blank lines to avoid sweeping gofmt changes
 // when adding or removing one entry.
-var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{}
+var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	PreemptionRestart: {Default: false, PreRelease: featuregate.Alpha},
+}
 
 func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) {
 	featuregatetesting.SetFeatureGateDuringTest(tb, utilfeature.DefaultFeatureGate, f, value)

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -299,10 +299,17 @@ func (j *JobSet) Build(ctx context.Context, info *runtime.Info, trainJob *traine
 
 	// TODO (andreyvelich): Refactor the builder with wrappers for PodSpec.
 	// TODO: Once we remove deprecated runtime.Info.Trainer, we should remove JobSet Builder with DeprecatedTrainer().
+	// Merge scheduler pod labels with the TrainJob name label for preemption restart support.
+	podLabels := maps.Clone(info.Scheduler.PodLabels)
+	if podLabels == nil {
+		podLabels = make(map[string]string)
+	}
+	podLabels[constants.LabelTrainJobName] = trainJob.Name
+
 	jobSet := jobSetBuilder.
 		Initializer(trainJob).
 		Trainer(info, trainJob).
-		PodLabels(info.Scheduler.PodLabels).
+		PodLabels(podLabels).
 		PodAnnotations(info.Scheduler.PodAnnotations).
 		Suspend(trainJob.Spec.Suspend).
 		Build().

--- a/pkg/util/preemption/preemption.go
+++ b/pkg/util/preemption/preemption.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2025 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preemption
+
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// PreemptionRestartCountAnnotation tracks the number of times a Pod has been
+	// recreated due to scheduler preemption. This is used to enforce the max
+	// preemption restart limit.
+	PreemptionRestartCountAnnotation = "trainer.kubeflow.org/preemption-restart-count"
+
+	// DefaultMaxPreemptionRestarts is the default maximum number of times a Pod
+	// can be recreated after preemption. 0 means unlimited.
+	DefaultMaxPreemptionRestarts = 3
+
+	// PreemptionBySchedulerReason is the reason set by Kubernetes schedulers
+	// (including Volcano) when preempting a pod.
+	PreemptionBySchedulerReason = "PreemptionByScheduler"
+)
+
+// IsPodPreempted checks if a pod has been preempted by the scheduler.
+// When Volcano or the default kube-scheduler preempts a pod, it sets a
+// DisruptionTarget condition with reason "PreemptionByScheduler" on the pod.
+// This is a standard Kubernetes mechanism (since K8s 1.26+).
+func IsPodPreempted(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.DisruptionTarget &&
+			condition.Status == corev1.ConditionTrue &&
+			condition.Reason == PreemptionBySchedulerReason {
+			return true
+		}
+	}
+	return false
+}
+
+// GetPreemptionRestartCount returns the number of times a Pod has been
+// recreated due to preemption, as tracked by the annotation.
+func GetPreemptionRestartCount(pod *corev1.Pod) int32 {
+	if pod.Annotations == nil {
+		return 0
+	}
+	val, ok := pod.Annotations[PreemptionRestartCountAnnotation]
+	if !ok {
+		return 0
+	}
+	count, err := strconv.ParseInt(val, 10, 32)
+	if err != nil {
+		return 0
+	}
+	return int32(count)
+}
+
+// FilterPreemptedPods returns pods that have been preempted by the scheduler.
+func FilterPreemptedPods(pods []corev1.Pod) []corev1.Pod {
+	var result []corev1.Pod
+	for i := range pods {
+		if IsPodPreempted(&pods[i]) {
+			result = append(result, pods[i])
+		}
+	}
+	return result
+}
+
+// CountNonPreemptedFailedPods returns the count of failed pods that were NOT preempted.
+// Preempted pods should not be counted as real failures since they will be recreated.
+func CountNonPreemptedFailedPods(pods []corev1.Pod) int32 {
+	var result int32
+	for i := range pods {
+		if pods[i].Status.Phase == corev1.PodFailed && !IsPodPreempted(&pods[i]) {
+			result++
+		}
+	}
+	return result
+}

--- a/pkg/util/preemption/preemption_test.go
+++ b/pkg/util/preemption/preemption_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2025 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preemption
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsPodPreempted(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected bool
+	}{
+		{
+			name: "pod with DisruptionTarget condition and PreemptionByScheduler reason",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.DisruptionTarget,
+							Status: corev1.ConditionTrue,
+							Reason: PreemptionBySchedulerReason,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pod with DisruptionTarget condition but different reason",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.DisruptionTarget,
+							Status: corev1.ConditionTrue,
+							Reason: "EvictionByEvictionAPI",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pod with DisruptionTarget condition but status is False",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.DisruptionTarget,
+							Status: corev1.ConditionFalse,
+							Reason: PreemptionBySchedulerReason,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pod without DisruptionTarget condition",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pod with no conditions",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := IsPodPreempted(tc.pod)
+			if result != tc.expected {
+				t.Errorf("IsPodPreempted() = %v, expected %v", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGetPreemptionRestartCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected int32
+	}{
+		{
+			name: "pod with restart count annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						PreemptionRestartCountAnnotation: "3",
+					},
+				},
+			},
+			expected: 3,
+		},
+		{
+			name: "pod without annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			expected: 0,
+		},
+		{
+			name: "pod with invalid annotation value",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						PreemptionRestartCountAnnotation: "invalid",
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "pod with zero count",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						PreemptionRestartCountAnnotation: "0",
+					},
+				},
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GetPreemptionRestartCount(tc.pod)
+			if result != tc.expected {
+				t.Errorf("GetPreemptionRestartCount() = %v, expected %v", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestCountNonPreemptedFailedPods(t *testing.T) {
+	tests := []struct {
+		name     string
+		pods     []corev1.Pod
+		expected int32
+	}{
+		{
+			name: "mix of preempted and non-preempted failed pods",
+			pods: []corev1.Pod{
+				{
+					Status: corev1.PodStatus{
+						Phase: corev1.PodFailed,
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.DisruptionTarget,
+								Status: corev1.ConditionTrue,
+								Reason: PreemptionBySchedulerReason,
+							},
+						},
+					},
+				},
+				{
+					Status: corev1.PodStatus{
+						Phase: corev1.PodFailed,
+					},
+				},
+				{
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			},
+			expected: 1,
+		},
+		{
+			name:     "no pods",
+			pods:     []corev1.Pod{},
+			expected: 0,
+		},
+		{
+			name: "all preempted",
+			pods: []corev1.Pod{
+				{
+					Status: corev1.PodStatus{
+						Phase: corev1.PodFailed,
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.DisruptionTarget,
+								Status: corev1.ConditionTrue,
+								Reason: PreemptionBySchedulerReason,
+							},
+						},
+					},
+				},
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := CountNonPreemptedFailedPods(tc.pods)
+			if result != tc.expected {
+				t.Errorf("CountNonPreemptedFailedPods() = %v, expected %v", result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add PreemptionRestart feature gate (alpha, disabled by default) that enables automatic Pod recreation when pods are preempted by schedulers like Volcano. This is critical for gang-scheduling scenarios where low-priority jobs may be reclaimed to make room for higher-priority jobs.

When enabled, the TrainJob controller:
- Detects pods with DisruptionTarget condition (reason: PreemptionByScheduler)
- Deletes preempted pods so the JobSet controller can recreate them
- Tracks restart count via annotation to enforce max restart limit (default: 3)
- Emits events for observability

Changes:
- pkg/features: Add PreemptionRestart feature gate
- pkg/constants: Add LabelTrainJobName for pod-to-TrainJob mapping
- pkg/util/preemption: Add utility functions for preemption detection
- pkg/controller/trainjob_controller: Add handlePreemptedPods logic
- pkg/runtime/framework/plugins/jobset: Label pods with TrainJob name

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
