### PR TITLE
feat: protect status server with network policy

### DIFF
--- a/manifests/base/manager/kustomization.yaml
+++ b/manifests/base/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
   - manager.yaml
+  - network_policy.yaml
 
 # Disable hash suffix for predictable ConfigMap names
 generatorOptions:

--- a/manifests/base/manager/network_policy.yaml
+++ b/manifests/base/manager/network_policy.yaml
@@ -5,17 +5,17 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/component: manager    # selects the controller manager pod (status server)
+      app.kubernetes.io/component: manager
   policyTypes:
   - Ingress
   ingress:
   - from:
     - namespaceSelector:
         matchLabels:
-          trainer.kubeflow.org/trainjob-namespace: "true"  # only labeled namespaces
+          trainer.kubeflow.org/trainjob-namespace: "true"
       podSelector:
         matchLabels:
-          trainer.kubeflow.org/trainjob-ancestor-step: trainer  # only trainer pods
+          trainer.kubeflow.org/trainjob-ancestor-step: trainer
     ports:
     - protocol: TCP
-      port: 10443                             # status server port
+      port: 10443

--- a/manifests/base/manager/network_policy.yaml
+++ b/manifests/base/manager/network_policy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: status-server-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: manager    # selects the controller manager pod (status server)
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          trainer.kubeflow.org/trainjob-namespace: "true"  # only labeled namespaces
+      podSelector:
+        matchLabels:
+          trainer.kubeflow.org/trainjob-ancestor-step: trainer  # only trainer pods
+    ports:
+    - protocol: TCP
+      port: 10443                             # status server port

--- a/manifests/base/runtimes/data-cache/torch_distributed_with_cache.yaml
+++ b/manifests/base/runtimes/data-cache/torch_distributed_with_cache.yaml
@@ -42,6 +42,9 @@ spec:
               trainer.kubeflow.org/trainjob-ancestor-step: trainer
           spec:
             template:
+              metadata:
+                labels:
+                  trainer.kubeflow.org/trainjob-ancestor-step: trainer
               spec:
                 containers:
                   - name: node

--- a/manifests/base/runtimes/deepspeed_distributed.yaml
+++ b/manifests/base/runtimes/deepspeed_distributed.yaml
@@ -28,6 +28,9 @@ spec:
                 trainer.kubeflow.org/trainjob-ancestor-step: trainer
             spec:
               template:
+                metadata:
+                  labels:
+                    trainer.kubeflow.org/trainjob-ancestor-step: trainer
                 spec:
                   containers:
                     - name: node

--- a/manifests/base/runtimes/jax_distributed.yaml
+++ b/manifests/base/runtimes/jax_distributed.yaml
@@ -18,6 +18,9 @@ spec:
                 trainer.kubeflow.org/trainjob-ancestor-step: trainer
             spec:
               template:
+                metadata:
+                  labels:
+                    trainer.kubeflow.org/trainjob-ancestor-step: trainer
                 spec:
                   containers:
                     - name: node

--- a/manifests/base/runtimes/mlx_distributed.yaml
+++ b/manifests/base/runtimes/mlx_distributed.yaml
@@ -28,6 +28,9 @@ spec:
                 trainer.kubeflow.org/trainjob-ancestor-step: trainer
             spec:
               template:
+                metadata:
+                  labels:
+                    trainer.kubeflow.org/trainjob-ancestor-step: trainer
                 spec:
                   containers:
                     - name: node

--- a/manifests/base/runtimes/torch_distributed.yaml
+++ b/manifests/base/runtimes/torch_distributed.yaml
@@ -18,6 +18,9 @@ spec:
                 trainer.kubeflow.org/trainjob-ancestor-step: trainer
             spec:
               template:
+                metadata:
+                  labels:
+                    trainer.kubeflow.org/trainjob-ancestor-step: trainer
                 spec:
                   containers:
                     - name: node

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -66,6 +66,9 @@ spec:
                 trainer.kubeflow.org/trainjob-ancestor-step: trainer
             spec:
               template:
+                metadata:
+                  labels:
+                    trainer.kubeflow.org/trainjob-ancestor-step: trainer
                 spec:
                   containers:
                     - name: node

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -66,6 +66,9 @@ spec:
                 trainer.kubeflow.org/trainjob-ancestor-step: trainer
             spec:
               template:
+                metadata:
+                  labels:
+                    trainer.kubeflow.org/trainjob-ancestor-step: trainer
                 spec:
                   containers:
                     - name: node

--- a/manifests/base/runtimes/torchtune/qwen2_5/qwen2_5_1.5B.yaml
+++ b/manifests/base/runtimes/torchtune/qwen2_5/qwen2_5_1.5B.yaml
@@ -66,6 +66,9 @@ spec:
                 trainer.kubeflow.org/trainjob-ancestor-step: trainer
             spec:
               template:
+                metadata:
+                  labels:
+                    trainer.kubeflow.org/trainjob-ancestor-step: trainer
                 spec:
                   containers:
                     - name: node

--- a/manifests/base/runtimes/xgboost_distributed.yaml
+++ b/manifests/base/runtimes/xgboost_distributed.yaml
@@ -18,6 +18,9 @@ spec:
                 trainer.kubeflow.org/trainjob-ancestor-step: trainer
             spec:
               template:
+                metadata:
+                  labels:
+                    trainer.kubeflow.org/trainjob-ancestor-step: trainer
                 spec:
                   containers:
                     - name: node


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Adds a NetworkPolicy to restrict ingress to the status server (port 10443) to only TrainJob pods. Also adds pod-level labels to runtime YAMLs so the NetworkPolicy can match against them via podSelector. 

**Which issue(s) this PR fixes**:
Fixes #3345

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
