### PR TITLE
fix(examples): unblock Megatron TP notebook on GPU E2E

### DIFF
--- a/examples/megatron/tensor-parallelism/megatron-core-gpt-tp.ipynb
+++ b/examples/megatron/tensor-parallelism/megatron-core-gpt-tp.ipynb
@@ -397,7 +397,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "client.wait_for_job_status(name=job_name, timeout=120)"
+    "client.wait_for_job_status(name=job_name, timeout=600)"
    ]
   },
   {

--- a/examples/megatron/tensor-parallelism/megatron-core-gpt-tp.ipynb
+++ b/examples/megatron/tensor-parallelism/megatron-core-gpt-tp.ipynb
@@ -180,7 +180,7 @@
     "        reset_attention_mask=False,\n",
     "        eod_mask_loss=False,\n",
     "        tokenizer=MegatronTokenizer.from_pretrained(\n",
-    "            metadata_path={\"library\": \"null\"},\n",
+    "            metadata_path={\"library\": \"null-text\"},\n",
     "            vocab_size=_SEQUENCE_LENGTH,\n",
     "        ),\n",
     "        mid_level_dataset_surplus=0.005,\n",


### PR DESCRIPTION
**What this PR does / why we need it**:

Two small fixes so `examples/megatron/tensor-parallelism/megatron-core-gpt-tp.ipynb` stops failing GPU E2E.

### 1. Update tokenizer library name for `megatron-core` 0.17.0

`megatron-core` 0.17.0 (published 2026-04-16 20:22 UTC) tightened the accepted set of tokenizer library names in `MegatronTokenizer.from_pretrained`. The bare `"null"` key was replaced by `"null-text"` / `"null-multimodal"`:

```diff
- if library not in ['byte-level', 'null']: assert tokenizer_path
+ if library not in ['byte-level', 'null-text', 'null-multimodal']: assert tokenizer_path
```

The notebook's `metadata_path={"library": "null"}` therefore trips `AssertionError: Tokenizer path must be specified.` now that the CI pod installs 0.17.0. Renaming to `"null-text"` routes through the same `NullTokenizer(vocab_size)` library class the old `"null"` key used, so runtime behavior is unchanged on 0.17.0.

### 2. Bump the `Complete`-wait timeout from 120s to 600s

The notebook's `client.wait_for_job_status(name=job_name, timeout=120)` left only ~24s of headroom (happy-path was ~96s end-to-end on the last passing 2026-04-15 run). More importantly, 120s was short enough that the call was firing `TimeoutError` before the TrainJob reached a terminal state, which masked the real tokenizer error above. With 600s, a failing TrainJob now surfaces the actual Python traceback in the uploaded notebook artifact. Papermill's outer `--execution-timeout=1800s` still bounds the notebook overall, so a genuinely stuck job will still fail the job.

### Timeline for the regression

- 2026-04-10: PR #3201 adds the notebook. `megatron-core==0.16.1` current on PyPI, `"library": "null"` is valid.
- 2026-04-15 10:47 UTC: Last passing GPU E2E run. Megatron TrainJob `Complete` in ~96s. Still on 0.16.1.
- 2026-04-16 ~16:00 UTC: GPU E2E starts failing with `TimeoutError` at the 120s mark (symptom only; real cause hidden).
- 2026-04-16 20:22 UTC: `megatron-core==0.17.0` published, renames `null` → `null-text`.
- 2026-04-17 onward: Once 0.17.0 is what pip resolves, the training pod hits the tokenizer assertion. The 120s wait still hid it.

Reference runs:
- Last pass (0.16.1): https://github.com/kubeflow/trainer/actions/runs/24450293584
- Pre-0.17.0 fail (timeout): https://github.com/kubeflow/trainer/actions/runs/24522349899/job/71808592032
- Post-0.17.0 fail (tokenizer, with 600s): https://github.com/kubeflow/trainer/actions/runs/24562565036/job/71814574768

**Which issue(s) this PR fixes**:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing