### PR TITLE
chore: add timeout-minutes to gpu-e2e-test workflow

### DIFF
--- a/.github/workflows/test-e2e-gpu.yaml
+++ b/.github/workflows/test-e2e-gpu.yaml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   gpu-e2e-test:
     name: GPU E2E Test
+    timeout-minutes: 120
     runs-on:
       labels: oracle-vm-gpu-a10-2
       group: GPUs


### PR DESCRIPTION
Adds `timeout-minutes: 120` to the gpu-e2e-test job to prevent stalled jobs from holding oracle-vm-gpu-a10-2 GPU runners for extended periods.

