### PR TITLE
chore(runtimes): persist runtimes map and expose Runtimes function

### DIFF
--- a/pkg/runtime/core/core.go
+++ b/pkg/runtime/core/core.go
@@ -29,28 +29,39 @@ import (
 // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainingruntimes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=clustertrainingruntimes,verbs=get;list;watch
 
+var runtimes map[string]runtime.Runtime
+
 func New(ctx context.Context, client client.Client, indexer client.FieldIndexer, cfg *configapi.Configuration) (map[string]runtime.Runtime, error) {
 	registry := NewRuntimeRegistry()
-	runtimes := make(map[string]runtime.Runtime, len(registry))
+	newRuntimes := make(map[string]runtime.Runtime, len(registry))
 	for name, registrar := range registry {
 		for _, dep := range registrar.dependencies {
 			depRegistrar, depExist := registry[dep]
-			_, depRegistered := runtimes[dep]
+			_, depRegistered := newRuntimes[dep]
 			if depExist && !depRegistered {
 				r, err := depRegistrar.factory(ctx, client, indexer, cfg)
 				if err != nil {
 					return nil, fmt.Errorf("initializing runtime %q on which %q depends: %w", dep, name, err)
 				}
-				runtimes[dep] = r
+				newRuntimes[dep] = r
 			}
 		}
-		if _, ok := runtimes[name]; !ok {
+		if _, ok := newRuntimes[name]; !ok {
 			r, err := registrar.factory(ctx, client, indexer, cfg)
 			if err != nil {
 				return nil, fmt.Errorf("initializing runtime %q: %w", name, err)
 			}
-			runtimes[name] = r
+			newRuntimes[name] = r
 		}
 	}
-	return runtimes, nil
+	runtimes = newRuntimes
+	return newRuntimes, nil
+}
+
+func Runtimes() map[string]runtime.Runtime {
+	runtimesCopy := make(map[string]runtime.Runtime, len(runtimes))
+	for d, r := range runtimes {
+		runtimesCopy[d] = r
+	}
+	return runtimesCopy
 }

--- a/pkg/runtime/core/core_test.go
+++ b/pkg/runtime/core/core_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	testingutil "github.com/kubeflow/trainer/v2/pkg/util/testing"
+)
+
+func TestRuntimes(t *testing.T) {
+	cases := map[string]struct {
+	}{
+		"returns a copy of the runtimes map": {},
+	}
+	for name := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			clientBuilder := testingutil.NewClientBuilder()
+			c := clientBuilder.Build()
+
+			newRuntimes, err := New(ctx, c, testingutil.AsIndex(clientBuilder), nil)
+			if err != nil {
+				t.Fatalf("Failed to initialize runtimes: %v", err)
+			}
+
+			gotRuntimes := Runtimes()
+			if diff := cmp.Diff(newRuntimes, gotRuntimes, cmpopts.IgnoreUnexported(TrainingRuntime{}, ClusterTrainingRuntime{})); len(diff) != 0 {
+				t.Errorf("Unexpected difference between new and got runtimes (-want,+got):\n%s", diff)
+			}
+
+			// Verify that modifying the returned map does not affect the persisted runtimes.
+			gotRuntimes["mutated-key"] = nil
+			gotRuntimes[TrainingRuntimeGroupKind] = nil
+			delete(gotRuntimes, ClusterTrainingRuntimeGroupKind)
+
+			if _, exists := runtimes["mutated-key"]; exists {
+				t.Error("Adding a key to Runtimes() return value should not affect the persisted runtimes")
+			}
+			if runtimes[TrainingRuntimeGroupKind] == nil {
+				t.Error("Modifying an existing key in Runtimes() return value should not affect the persisted runtimes")
+			}
+			if _, exists := runtimes[ClusterTrainingRuntimeGroupKind]; !exists {
+				t.Error("Deleting a key from Runtimes() return value should not affect the persisted runtimes")
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR updates `runtime.core.New` to persist the available runtimes and exposes them via the Runtimes function. This allows external controllers to lazily load runtimes, avoiding the need to maintain them in their own state.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
