### PR TITLE
fix(cache): use status code (not identity) to detect Service AlreadyExists

### DIFF
--- a/pkg/initializers/dataset/cache.py
+++ b/pkg/initializers/dataset/cache.py
@@ -3,7 +3,6 @@ import time
 
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
-from kubernetes.dynamic.exceptions import ConflictError
 
 import pkg.initializers.types.types as types
 import pkg.initializers.utils.utils as utils
@@ -269,7 +268,7 @@ class CacheInitializer(utils.DatasetProvider):
                 core_v1.create_namespaced_service(namespace=namespace, body=service)
                 logging.info(f"Created Service {service.metadata.name}")
             except ApiException as e:
-                if e is ConflictError:
+                if e.status == 409:
                     logging.info(
                         f"Service {service.metadata.name} already exists, "
                         f"skipping creation"

--- a/pkg/initializers/dataset/cache_test.py
+++ b/pkg/initializers/dataset/cache_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from kubernetes.client.rest import ApiException
 
 import pkg.initializers.utils.utils as utils
 from pkg.initializers.dataset.cache import CacheInitializer
@@ -231,3 +232,61 @@ def test_download_dataset(test_name, test_case):
         mock_client.CustomObjectsApi.assert_called_once_with(mock_api_client)
 
     print("Test execution completed")
+
+
+def test_download_dataset_service_already_exists():
+    """Service creation should be idempotent — a 409 AlreadyExists response
+    must be treated as a no-op, not as a creation failure that triggers
+    ServiceAccount cleanup."""
+
+    cache_initializer_instance = CacheInitializer()
+
+    config = {
+        "storage_uri": "cache://test_schema/test_table",
+        "train_job_name": "idempotent-job",
+        "cache_image": "test-image:latest",
+        "iam_role": "arn:aws:iam::123456789012:role/test-role",
+        "metadata_loc": "s3://test-bucket/metadata",
+    }
+
+    with patch.object(utils, "get_config_from_env", return_value=config):
+        cache_initializer_instance.load_config()
+
+    with patch(
+        "pkg.initializers.dataset.cache.get_namespace", return_value="test-namespace"
+    ), patch("pkg.initializers.dataset.cache.config"), patch(
+        "pkg.initializers.dataset.cache.client"
+    ) as mock_client:
+
+        mock_api_client = MagicMock()
+        mock_core_v1 = MagicMock()
+        mock_custom_api = MagicMock()
+
+        mock_client.ApiClient.return_value = mock_api_client
+        mock_client.CoreV1Api.return_value = mock_core_v1
+        mock_client.CustomObjectsApi.return_value = mock_custom_api
+
+        # Simulate Service already existing in the cluster (e.g., from a previous
+        # reconcile that crashed after creating the Service).
+        mock_core_v1.create_namespaced_service.side_effect = ApiException(
+            status=409, reason="AlreadyExists"
+        )
+
+        mock_training_job = {
+            "apiVersion": "trainer.kubeflow.org/v1alpha1",
+            "kind": "TrainJob",
+            "metadata": {"name": "idempotent-job", "uid": "test-uid"},
+        }
+        mock_lws_ready = {
+            "status": {"conditions": [{"type": "Available", "status": "True"}]}
+        }
+        mock_custom_api.get_namespaced_custom_object.side_effect = [
+            mock_training_job,
+            mock_lws_ready,
+        ]
+
+        # Must not raise.
+        cache_initializer_instance.download_dataset()
+
+        # Must not trigger cleanup of the ServiceAccount.
+        mock_core_v1.delete_namespaced_service_account.assert_not_called()


### PR DESCRIPTION
## What this PR does

`pkg/initializers/dataset/cache.py:272` checks `if e is ConflictError:` after a failed `create_namespaced_service`. That's a class-identity comparison against the exception instance, which is always False. So when a cache cluster's Service already exists (HTTP 409 on retry), the code falls through to the cleanup branch and deletes the ServiceAccount that was just successfully created.

The sibling ServiceAccount creation block 145 lines above uses the correct `if e.status == 409:` pattern. This PR aligns the Service branch with it.

## Why

Symptom on re-run of a dataset cache initialization:
- ServiceAccount created (200)
- Service create → 409 AlreadyExists
- ConflictError identity check fails → cleanup branch fires
- ServiceAccount deleted
- Cache pod ends up orphaned without its SA

The fix is two lines (one comparison change, one now-unused import removed).

## How was this tested?

Added `test_download_dataset_service_already_exists` in `pkg/initializers/dataset/cache_test.py`. It mocks `create_namespaced_service` to raise `ApiException(status=409)` and asserts `delete_namespaced_service_account` is NOT called. The new test fails on master and passes with this PR.

Signed-off-by: 1fanwang <1fannnw@gmail.com>
