### PR TITLE
feat(runtimes): add validation for reserved MPI environment variables

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -293,6 +293,9 @@ var (
 	// XGBoostReservedEnvNames is XGBoost reserved env names that should not be set by users.
 	XGBoostReservedEnvNames = sets.New(XGBoostEnvTrackerURI, XGBoostEnvTrackerPort, XGBoostEnvTaskID, XGBoostEnvNumWorker)
 
+	// MPIReservedEnvNames is MPI reserved env names that users must not set manually.
+	MPIReservedEnvNames = sets.New(OpenMPIEnvHostFileLocation, OpenMPIEnvKeyRSHArgs, OpenMPIEnvKeepFQDNHostNames, OpenMPIEnvDefaultSlots)
+
 	// ResourceInUseFinalizer is a finalizer for managed resources which is used by other resources.
 	ResourceInUseFinalizer = fmt.Sprintf("%s/resource-in-use", trainer.GroupVersion.Group)
 

--- a/pkg/runtime/framework/plugins/mpi/mpi.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
@@ -76,7 +77,6 @@ func (m *MPI) Name() string {
 	return Name
 }
 
-// TODO (andreyvelich): Add validation to check that TrainJob doesn't have MPI envs.
 // TODO (andreyvelich): We should validate that envs from different plugins don't conflict with each other.
 // Ref: https://github.com/kubeflow/trainer/pull/2308#discussion_r1823229940
 func (m *MPI) Validate(_ context.Context, runtimeInfo *runtime.Info, _, newJobObj *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
@@ -90,6 +90,19 @@ func (m *MPI) Validate(_ context.Context, runtimeInfo *runtime.Info, _, newJobOb
 		if runtimeInfo.FindPodSetByName(constants.Launcher) == nil || runtimeInfo.FindPodSetByName(constants.Node) == nil {
 			numNodesPath := specPath.Child("trainer", "numNodes")
 			allErrs = append(allErrs, field.Invalid(numNodesPath, newJobObj.Spec.Trainer.NumNodes, "must have 1 when MPI trainingRuntime with enabled runLauncherAsNode does not have either launcher and node"))
+		}
+	}
+	// Check reserved MPI envs.
+	if trainJobTrainer := newJobObj.Spec.Trainer; trainJobTrainer != nil {
+		mpiEnvs := sets.New[string]()
+		for _, env := range trainJobTrainer.Env {
+			if constants.MPIReservedEnvNames.Has(env.Name) {
+				mpiEnvs.Insert(env.Name)
+			}
+		}
+		if mpiEnvs.Len() > 0 {
+			trainerEnvsPath := specPath.Child("trainer").Child("env")
+			allErrs = append(allErrs, field.Invalid(trainerEnvsPath, trainJobTrainer.Env, fmt.Sprintf("must not have reserved envs, invalid envs configured: %v", sets.List(mpiEnvs))))
 		}
 	}
 	return nil, allErrs

--- a/pkg/runtime/framework/plugins/mpi/mpi_test.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi_test.go
@@ -987,6 +987,77 @@ func TestValidate(t *testing.T) {
 				field.Invalid(field.NewPath("spec").Child("trainer", "numNodes"), ptr.To(int32(2)), "must have 1 when MPI trainingRuntime with enabled runLauncherAsNode does not have either launcher and node"),
 			},
 		},
+		"trainer has reserved MPI env OMPI_MCA_orte_default_hostfile": {
+			info: runtime.NewInfo(
+				runtime.WithMLPolicySource(utiltesting.MakeMLPolicyWrapper().
+					WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+						MPIPolicy(ptr.To[int32](1), trainer.MPIImplementationOpenMPI, nil, nil).
+						Obj(),
+					).
+					Obj(),
+				),
+			),
+			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				Trainer(utiltesting.MakeTrainJobTrainerWrapper().
+					Env(corev1.EnvVar{Name: constants.OpenMPIEnvHostFileLocation, Value: "/custom/hostfile"}).
+					Obj(),
+				).
+				Obj(),
+			wantError: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec").Child("trainer").Child("env"),
+					[]corev1.EnvVar{{Name: constants.OpenMPIEnvHostFileLocation, Value: "/custom/hostfile"}},
+					fmt.Sprintf("must not have reserved envs, invalid envs configured: %v", []string{constants.OpenMPIEnvHostFileLocation}),
+				),
+			},
+		},
+		"trainer has multiple reserved MPI envs": {
+			info: runtime.NewInfo(
+				runtime.WithMLPolicySource(utiltesting.MakeMLPolicyWrapper().
+					WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+						MPIPolicy(ptr.To[int32](1), trainer.MPIImplementationOpenMPI, nil, nil).
+						Obj(),
+					).
+					Obj(),
+				),
+			),
+			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				Trainer(utiltesting.MakeTrainJobTrainerWrapper().
+					Env(
+						corev1.EnvVar{Name: constants.OpenMPIEnvHostFileLocation, Value: "/custom/hostfile"},
+						corev1.EnvVar{Name: constants.OpenMPIEnvKeyRSHArgs, Value: "custom-args"},
+					).
+					Obj(),
+				).
+				Obj(),
+			wantError: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec").Child("trainer").Child("env"),
+					[]corev1.EnvVar{
+						{Name: constants.OpenMPIEnvHostFileLocation, Value: "/custom/hostfile"},
+						{Name: constants.OpenMPIEnvKeyRSHArgs, Value: "custom-args"},
+					},
+					fmt.Sprintf("must not have reserved envs, invalid envs configured: %v", []string{constants.OpenMPIEnvHostFileLocation, constants.OpenMPIEnvKeyRSHArgs}),
+				),
+			},
+		},
+		"trainer has non-reserved env is valid": {
+			info: runtime.NewInfo(
+				runtime.WithMLPolicySource(utiltesting.MakeMLPolicyWrapper().
+					WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+						MPIPolicy(ptr.To[int32](1), trainer.MPIImplementationOpenMPI, nil, nil).
+						Obj(),
+					).
+					Obj(),
+				),
+			),
+			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				Trainer(utiltesting.MakeTrainJobTrainerWrapper().
+					Env(corev1.EnvVar{Name: "CUSTOM_ENV", Value: "custom-value"}).
+					Obj(),
+				).
+				Obj(),
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Picking up #3145 per @andreyvelich's ask. The original PR was approved in approach but went stale waiting on a rebase, so this is that rebase.

The MPI plugin's `Validate` function already catches a few things; this adds a check that rejects any `TrainJob.spec.trainer.env` entry whose name is in a new `MPIReservedEnvNames` set. The set lives in `pkg/constants/constants.go` and covers the four OpenMPI variables the operator manages internally (`OMPI_MCA_orte_default_hostfile`, `OMPI_MCA_plm_rsh_args`, `OMPI_MCA_orte_keep_fqdn_hostnames`, `OMPI_MCA_orte_set_default_slots`). Approach mirrors the Torch plugin's `TorchRunReservedEnvNames` check.

Tests in `mpi_test.go` cover one reserved var, two reserved vars, and a custom var that still passes.

Rebase notes: minor conflicts in `constants.go` (master added `XGBoostReservedEnvNames` at the same insertion point) and `mpi.go` (master dropped an unused `intstr` import). `go vet`, `gofmt`, and the package tests all pass locally.

Fixes #3126

Co-authored-by: Vishal Painjane <painjanevishal2204@gmail.com>