### PR TITLE
fix(statusserver): improve bearer token parsing and add helper tests

### DIFF
--- a/pkg/statusserver/auth.go
+++ b/pkg/statusserver/auth.go
@@ -114,9 +114,9 @@ func (p *projectedServiceAccountTokenAuthorizer) Authorize(ctx context.Context, 
 }
 
 func extractRawToken(authHeader string) string {
-	parts := strings.Split(authHeader, " ")
+	parts := strings.Fields(authHeader)
 
-	if len(parts) != 2 || parts[0] != "Bearer" {
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
 		return ""
 	}
 

--- a/pkg/statusserver/auth_test.go
+++ b/pkg/statusserver/auth_test.go
@@ -1,0 +1,61 @@
+package statusserver
+
+import "testing"
+
+func TestExtractRawToken(t *testing.T) {
+	tests := []struct {
+		name       string
+		authHeader string
+		expected   string
+	}{
+		{
+			name:       "valid bearer token",
+			authHeader: "Bearer abc123",
+			expected:   "abc123",
+		},
+		{
+			name:       "empty header",
+			authHeader: "",
+			expected:   "",
+		},
+		{
+			name:       "missing token",
+			authHeader: "Bearer",
+			expected:   "",
+		},
+		{
+			name:       "wrong auth scheme",
+			authHeader: "Basic abc123",
+			expected:   "",
+		},
+		{
+			name:       "too many parts",
+			authHeader: "Bearer abc def",
+			expected:   "",
+		},
+		{
+			name:       "multiple spaces",
+			authHeader: "Bearer    abc123",
+			expected:   "abc123",
+		},
+		{
+			name:       "lowercase bearer",
+			authHeader: "bearer abc123",
+			expected:   "abc123",
+		},
+		{
+			name:       "leading and trailing spaces",
+			authHeader: "   Bearer abc123   ",
+			expected:   "abc123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractRawToken(tt.authHeader)
+			if got != tt.expected {
+				t.Fatalf("extractRawToken(%q) = %q, want %q", tt.authHeader, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/statusserver/utils_test.go
+++ b/pkg/statusserver/utils_test.go
@@ -1,0 +1,65 @@
+package statusserver
+
+import "testing"
+
+func TestTokenAudience(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		trainJob  string
+		expected  string
+	}{
+		{
+			name:      "default namespace",
+			namespace: "default",
+			trainJob:  "mnist",
+			expected:  "trainer.kubeflow.org/v1alpha1/namespaces/default/trainjobs/mnist/status",
+		},
+		{
+			name:      "kubeflow namespace",
+			namespace: "kubeflow",
+			trainJob:  "llm-job",
+			expected:  "trainer.kubeflow.org/v1alpha1/namespaces/kubeflow/trainjobs/llm-job/status",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TokenAudience(tt.namespace, tt.trainJob)
+			if got != tt.expected {
+				t.Fatalf("TokenAudience(%q, %q) = %q, want %q", tt.namespace, tt.trainJob, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStatusUrl(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		trainJob  string
+		expected  string
+	}{
+		{
+			name:      "default namespace",
+			namespace: "default",
+			trainJob:  "mnist",
+			expected:  "/apis/trainer.kubeflow.org/v1alpha1/namespaces/default/trainjobs/mnist/status",
+		},
+		{
+			name:      "kubeflow namespace",
+			namespace: "kubeflow",
+			trainJob:  "llm-job",
+			expected:  "/apis/trainer.kubeflow.org/v1alpha1/namespaces/kubeflow/trainjobs/llm-job/status",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StatusUrl(tt.namespace, tt.trainJob)
+			if got != tt.expected {
+				t.Fatalf("StatusUrl(%q, %q) = %q, want %q", tt.namespace, tt.trainJob, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds focused unit tests for helper functions in `pkg/statusserver`:

- `extractRawToken`
- `TokenAudience`
- `StatusUrl`

It also makes bearer token parsing in `extractRawToken` more robust by:
- handling repeated whitespace with `strings.Fields`
- accepting case-insensitive `Bearer` with `strings.EqualFold`

## Why

These helpers are small but important for status server auth and path generation. Adding direct unit test coverage makes the behavior clearer and improves reliability for future changes.

## Changes

- add table-driven tests for `extractRawToken`
- add table-driven tests for `TokenAudience`
- add table-driven tests for `StatusUrl`
- update `extractRawToken` to handle extra whitespace and lowercase `bearer`

Fixes #3404 