### PR TITLE
fix(manifests): Use released version for JobSet and LWS images

### DIFF
--- a/manifests/third-party/jobset/kustomization.yaml
+++ b/manifests/third-party/jobset/kustomization.yaml
@@ -4,6 +4,11 @@ kind: Kustomization
 resources:
   - https://github.com/kubernetes-sigs/jobset/releases/download/v0.11.0/manifests.yaml
 
+images:
+  - name: us-central1-docker.pkg.dev/k8s-staging-images/jobset/jobset
+    newName: registry.k8s.io/jobset/jobset
+    newTag: v0.11.0
+
 # Add required patches.
 patches:
   # Remove namespace from the JobSet release manifests.

--- a/manifests/third-party/leaderworkerset/kustomization.yaml
+++ b/manifests/third-party/leaderworkerset/kustomization.yaml
@@ -7,6 +7,11 @@ resources:
 # Transform all namespace references from lws-system to be set by parent overlay
 namespace: kubeflow-system
 
+images:
+  - name: us-central1-docker.pkg.dev/k8s-staging-images/lws/lws
+    newName: registry.k8s.io/lws/lws
+    newTag: v0.8.0
+
 # Add required patches.
 patches:
   # Remove namespace from the LeaderWorkerSet release manifests.


### PR DESCRIPTION
It looks like JobSet and LWS kustomize manifests use staging images in their releases:
Ref: https://github.com/kubernetes-sigs/jobset/releases/tag/v0.11.1

We should use the officially released image, like we do in Helm charts.


cc @kubeflow/kubeflow-trainer-team @akshaychitneni @robert-bell @kannon92 