### PR TITLE
chore(deps): Bumo Go to 1.26

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ For the Kubeflow Trainer documentation, please check [the official Kubeflow docu
 
 ## Requirements
 
-- [Go](https://golang.org/) (1.25 or later)
+- [Go](https://golang.org/) (1.26 or later)
 - [Docker](https://docs.docker.com/) (23 or later)
 - [Lima](https://github.com/lima-vm/lima?tab=readme-ov-file#adopters) (an alternative to DockerDesktop) (0.21.0 or later)
   - [Colima](https://github.com/abiosoft/colima) (Lima specifically for MacOS) (0.6.8 or later)

--- a/cmd/trainer-controller-manager/Dockerfile
+++ b/cmd/trainer-controller-manager/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/trainer/v2
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/coreos/go-oidc/v3 v3.18.0


### PR DESCRIPTION
Updated Go to 1.26 to update Kubernetes version.

/assign @kubeflow/kubeflow-trainer-team @akshaychitneni @robert-bell @jaiakash 