### PR TITLE
fix: back to a10-1 for gpu e2e and time slicing

### DIFF
--- a/.github/workflows/test-e2e-gpu.yaml
+++ b/.github/workflows/test-e2e-gpu.yaml
@@ -13,7 +13,7 @@ jobs:
     name: GPU E2E Test
     timeout-minutes: 120
     runs-on:
-      labels: oracle-vm-gpu-a10-2
+      labels: oracle-vm-gpu-a10-1
       group: GPUs
 
     env:

--- a/hack/e2e-setup-gpu-cluster.sh
+++ b/hack/e2e-setup-gpu-cluster.sh
@@ -88,7 +88,7 @@ mkdir -p "$HELM_CONFIG_HOME" "$HELM_CACHE_HOME" "$HELM_DATA_HOME"
 
 helm repo add nvidia https://helm.ngc.nvidia.com/nvidia && helm repo update
 
-# Configure GPU time slicing with 3 replicas per GPU.
+# Configure GPU time slicing for GPU.
 kubectl create -n gpu-operator -f ./hack/gpu-time-slicing.yml
 
 helm install --wait --generate-name \

--- a/hack/e2e-setup-gpu-cluster.sh
+++ b/hack/e2e-setup-gpu-cluster.sh
@@ -88,11 +88,20 @@ mkdir -p "$HELM_CONFIG_HOME" "$HELM_CACHE_HOME" "$HELM_DATA_HOME"
 
 helm repo add nvidia https://helm.ngc.nvidia.com/nvidia && helm repo update
 
+# Configure GPU time slicing with 3 replicas per GPU.
+kubectl create -n gpu-operator -f ./hack/gpu-time-slicing.yml
+
 helm install --wait --generate-name \
   -n gpu-operator --create-namespace \
   nvidia/gpu-operator \
   --version="${GPU_OPERATOR_VERSION}" \
-  --set driver.enabled=false
+  --set driver.enabled=false \
+  --set devicePlugin.config.name=gpu-time-slicing-config
+
+# Patch cluster to use the time slicing configuration.
+kubectl patch clusterpolicies.nvidia.com/cluster-policy \
+  -n gpu-operator --type merge \
+  -p '{"spec": {"devicePlugin": {"config": {"name": "gpu-time-slicing-config", "default": "any"}}}}'
 
 # Validation steps for GPU operator installation
 kubectl get ns gpu-operator

--- a/hack/gpu-time-slicing.yml
+++ b/hack/gpu-time-slicing.yml
@@ -1,7 +1,8 @@
-# With GPU A10-2, the runner were queued for long time to host capacity limit of CNCF Runner
+# With GPU A10-2, the runner were queued for long time due to host capacity limit of CNCF Runner
+# Check for dicussion: https://cloud-native.slack.com/archives/C08P4HUFQ6M/p1773430783406709
+
 # This adds time slicing to A10-1 GPU runners.
 # Time slicing docs: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html#time-slicing-gpus-in-kubernetes
-# Check for dicussion: https://cloud-native.slack.com/archives/C08P4HUFQ6M/p1773430783406709
 
 apiVersion: v1
 kind: ConfigMap
@@ -16,4 +17,4 @@ data:
       timeSlicing:
         resources:
         - name: nvidia.com/gpu
-          replicas: 3
+          replicas: 4

--- a/hack/gpu-time-slicing.yml
+++ b/hack/gpu-time-slicing.yml
@@ -17,4 +17,4 @@ data:
       timeSlicing:
         resources:
         - name: nvidia.com/gpu
-          replicas: 4
+          replicas: 2

--- a/hack/gpu-time-slicing.yml
+++ b/hack/gpu-time-slicing.yml
@@ -1,0 +1,19 @@
+# With GPU A10-2, the runner were queued for long time to host capacity limit of CNCF Runner
+# This adds time slicing to A10-1 GPU runners.
+# Time slicing docs: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html#time-slicing-gpus-in-kubernetes
+# Check for dicussion: https://cloud-native.slack.com/archives/C08P4HUFQ6M/p1773430783406709
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gpu-time-slicing-config
+data:
+  any: |-
+    version: v1
+    flags:
+      migStrategy: none
+    sharing:
+      timeSlicing:
+        resources:
+        - name: nvidia.com/gpu
+          replicas: 3


### PR DESCRIPTION
**What this PR does / why we need it**:

Related https://github.com/kubeflow/trainer/issues/3336

This PR changes the runner for GPU test to A10.1 due to capacity issue and add time slicing for the runner.
Time slicing docs: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html#time-slicing-gpus-in-kubernetes


**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
