### PR TITLE
fix(runtimes): set MPI SSH auth secret volume default mode to 0640

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -143,6 +143,12 @@ const (
 	// MPISSHAuthorizedKeys is the file name for authorized keys.
 	MPISSHAuthorizedKeys string = "authorized_keys"
 
+	// MPISSHSecretPrivateKeyFileMode is the mode for the mounted MPI SSH private key (0600: OpenSSH-compatible; not group/other readable).
+	MPISSHSecretPrivateKeyFileMode int32 = 0600
+
+	// MPISSHSecretSharedSSHFileMode is the mode for the mounted MPI SSH public key and authorized_keys files (0644).
+	MPISSHSecretSharedSSHFileMode int32 = 0644
+
 	// MPIHostfilePath is the directory for the MPI hostfile.
 	MPIHostfileDir string = "/etc/mpi"
 

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -1978,20 +1978,22 @@ test-job-node-0-1.test-job slots=8
 							Name: constants.MPISSHAuthVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName:  fmt.Sprintf("test-job%s", constants.MPISSHAuthSecretSuffix),
-									DefaultMode: ptr.To[int32](0640),
+									SecretName: fmt.Sprintf("test-job%s", constants.MPISSHAuthSecretSuffix),
 									Items: []corev1.KeyToPath{
 										{
 											Key:  corev1.SSHAuthPrivateKey,
 											Path: constants.MPISSHPrivateKeyFile,
+											Mode: ptr.To(constants.MPISSHSecretPrivateKeyFileMode),
 										},
 										{
 											Key:  constants.MPISSHPublicKey,
 											Path: constants.MPISSHPublicKeyFile,
+											Mode: ptr.To(constants.MPISSHSecretSharedSSHFileMode),
 										},
 										{
 											Key:  constants.MPISSHPublicKey,
 											Path: constants.MPISSHAuthorizedKeys,
+											Mode: ptr.To(constants.MPISSHSecretSharedSSHFileMode),
 										},
 									},
 								},
@@ -2018,20 +2020,22 @@ test-job-node-0-1.test-job slots=8
 							Name: constants.MPISSHAuthVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName:  fmt.Sprintf("test-job%s", constants.MPISSHAuthSecretSuffix),
-									DefaultMode: ptr.To[int32](0640),
+									SecretName: fmt.Sprintf("test-job%s", constants.MPISSHAuthSecretSuffix),
 									Items: []corev1.KeyToPath{
 										{
 											Key:  corev1.SSHAuthPrivateKey,
 											Path: constants.MPISSHPrivateKeyFile,
+											Mode: ptr.To(constants.MPISSHSecretPrivateKeyFileMode),
 										},
 										{
 											Key:  constants.MPISSHPublicKey,
 											Path: constants.MPISSHPublicKeyFile,
+											Mode: ptr.To(constants.MPISSHSecretSharedSSHFileMode),
 										},
 										{
 											Key:  constants.MPISSHPublicKey,
 											Path: constants.MPISSHAuthorizedKeys,
+											Mode: ptr.To(constants.MPISSHSecretSharedSSHFileMode),
 										},
 									},
 								},

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -1978,7 +1978,8 @@ test-job-node-0-1.test-job slots=8
 							Name: constants.MPISSHAuthVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: fmt.Sprintf("test-job%s", constants.MPISSHAuthSecretSuffix),
+									SecretName:  fmt.Sprintf("test-job%s", constants.MPISSHAuthSecretSuffix),
+									DefaultMode: ptr.To[int32](0640),
 									Items: []corev1.KeyToPath{
 										{
 											Key:  corev1.SSHAuthPrivateKey,
@@ -2017,7 +2018,8 @@ test-job-node-0-1.test-job slots=8
 							Name: constants.MPISSHAuthVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: fmt.Sprintf("test-job%s", constants.MPISSHAuthSecretSuffix),
+									SecretName:  fmt.Sprintf("test-job%s", constants.MPISSHAuthSecretSuffix),
+									DefaultMode: ptr.To[int32](0640),
 									Items: []corev1.KeyToPath{
 										{
 											Key:  corev1.SSHAuthPrivateKey,

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -2198,10 +2198,7 @@ test-job-node-0-1.test-job slots=1
 		cmpopts.SortSlices(func(a, b apiruntime.Object) bool {
 			return a.GetObjectKind().GroupVersionKind().String() < b.GetObjectKind().GroupVersionKind().String()
 		}),
-		// Compare MPI Secret data contents, but ignore DefaultMode differences on Secret volumes,
-		// which are validated more directly in MPI-specific tests.
 		cmp.Comparer(testingutil.MPISecretDataComparer),
-		cmpopts.IgnoreFields(corev1.SecretVolumeSource{}, "DefaultMode"),
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -901,17 +901,19 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 														WithName(constants.MPISSHAuthVolumeName).
 														WithSecret(corev1ac.SecretVolumeSource().
 															WithSecretName(fmt.Sprintf("test-job%s", constants.MPISSHAuthSecretSuffix)).
-															WithDefaultMode(0640).
 															WithItems(
 																corev1ac.KeyToPath().
 																	WithKey(corev1.SSHAuthPrivateKey).
-																	WithPath(constants.MPISSHPrivateKeyFile),
+																	WithPath(constants.MPISSHPrivateKeyFile).
+																	WithMode(constants.MPISSHSecretPrivateKeyFileMode),
 																corev1ac.KeyToPath().
 																	WithKey(constants.MPISSHPublicKey).
-																	WithPath(constants.MPISSHPublicKeyFile),
+																	WithPath(constants.MPISSHPublicKeyFile).
+																	WithMode(constants.MPISSHSecretSharedSSHFileMode),
 																corev1ac.KeyToPath().
 																	WithKey(constants.MPISSHPublicKey).
-																	WithPath(constants.MPISSHAuthorizedKeys),
+																	WithPath(constants.MPISSHAuthorizedKeys).
+																	WithMode(constants.MPISSHSecretSharedSSHFileMode),
 															),
 														),
 													corev1ac.Volume().
@@ -976,17 +978,19 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 														WithName(constants.MPISSHAuthVolumeName).
 														WithSecret(corev1ac.SecretVolumeSource().
 															WithSecretName(fmt.Sprintf("test-job%s", constants.MPISSHAuthSecretSuffix)).
-															WithDefaultMode(0640).
 															WithItems(
 																corev1ac.KeyToPath().
 																	WithKey(corev1.SSHAuthPrivateKey).
-																	WithPath(constants.MPISSHPrivateKeyFile),
+																	WithPath(constants.MPISSHPrivateKeyFile).
+																	WithMode(constants.MPISSHSecretPrivateKeyFileMode),
 																corev1ac.KeyToPath().
 																	WithKey(constants.MPISSHPublicKey).
-																	WithPath(constants.MPISSHPublicKeyFile),
+																	WithPath(constants.MPISSHPublicKeyFile).
+																	WithMode(constants.MPISSHSecretSharedSSHFileMode),
 																corev1ac.KeyToPath().
 																	WithKey(constants.MPISSHPublicKey).
-																	WithPath(constants.MPISSHAuthorizedKeys),
+																	WithPath(constants.MPISSHAuthorizedKeys).
+																	WithMode(constants.MPISSHSecretSharedSSHFileMode),
 															),
 														),
 												),
@@ -1087,17 +1091,19 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("test-job%s", constants.MPISSHAuthSecretSuffix)).
-										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
-												WithPath(constants.MPISSHPrivateKeyFile),
+												WithPath(constants.MPISSHPrivateKeyFile).
+												WithMode(constants.MPISSHSecretPrivateKeyFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHPublicKeyFile),
+												WithPath(constants.MPISSHPublicKeyFile).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHAuthorizedKeys),
+												WithPath(constants.MPISSHAuthorizedKeys).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 										),
 									),
 								*corev1ac.Volume().
@@ -1145,17 +1151,19 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("test-job%s", constants.MPISSHAuthSecretSuffix)).
-										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
-												WithPath(constants.MPISSHPrivateKeyFile),
+												WithPath(constants.MPISSHPrivateKeyFile).
+												WithMode(constants.MPISSHSecretPrivateKeyFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHPublicKeyFile),
+												WithPath(constants.MPISSHPublicKeyFile).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHAuthorizedKeys),
+												WithPath(constants.MPISSHAuthorizedKeys).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 										),
 									),
 							},
@@ -1215,14 +1223,17 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 										{
 											Key:  corev1.SSHAuthPrivateKey,
 											Path: constants.MPISSHPrivateKeyFile,
+											Mode: ptr.To(constants.MPISSHSecretPrivateKeyFileMode),
 										},
 										{
 											Key:  constants.MPISSHPublicKey,
 											Path: constants.MPISSHPublicKeyFile,
+											Mode: ptr.To(constants.MPISSHSecretSharedSSHFileMode),
 										},
 										{
 											Key:  constants.MPISSHPublicKey,
 											Path: constants.MPISSHAuthorizedKeys,
+											Mode: ptr.To(constants.MPISSHSecretSharedSSHFileMode),
 										},
 									},
 								},
@@ -1256,14 +1267,17 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 										{
 											Key:  corev1.SSHAuthPrivateKey,
 											Path: constants.MPISSHPrivateKeyFile,
+											Mode: ptr.To(constants.MPISSHSecretPrivateKeyFileMode),
 										},
 										{
 											Key:  constants.MPISSHPublicKey,
 											Path: constants.MPISSHPublicKeyFile,
+											Mode: ptr.To(constants.MPISSHSecretSharedSSHFileMode),
 										},
 										{
 											Key:  constants.MPISSHPublicKey,
 											Path: constants.MPISSHAuthorizedKeys,
+											Mode: ptr.To(constants.MPISSHSecretSharedSSHFileMode),
 										},
 									},
 								},

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -901,6 +901,7 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 														WithName(constants.MPISSHAuthVolumeName).
 														WithSecret(corev1ac.SecretVolumeSource().
 															WithSecretName(fmt.Sprintf("test-job%s", constants.MPISSHAuthSecretSuffix)).
+															WithDefaultMode(0640).
 															WithItems(
 																corev1ac.KeyToPath().
 																	WithKey(corev1.SSHAuthPrivateKey).
@@ -975,6 +976,7 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 														WithName(constants.MPISSHAuthVolumeName).
 														WithSecret(corev1ac.SecretVolumeSource().
 															WithSecretName(fmt.Sprintf("test-job%s", constants.MPISSHAuthSecretSuffix)).
+															WithDefaultMode(0640).
 															WithItems(
 																corev1ac.KeyToPath().
 																	WithKey(corev1.SSHAuthPrivateKey).
@@ -1085,6 +1087,7 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("test-job%s", constants.MPISSHAuthSecretSuffix)).
+										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
@@ -1142,6 +1145,7 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("test-job%s", constants.MPISSHAuthSecretSuffix)).
+										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
@@ -2194,7 +2198,10 @@ test-job-node-0-1.test-job slots=1
 		cmpopts.SortSlices(func(a, b apiruntime.Object) bool {
 			return a.GetObjectKind().GroupVersionKind().String() < b.GetObjectKind().GroupVersionKind().String()
 		}),
+		// Compare MPI Secret data contents, but ignore DefaultMode differences on Secret volumes,
+		// which are validated more directly in MPI-specific tests.
 		cmp.Comparer(testingutil.MPISecretDataComparer),
+		cmpopts.IgnoreFields(corev1.SecretVolumeSource{}, "DefaultMode"),
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/runtime/framework/plugins/mpi/mpi.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi.go
@@ -138,17 +138,19 @@ func (m *MPI) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) er
 					WithSecret(
 						corev1ac.SecretVolumeSource().
 							WithSecretName(fmt.Sprintf("%s%s", trainJob.Name, constants.MPISSHAuthSecretSuffix)).
-							WithDefaultMode(0640).
 							WithItems(
 								corev1ac.KeyToPath().
 									WithKey(corev1.SSHAuthPrivateKey).
-									WithPath(constants.MPISSHPrivateKeyFile),
+									WithPath(constants.MPISSHPrivateKeyFile).
+									WithMode(constants.MPISSHSecretPrivateKeyFileMode),
 								corev1ac.KeyToPath().
 									WithKey(constants.MPISSHPublicKey).
-									WithPath(constants.MPISSHPublicKeyFile),
+									WithPath(constants.MPISSHPublicKeyFile).
+									WithMode(constants.MPISSHSecretSharedSSHFileMode),
 								corev1ac.KeyToPath().
 									WithKey(constants.MPISSHPublicKey).
-									WithPath(constants.MPISSHAuthorizedKeys),
+									WithPath(constants.MPISSHAuthorizedKeys).
+									WithMode(constants.MPISSHSecretSharedSSHFileMode),
 							),
 					),
 			}...,

--- a/pkg/runtime/framework/plugins/mpi/mpi.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi.go
@@ -135,19 +135,21 @@ func (m *MPI) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) er
 			[]corev1ac.VolumeApplyConfiguration{
 				*corev1ac.Volume().
 					WithName(constants.MPISSHAuthVolumeName).
-					WithSecret(corev1ac.SecretVolumeSource().
-						WithSecretName(fmt.Sprintf("%s%s", trainJob.Name, constants.MPISSHAuthSecretSuffix)).
-						WithItems(
-							corev1ac.KeyToPath().
-								WithKey(corev1.SSHAuthPrivateKey).
-								WithPath(constants.MPISSHPrivateKeyFile),
-							corev1ac.KeyToPath().
-								WithKey(constants.MPISSHPublicKey).
-								WithPath(constants.MPISSHPublicKeyFile),
-							corev1ac.KeyToPath().
-								WithKey(constants.MPISSHPublicKey).
-								WithPath(constants.MPISSHAuthorizedKeys),
-						),
+					WithSecret(
+						corev1ac.SecretVolumeSource().
+							WithSecretName(fmt.Sprintf("%s%s", trainJob.Name, constants.MPISSHAuthSecretSuffix)).
+							WithDefaultMode(0640).
+							WithItems(
+								corev1ac.KeyToPath().
+									WithKey(corev1.SSHAuthPrivateKey).
+									WithPath(constants.MPISSHPrivateKeyFile),
+								corev1ac.KeyToPath().
+									WithKey(constants.MPISSHPublicKey).
+									WithPath(constants.MPISSHPublicKeyFile),
+								corev1ac.KeyToPath().
+									WithKey(constants.MPISSHPublicKey).
+									WithPath(constants.MPISSHAuthorizedKeys),
+							),
 					),
 			}...,
 		)

--- a/pkg/runtime/framework/plugins/mpi/mpi_test.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi_test.go
@@ -137,6 +137,7 @@ func TestMPI(t *testing.T) {
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
+										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
@@ -174,6 +175,7 @@ func TestMPI(t *testing.T) {
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
+										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
@@ -274,6 +276,7 @@ trainJob-node-1-1.trainJob slots=1
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
+										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
@@ -311,6 +314,7 @@ trainJob-node-1-1.trainJob slots=1
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
+										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
@@ -411,6 +415,7 @@ trainJob-node-1-1.trainJob slots=1
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
+										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
@@ -448,6 +453,7 @@ trainJob-node-1-1.trainJob slots=1
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
+										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
@@ -579,6 +585,7 @@ trainJob-node-1-1.trainJob slots=1
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
+										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
@@ -624,6 +631,7 @@ trainJob-node-1-1.trainJob slots=1
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
+										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
@@ -707,6 +715,7 @@ trainJob-node-1-0.trainJob slots=1
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
+										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
@@ -790,6 +799,7 @@ trainJob-node-1-0.trainJob slots=1
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
+										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).

--- a/pkg/runtime/framework/plugins/mpi/mpi_test.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi_test.go
@@ -137,17 +137,19 @@ func TestMPI(t *testing.T) {
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
-										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
-												WithPath(constants.MPISSHPrivateKeyFile),
+												WithPath(constants.MPISSHPrivateKeyFile).
+												WithMode(constants.MPISSHSecretPrivateKeyFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHPublicKeyFile),
+												WithPath(constants.MPISSHPublicKeyFile).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHAuthorizedKeys),
+												WithPath(constants.MPISSHAuthorizedKeys).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 										),
 									),
 								*corev1ac.Volume().
@@ -175,17 +177,19 @@ func TestMPI(t *testing.T) {
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
-										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
-												WithPath(constants.MPISSHPrivateKeyFile),
+												WithPath(constants.MPISSHPrivateKeyFile).
+												WithMode(constants.MPISSHSecretPrivateKeyFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHPublicKeyFile),
+												WithPath(constants.MPISSHPublicKeyFile).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHAuthorizedKeys),
+												WithPath(constants.MPISSHAuthorizedKeys).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 										),
 									),
 							},
@@ -276,17 +280,19 @@ trainJob-node-1-1.trainJob slots=1
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
-										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
-												WithPath(constants.MPISSHPrivateKeyFile),
+												WithPath(constants.MPISSHPrivateKeyFile).
+												WithMode(constants.MPISSHSecretPrivateKeyFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHPublicKeyFile),
+												WithPath(constants.MPISSHPublicKeyFile).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHAuthorizedKeys),
+												WithPath(constants.MPISSHAuthorizedKeys).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 										),
 									),
 								*corev1ac.Volume().
@@ -314,17 +320,19 @@ trainJob-node-1-1.trainJob slots=1
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
-										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
-												WithPath(constants.MPISSHPrivateKeyFile),
+												WithPath(constants.MPISSHPrivateKeyFile).
+												WithMode(constants.MPISSHSecretPrivateKeyFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHPublicKeyFile),
+												WithPath(constants.MPISSHPublicKeyFile).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHAuthorizedKeys),
+												WithPath(constants.MPISSHAuthorizedKeys).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 										),
 									),
 							},
@@ -415,17 +423,19 @@ trainJob-node-1-1.trainJob slots=1
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
-										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
-												WithPath(constants.MPISSHPrivateKeyFile),
+												WithPath(constants.MPISSHPrivateKeyFile).
+												WithMode(constants.MPISSHSecretPrivateKeyFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHPublicKeyFile),
+												WithPath(constants.MPISSHPublicKeyFile).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHAuthorizedKeys),
+												WithPath(constants.MPISSHAuthorizedKeys).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 										),
 									),
 								*corev1ac.Volume().
@@ -453,17 +463,19 @@ trainJob-node-1-1.trainJob slots=1
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
-										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
-												WithPath(constants.MPISSHPrivateKeyFile),
+												WithPath(constants.MPISSHPrivateKeyFile).
+												WithMode(constants.MPISSHSecretPrivateKeyFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHPublicKeyFile),
+												WithPath(constants.MPISSHPublicKeyFile).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHAuthorizedKeys),
+												WithPath(constants.MPISSHAuthorizedKeys).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 										),
 									),
 							},
@@ -585,17 +597,19 @@ trainJob-node-1-1.trainJob slots=1
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
-										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
-												WithPath(constants.MPISSHPrivateKeyFile),
+												WithPath(constants.MPISSHPrivateKeyFile).
+												WithMode(constants.MPISSHSecretPrivateKeyFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHPublicKeyFile),
+												WithPath(constants.MPISSHPublicKeyFile).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHAuthorizedKeys),
+												WithPath(constants.MPISSHAuthorizedKeys).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 										),
 									),
 								*corev1ac.Volume().
@@ -631,17 +645,19 @@ trainJob-node-1-1.trainJob slots=1
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
-										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
-												WithPath(constants.MPISSHPrivateKeyFile),
+												WithPath(constants.MPISSHPrivateKeyFile).
+												WithMode(constants.MPISSHSecretPrivateKeyFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHPublicKeyFile),
+												WithPath(constants.MPISSHPublicKeyFile).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHAuthorizedKeys),
+												WithPath(constants.MPISSHAuthorizedKeys).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 										),
 									),
 							},
@@ -715,17 +731,19 @@ trainJob-node-1-0.trainJob slots=1
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
-										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
-												WithPath(constants.MPISSHPrivateKeyFile),
+												WithPath(constants.MPISSHPrivateKeyFile).
+												WithMode(constants.MPISSHSecretPrivateKeyFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHPublicKeyFile),
+												WithPath(constants.MPISSHPublicKeyFile).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHAuthorizedKeys),
+												WithPath(constants.MPISSHAuthorizedKeys).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 										),
 									),
 								*corev1ac.Volume().
@@ -799,17 +817,19 @@ trainJob-node-1-0.trainJob slots=1
 									WithName(constants.MPISSHAuthVolumeName).
 									WithSecret(corev1ac.SecretVolumeSource().
 										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
-										WithDefaultMode(0640).
 										WithItems(
 											corev1ac.KeyToPath().
 												WithKey(corev1.SSHAuthPrivateKey).
-												WithPath(constants.MPISSHPrivateKeyFile),
+												WithPath(constants.MPISSHPrivateKeyFile).
+												WithMode(constants.MPISSHSecretPrivateKeyFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHPublicKeyFile),
+												WithPath(constants.MPISSHPublicKeyFile).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 											corev1ac.KeyToPath().
 												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHAuthorizedKeys),
+												WithPath(constants.MPISSHAuthorizedKeys).
+												WithMode(constants.MPISSHSecretSharedSSHFileMode),
 										),
 									),
 								*corev1ac.Volume().

--- a/test/integration/controller/trainjob_controller_test.go
+++ b/test/integration/controller/trainjob_controller_test.go
@@ -1026,7 +1026,8 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 									Name: constants.MPISSHAuthVolumeName,
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: fmt.Sprintf("%s%s", trainJobKey.Name, constants.MPISSHAuthSecretSuffix),
+											SecretName:  fmt.Sprintf("%s%s", trainJobKey.Name, constants.MPISSHAuthSecretSuffix),
+											DefaultMode: ptr.To[int32](0640),
 											Items: []corev1.KeyToPath{
 												{
 													Key:  corev1.SSHAuthPrivateKey,
@@ -1065,7 +1066,8 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 									Name: constants.MPISSHAuthVolumeName,
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: fmt.Sprintf("%s%s", trainJobKey.Name, constants.MPISSHAuthSecretSuffix),
+											SecretName:  fmt.Sprintf("%s%s", trainJobKey.Name, constants.MPISSHAuthSecretSuffix),
+											DefaultMode: ptr.To[int32](0640),
 											Items: []corev1.KeyToPath{
 												{
 													Key:  corev1.SSHAuthPrivateKey,

--- a/test/integration/controller/trainjob_controller_test.go
+++ b/test/integration/controller/trainjob_controller_test.go
@@ -1026,20 +1026,22 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 									Name: constants.MPISSHAuthVolumeName,
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName:  fmt.Sprintf("%s%s", trainJobKey.Name, constants.MPISSHAuthSecretSuffix),
-											DefaultMode: ptr.To[int32](0640),
+											SecretName: fmt.Sprintf("%s%s", trainJobKey.Name, constants.MPISSHAuthSecretSuffix),
 											Items: []corev1.KeyToPath{
 												{
 													Key:  corev1.SSHAuthPrivateKey,
 													Path: constants.MPISSHPrivateKeyFile,
+													Mode: ptr.To(constants.MPISSHSecretPrivateKeyFileMode),
 												},
 												{
 													Key:  constants.MPISSHPublicKey,
 													Path: constants.MPISSHPublicKeyFile,
+													Mode: ptr.To(constants.MPISSHSecretSharedSSHFileMode),
 												},
 												{
 													Key:  constants.MPISSHPublicKey,
 													Path: constants.MPISSHAuthorizedKeys,
+													Mode: ptr.To(constants.MPISSHSecretSharedSSHFileMode),
 												},
 											},
 										},
@@ -1066,20 +1068,22 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 									Name: constants.MPISSHAuthVolumeName,
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName:  fmt.Sprintf("%s%s", trainJobKey.Name, constants.MPISSHAuthSecretSuffix),
-											DefaultMode: ptr.To[int32](0640),
+											SecretName: fmt.Sprintf("%s%s", trainJobKey.Name, constants.MPISSHAuthSecretSuffix),
 											Items: []corev1.KeyToPath{
 												{
 													Key:  corev1.SSHAuthPrivateKey,
 													Path: constants.MPISSHPrivateKeyFile,
+													Mode: ptr.To(constants.MPISSHSecretPrivateKeyFileMode),
 												},
 												{
 													Key:  constants.MPISSHPublicKey,
 													Path: constants.MPISSHPublicKeyFile,
+													Mode: ptr.To(constants.MPISSHSecretSharedSSHFileMode),
 												},
 												{
 													Key:  constants.MPISSHPublicKey,
 													Path: constants.MPISSHAuthorizedKeys,
+													Mode: ptr.To(constants.MPISSHSecretSharedSSHFileMode),
 												},
 											},
 										},


### PR DESCRIPTION

**What this PR does?**:
- Set DefaultMode to 0640 on the MPI SSH auth Secret volume in the MPI plugin so mounted secret files (private key, authorized_keys) have restricted permissions.
- Update unit, framework, and integration test expectations to include DefaultMode: 0640 for MPI SSH auth volumes.
- In the framework component-builder test, add cmpopts.IgnoreFields(corev1.SecretVolumeSource{}, "DefaultMode") so the generic comparison focuses on Secret data; DefaultMode is asserted in MPI-specific tests.


**Why we need it?**

Explicit default mode improves security for MPI SSH keys (owner read/write, group read, others none) and avoids relying on cluster default behavior.

**Which issue this PR fixes** 

Fixes [3262](https://github.com/kubeflow/trainer/issues/3262)

**Checklist:**

- [x] Unit tests passed
- [x] Integration tests passed
- [x] E2E tests passed
- [x] Linter & fmt ran
