### PR TITLE
fix(ci): Bump Python to 3.12 in E2Es

### DIFF
--- a/.github/workflows/test-e2e-gpu.yaml
+++ b/.github/workflows/test-e2e-gpu.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         # Python version to run unit and integration tests.
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
       - name: Checkout code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ For the Kubeflow Trainer documentation, please check [the official Kubeflow docu
 - [Docker](https://docs.docker.com/) (23 or later)
 - [Lima](https://github.com/lima-vm/lima?tab=readme-ov-file#adopters) (an alternative to DockerDesktop) (0.21.0 or later)
   - [Colima](https://github.com/abiosoft/colima) (Lima specifically for MacOS) (0.6.8 or later)
-- [Python](https://www.python.org/) (3.11 or later)
+- [Python](https://www.python.org/) (3.12 or later)
 - [kustomize](https://kustomize.io/) (4.0.5 or later)
 - [Kind](https://kind.sigs.k8s.io/) (0.27.0 or later)
 - [pre-commit](https://pre-commit.com/)


### PR DESCRIPTION
We should update Python to 3.12 since PyTorch 2.10 uses it.
/cc @kubeflow/kubeflow-trainer-team @akshaychitneni @robert-bell 