### PR TITLE
chore: update golangci-linter and kube-api-linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ helm: ## Download helm locally if required.
 
 .PHONY: golangci-lint-install
 golangci-lint-install: ## Download golangci-lint locally if required.
-	@GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.1
+	@GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1
 
 .PHONY: golangci-lint-kal
 golangci-lint-kal: ## Build golangci-lint-kal from custom configuration.

--- a/hack/.custom-gcl.yaml
+++ b/hack/.custom-gcl.yaml
@@ -1,6 +1,6 @@
-version: v2.4.0
+version: v2.12.1
 name: golangci-lint-kube-api-linter
 destination: ./bin
 plugins:
   - module: 'sigs.k8s.io/kube-api-linter'
-    version: v0.0.0-20250908163129-65a570bd22aa
+    version: v0.0.0-20260423112246-3fa174937a6b

--- a/pkg/runtime/framework/plugins/mpi/mpi.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi.go
@@ -305,7 +305,7 @@ func (m *MPI) buildHostFileConfigMap(info *runtime.Info, trainJob *trainer.Train
 		switch *info.RuntimePolicy.MLPolicySource.MPI.MPIImplementation {
 		case trainer.MPIImplementationOpenMPI:
 			for e := range ps.Endpoints {
-				hostFile.WriteString(fmt.Sprintf("%s slots=%d\n", e, slots))
+				fmt.Fprintf(&hostFile, "%s slots=%d\n", e, slots)
 			}
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Update golang-ci-linter and kube-api-linter.

Found that there were some linter changes when we update in a separate PR.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
