### PR TITLE
fix(operator): apply Configuration.ClientConnection QPS/Burst to the manager rest.Config

### DIFF
--- a/cmd/trainer-controller-manager/main.go
+++ b/cmd/trainer-controller-manager/main.go
@@ -119,7 +119,22 @@ func main() {
 	}
 
 	setupLog.Info("Creating manager")
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
+	restCfg := ctrl.GetConfigOrDie()
+	// Apply the Configuration.ClientConnection QPS/Burst to the
+	// manager's rest.Config. Without this, the documented defaults
+	// (QPS=50, Burst=100) from the Configuration API were validated
+	// and defaulted but never wired through, so the manager ran with
+	// the client-go defaults (QPS=5, Burst=10). The status server's
+	// createClient already uses this pattern (#3431).
+	if cfg.ClientConnection != nil {
+		if cfg.ClientConnection.QPS != nil {
+			restCfg.QPS = *cfg.ClientConnection.QPS
+		}
+		if cfg.ClientConnection.Burst != nil {
+			restCfg.Burst = int(*cfg.ClientConnection.Burst)
+		}
+	}
+	mgr, err := ctrl.NewManager(restCfg, options)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)


### PR DESCRIPTION
## Summary

Fixes #3431.

`cfg.ClientConnection` is validated and defaulted by the Configuration API (`QPS=50`, `Burst=100`) but never wired into the manager's `rest.Config`, so the manager ran with the client-go defaults (`QPS=5`, `Burst=10`). Operators tuning `clientConnection` saw the values take effect in the status server (`pkg/statusserver/setup.go`'s `createClient` already does the `rest.CopyConfig` + override dance) but silently ignored for the main reconciler.

## Fix

Mirror the status-server pattern in `cmd/trainer-controller-manager/main.go`: copy from `ctrl.GetConfigOrDie()`, overlay `cfg.ClientConnection.{QPS,Burst}` when non-nil, and hand that config to `ctrl.NewManager`. No behaviour change when `ClientConnection` is unset; new defaults now flow through when it is.

## Test plan

- [x] `go build ./cmd/trainer-controller-manager/...` clean
- [x] `go vet ./cmd/trainer-controller-manager/...` clean
- [ ] Manual: set `clientConnection.qps = 25`, `clientConnection.burst = 50` in the Configuration CR, check the manager's actual rest client rate limits with `--v=6` logging or the `workqueue_*_requests_total` metrics — should scale with the new values instead of topping out at QPS=5/Burst=10.
