### PR TITLE
chore(test): add test for cross-plugin env conflict between TorchTune and torchrun

### DIFF
--- a/pkg/runtime/framework/plugins/torch/torch_test.go
+++ b/pkg/runtime/framework/plugins/torch/torch_test.go
@@ -1545,10 +1545,11 @@ func TestTorchValidate(t *testing.T) {
 						Env(
 							[]corev1.EnvVar{
 								{
-									// PET_MASTER_ADDR is a torchrun reserved env.
-									// Setting it alongside the TorchTune entrypoint
-									// causes a cross-plugin conflict since TorchTune
-									// manages its own rendezvous via --rdzv_endpoint.
+									// PET_MASTER_ADDR is one of the torchrun rendezvous envs.
+									// Setting PET_MASTER_ADDR (and similarly PET_MASTER_PORT)
+									// alongside a TorchTune entrypoint causes a cross-plugin
+									// conflict because TorchTune configures rendezvous itself
+									// via --rdzv_endpoint.
 									// Ref: pkg/runtime/framework/plugins/torch/torch.go
 									// TODO (andreyvelich): extend this check once the
 									// multi-backend BuiltinTrainer plugin registry (#2752)

--- a/pkg/runtime/framework/plugins/torch/torch_test.go
+++ b/pkg/runtime/framework/plugins/torch/torch_test.go
@@ -1524,6 +1524,64 @@ func TestTorchValidate(t *testing.T) {
 				),
 			},
 		},
+			"torchtune entrypoint with reserved torchrun env causes cross-plugin conflict": {
+				info: runtime.NewInfo(
+					runtime.WithMLPolicySource(utiltesting.MakeMLPolicyWrapper().
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							TorchPolicy().
+							Obj(),
+						).
+						Obj(),
+					),
+				),
+				newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+					Trainer(utiltesting.MakeTrainJobTrainerWrapper().
+						Container(
+							"ghcr.io/kubeflow/trainer/torchtune-trainer",
+							[]string{"tune", "run"},
+							nil,
+							corev1.ResourceList{},
+						).
+						Env(
+							[]corev1.EnvVar{
+								{
+									// PET_MASTER_ADDR is a torchrun reserved env.
+									// Setting it alongside the TorchTune entrypoint
+									// causes a cross-plugin conflict since TorchTune
+									// manages its own rendezvous via --rdzv_endpoint.
+									// Ref: pkg/runtime/framework/plugins/torch/torch.go
+									// TODO (andreyvelich): extend this check once the
+									// multi-backend BuiltinTrainer plugin registry (#2752)
+									// is implemented.
+									Name:  constants.TorchEnvMasterAddr,
+									Value: "custom-master:29500",
+								},
+							}...,
+						).
+						Obj(),
+					).
+					RuntimeRef(
+						trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind),
+						"torchtune-llama3.2-1b",
+					).
+					Obj(),
+				wantError: field.ErrorList{
+					field.Invalid(
+						field.NewPath("spec").Child("trainer").Child("env"),
+						[]corev1.EnvVar{
+							{
+								Name:  constants.TorchEnvMasterAddr,
+								Value: "custom-master:29500",
+							},
+						},
+						fmt.Sprintf("must not have reserved envs, invalid envs configured: %v", func() []string {
+							torchEnvs := sets.New[string]()
+							torchEnvs.Insert(constants.TorchEnvMasterAddr)
+							return sets.List(torchEnvs)
+						}()),
+					),
+				},
+			},
 		"unsupported pretrained model": {
 			info: runtime.NewInfo(
 				runtime.WithMLPolicySource(utiltesting.MakeMLPolicyWrapper().


### PR DESCRIPTION
## Summary

Adds a test case to `TestTorchValidate` that explicitly covers the
cross-plugin env conflict between TorchTune and torchrun.

When a TrainJob uses the TorchTune entrypoint (`tune run`), setting
torchrun reserved `PET_*` envs (e.g. `PET_MASTER_ADDR`) creates a
conflict — TorchTune manages rendezvous independently via
`--rdzv_endpoint` and the `PET_*` envs are meaningless in that context.

The existing `TorchRunReservedEnvNames` validation already catches this
but no test covered the TorchTune-specific path. This PR documents that
behavior and sets the foundation for the broader cross-plugin conflict
detection noted in the TODO at torch.go:124.

This is preparatory work for the pluggable BuiltinTrainer backend
architecture tracked in #2752.

## Testing