### PR TITLE
feat: storageuri targetjob validation fix

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13922,7 +13922,7 @@
             ]
           },
           "storageUri": {
-            "description": "storageUri is the URI for the dataset provider. If set, it may be empty, or it should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path).",
+            "description": "storageUri is the URI for the dataset provider. If set, it may be empty, or it must be a valid URI format (e.g., s3://bucket/path, gs://bucket/path).",
             "type": "string"
           }
         }
@@ -14276,7 +14276,7 @@
             ]
           },
           "storageUri": {
-            "description": "storageUri is the URI for the model provider. If set, it may be empty, or it should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path).",
+            "description": "storageUri is the URI for the model provider. If set, it may be empty, or it must be a valid URI format (e.g., s3://bucket/path, gs://bucket/path).",
             "type": "string"
           }
         }

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14276,7 +14276,7 @@
             ]
           },
           "storageUri": {
-            "description": "storageUri is the URI for the model provider.",
+            "description": "storageUri is the URI for the model provider. Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)",
             "type": "string"
           }
         }

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13922,7 +13922,7 @@
             ]
           },
           "storageUri": {
-            "description": "storageUri is the URI for the dataset provider. Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)",
+            "description": "storageUri is the URI for the dataset provider. If set, it may be empty, or it should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path).",
             "type": "string"
           }
         }
@@ -14276,7 +14276,7 @@
             ]
           },
           "storageUri": {
-            "description": "storageUri is the URI for the model provider. Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)",
+            "description": "storageUri is the URI for the model provider. If set, it may be empty, or it should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path).",
             "type": "string"
           }
         }

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13922,7 +13922,7 @@
             ]
           },
           "storageUri": {
-            "description": "storageUri is the URI for the dataset provider.",
+            "description": "storageUri is the URI for the dataset provider. Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)",
             "type": "string"
           }
         }

--- a/api/python_api/kubeflow_trainer_api/models/trainer_v1alpha1_dataset_initializer.py
+++ b/api/python_api/kubeflow_trainer_api/models/trainer_v1alpha1_dataset_initializer.py
@@ -30,7 +30,7 @@ class TrainerV1alpha1DatasetInitializer(BaseModel):
     """ # noqa: E501
     env: Optional[List[IoK8sApiCoreV1EnvVar]] = Field(default=None, description="env is the list of environment variables to set in the dataset initializer container. These values will be merged with the TrainingRuntime's dataset initializer environments.")
     secret_ref: Optional[IoK8sApiCoreV1LocalObjectReference] = Field(default=None, description="secretRef is the reference to the secret with credentials to download dataset. Secret must be created in the TrainJob's namespace.", alias="secretRef")
-    storage_uri: Optional[StrictStr] = Field(default=None, description="storageUri is the URI for the dataset provider. Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)", alias="storageUri")
+    storage_uri: Optional[StrictStr] = Field(default=None, description="storageUri is the URI for the dataset provider. If set, it may be empty, or it should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path).", alias="storageUri")
     __properties: ClassVar[List[str]] = ["env", "secretRef", "storageUri"]
 
     model_config = ConfigDict(

--- a/api/python_api/kubeflow_trainer_api/models/trainer_v1alpha1_dataset_initializer.py
+++ b/api/python_api/kubeflow_trainer_api/models/trainer_v1alpha1_dataset_initializer.py
@@ -30,7 +30,7 @@ class TrainerV1alpha1DatasetInitializer(BaseModel):
     """ # noqa: E501
     env: Optional[List[IoK8sApiCoreV1EnvVar]] = Field(default=None, description="env is the list of environment variables to set in the dataset initializer container. These values will be merged with the TrainingRuntime's dataset initializer environments.")
     secret_ref: Optional[IoK8sApiCoreV1LocalObjectReference] = Field(default=None, description="secretRef is the reference to the secret with credentials to download dataset. Secret must be created in the TrainJob's namespace.", alias="secretRef")
-    storage_uri: Optional[StrictStr] = Field(default=None, description="storageUri is the URI for the dataset provider.", alias="storageUri")
+    storage_uri: Optional[StrictStr] = Field(default=None, description="storageUri is the URI for the dataset provider. Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)", alias="storageUri")
     __properties: ClassVar[List[str]] = ["env", "secretRef", "storageUri"]
 
     model_config = ConfigDict(

--- a/api/python_api/kubeflow_trainer_api/models/trainer_v1alpha1_dataset_initializer.py
+++ b/api/python_api/kubeflow_trainer_api/models/trainer_v1alpha1_dataset_initializer.py
@@ -30,7 +30,7 @@ class TrainerV1alpha1DatasetInitializer(BaseModel):
     """ # noqa: E501
     env: Optional[List[IoK8sApiCoreV1EnvVar]] = Field(default=None, description="env is the list of environment variables to set in the dataset initializer container. These values will be merged with the TrainingRuntime's dataset initializer environments.")
     secret_ref: Optional[IoK8sApiCoreV1LocalObjectReference] = Field(default=None, description="secretRef is the reference to the secret with credentials to download dataset. Secret must be created in the TrainJob's namespace.", alias="secretRef")
-    storage_uri: Optional[StrictStr] = Field(default=None, description="storageUri is the URI for the dataset provider. If set, it may be empty, or it should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path).", alias="storageUri")
+    storage_uri: Optional[StrictStr] = Field(default=None, description="storageUri is the URI for the dataset provider. If set, it may be empty, or it must be a valid URI format (e.g., s3://bucket/path, gs://bucket/path).", alias="storageUri")
     __properties: ClassVar[List[str]] = ["env", "secretRef", "storageUri"]
 
     model_config = ConfigDict(

--- a/api/python_api/kubeflow_trainer_api/models/trainer_v1alpha1_model_initializer.py
+++ b/api/python_api/kubeflow_trainer_api/models/trainer_v1alpha1_model_initializer.py
@@ -30,7 +30,7 @@ class TrainerV1alpha1ModelInitializer(BaseModel):
     """ # noqa: E501
     env: Optional[List[IoK8sApiCoreV1EnvVar]] = Field(default=None, description="env is the list of environment variables to set in the model initializer container. These values will be merged with the TrainingRuntime's model initializer environments.")
     secret_ref: Optional[IoK8sApiCoreV1LocalObjectReference] = Field(default=None, description="secretRef is the reference to the secret with credentials to download model. Secret must be created in the TrainJob's namespace.", alias="secretRef")
-    storage_uri: Optional[StrictStr] = Field(default=None, description="storageUri is the URI for the model provider. Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)", alias="storageUri")
+    storage_uri: Optional[StrictStr] = Field(default=None, description="storageUri is the URI for the model provider. If set, it may be empty, or it should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path).", alias="storageUri")
     __properties: ClassVar[List[str]] = ["env", "secretRef", "storageUri"]
 
     model_config = ConfigDict(

--- a/api/python_api/kubeflow_trainer_api/models/trainer_v1alpha1_model_initializer.py
+++ b/api/python_api/kubeflow_trainer_api/models/trainer_v1alpha1_model_initializer.py
@@ -30,7 +30,7 @@ class TrainerV1alpha1ModelInitializer(BaseModel):
     """ # noqa: E501
     env: Optional[List[IoK8sApiCoreV1EnvVar]] = Field(default=None, description="env is the list of environment variables to set in the model initializer container. These values will be merged with the TrainingRuntime's model initializer environments.")
     secret_ref: Optional[IoK8sApiCoreV1LocalObjectReference] = Field(default=None, description="secretRef is the reference to the secret with credentials to download model. Secret must be created in the TrainJob's namespace.", alias="secretRef")
-    storage_uri: Optional[StrictStr] = Field(default=None, description="storageUri is the URI for the model provider. If set, it may be empty, or it should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path).", alias="storageUri")
+    storage_uri: Optional[StrictStr] = Field(default=None, description="storageUri is the URI for the model provider. If set, it may be empty, or it must be a valid URI format (e.g., s3://bucket/path, gs://bucket/path).", alias="storageUri")
     __properties: ClassVar[List[str]] = ["env", "secretRef", "storageUri"]
 
     model_config = ConfigDict(

--- a/api/python_api/kubeflow_trainer_api/models/trainer_v1alpha1_model_initializer.py
+++ b/api/python_api/kubeflow_trainer_api/models/trainer_v1alpha1_model_initializer.py
@@ -30,7 +30,7 @@ class TrainerV1alpha1ModelInitializer(BaseModel):
     """ # noqa: E501
     env: Optional[List[IoK8sApiCoreV1EnvVar]] = Field(default=None, description="env is the list of environment variables to set in the model initializer container. These values will be merged with the TrainingRuntime's model initializer environments.")
     secret_ref: Optional[IoK8sApiCoreV1LocalObjectReference] = Field(default=None, description="secretRef is the reference to the secret with credentials to download model. Secret must be created in the TrainJob's namespace.", alias="secretRef")
-    storage_uri: Optional[StrictStr] = Field(default=None, description="storageUri is the URI for the model provider.", alias="storageUri")
+    storage_uri: Optional[StrictStr] = Field(default=None, description="storageUri is the URI for the model provider. Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)", alias="storageUri")
     __properties: ClassVar[List[str]] = ["env", "secretRef", "storageUri"]
 
     model_config = ConfigDict(

--- a/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -442,7 +442,9 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       storageUri:
-                        description: storageUri is the URI for the model provider.
+                        description: |-
+                          storageUri is the URI for the model provider.
+                          Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
                         maxLength: 2048
                         type: string
                         x-kubernetes-validations:

--- a/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -255,7 +255,7 @@ spec:
                         x-kubernetes-validations:
                         - message: storageUri must be a valid URI (scheme://...) or
                             absolute path (/...)
-                          rule: self.matches('^([A-Za-z][A-Za-z0-9+.-]*://.*|/.*)$')
+                          rule: self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')
                     type: object
                   model:
                     description: model defines the configuration for the pre-trained
@@ -450,7 +450,7 @@ spec:
                         x-kubernetes-validations:
                         - message: storageUri must be a valid URI (scheme://...) or
                             absolute path (/...)
-                          rule: self.matches('^([A-Za-z][A-Za-z0-9+.-]*://.*|/.*)$')
+                          rule: self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')
                     type: object
                 type: object
                 x-kubernetes-validations:

--- a/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -249,12 +249,13 @@ spec:
                       storageUri:
                         description: |-
                           storageUri is the URI for the dataset provider.
-                          Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
+                          If set, it may be empty, or it should be a valid URI format
+                          (e.g., s3://bucket/path, gs://bucket/path, /local/path).
                         maxLength: 2048
                         type: string
                         x-kubernetes-validations:
-                        - message: storageUri must be a valid URI (scheme://...) or
-                            absolute path (/...)
+                        - message: storageUri may be empty, or it must be a valid
+                            URI (scheme://...) or absolute path (/...)
                           rule: self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')
                     type: object
                   model:
@@ -444,7 +445,8 @@ spec:
                       storageUri:
                         description: |-
                           storageUri is the URI for the model provider.
-                          Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
+                          If set, it may be empty, or it should be a valid URI format
+                          (e.g., s3://bucket/path, gs://bucket/path, /local/path).
                         maxLength: 2048
                         type: string
                         x-kubernetes-validations:

--- a/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -247,9 +247,15 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       storageUri:
-                        description: storageUri is the URI for the dataset provider.
+                        description: |-
+                          storageUri is the URI for the dataset provider.
+                          Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
                         maxLength: 2048
                         type: string
+                        x-kubernetes-validations:
+                        - message: storageUri must be a valid URI (scheme://...) or
+                            absolute path (/...)
+                          rule: self.matches('^([A-Za-z][A-Za-z0-9+.-]*://.*|/.*)$')
                     type: object
                   model:
                     description: model defines the configuration for the pre-trained
@@ -439,6 +445,10 @@ spec:
                         description: storageUri is the URI for the model provider.
                         maxLength: 2048
                         type: string
+                        x-kubernetes-validations:
+                        - message: storageUri must be a valid URI (scheme://...) or
+                            absolute path (/...)
+                          rule: self.matches('^([A-Za-z][A-Za-z0-9+.-]*://.*|/.*)$')
                     type: object
                 type: object
                 x-kubernetes-validations:
@@ -531,8 +541,9 @@ spec:
                                       name:
                                         description: name is the name of the replicated
                                           job to patch.
-                                        maxLength: 253
+                                        maxLength: 63
                                         minLength: 1
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       template:
                                         description: template patches the Job template

--- a/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -249,14 +249,14 @@ spec:
                       storageUri:
                         description: |-
                           storageUri is the URI for the dataset provider.
-                          If set, it may be empty, or it should be a valid URI format
-                          (e.g., s3://bucket/path, gs://bucket/path, /local/path).
+                          If set, it may be empty, or it must be a valid URI format
+                          (e.g., s3://bucket/path, gs://bucket/path).
                         maxLength: 2048
                         type: string
                         x-kubernetes-validations:
                         - message: storageUri may be empty, or it must be a valid
-                            URI (scheme://...) or absolute path (/...)
-                          rule: self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')
+                            URI (scheme://...)
+                          rule: self == '' || self.matches('^[A-Za-z][A-Za-z0-9+.-]*://.+$')
                     type: object
                   model:
                     description: model defines the configuration for the pre-trained
@@ -445,14 +445,14 @@ spec:
                       storageUri:
                         description: |-
                           storageUri is the URI for the model provider.
-                          If set, it may be empty, or it should be a valid URI format
-                          (e.g., s3://bucket/path, gs://bucket/path, /local/path).
+                          If set, it may be empty, or it must be a valid URI format
+                          (e.g., s3://bucket/path, gs://bucket/path).
                         maxLength: 2048
                         type: string
                         x-kubernetes-validations:
-                        - message: storageUri must be a valid URI (scheme://...) or
-                            absolute path (/...)
-                          rule: self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')
+                        - message: storageUri may be empty, or it must be a valid
+                            URI (scheme://...)
+                          rule: self == '' || self.matches('^[A-Za-z][A-Za-z0-9+.-]*://.+$')
                     type: object
                 type: object
                 x-kubernetes-validations:
@@ -545,7 +545,7 @@ spec:
                                       name:
                                         description: name is the name of the replicated
                                           job to patch.
-                                        maxLength: 63
+                                        maxLength: 253
                                         minLength: 1
                                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string

--- a/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -547,7 +547,6 @@ spec:
                                           job to patch.
                                         maxLength: 253
                                         minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       template:
                                         description: template patches the Job template

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -442,7 +442,9 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       storageUri:
-                        description: storageUri is the URI for the model provider.
+                        description: |-
+                          storageUri is the URI for the model provider.
+                          Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
                         maxLength: 2048
                         type: string
                         x-kubernetes-validations:

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -255,7 +255,7 @@ spec:
                         x-kubernetes-validations:
                         - message: storageUri must be a valid URI (scheme://...) or
                             absolute path (/...)
-                          rule: self.matches('^([A-Za-z][A-Za-z0-9+.-]*://.*|/.*)$')
+                          rule: self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')
                     type: object
                   model:
                     description: model defines the configuration for the pre-trained
@@ -450,7 +450,7 @@ spec:
                         x-kubernetes-validations:
                         - message: storageUri must be a valid URI (scheme://...) or
                             absolute path (/...)
-                          rule: self.matches('^([A-Za-z][A-Za-z0-9+.-]*://.*|/.*)$')
+                          rule: self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')
                     type: object
                 type: object
                 x-kubernetes-validations:

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -249,12 +249,13 @@ spec:
                       storageUri:
                         description: |-
                           storageUri is the URI for the dataset provider.
-                          Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
+                          If set, it may be empty, or it should be a valid URI format
+                          (e.g., s3://bucket/path, gs://bucket/path, /local/path).
                         maxLength: 2048
                         type: string
                         x-kubernetes-validations:
-                        - message: storageUri must be a valid URI (scheme://...) or
-                            absolute path (/...)
+                        - message: storageUri may be empty, or it must be a valid
+                            URI (scheme://...) or absolute path (/...)
                           rule: self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')
                     type: object
                   model:
@@ -444,7 +445,8 @@ spec:
                       storageUri:
                         description: |-
                           storageUri is the URI for the model provider.
-                          Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
+                          If set, it may be empty, or it should be a valid URI format
+                          (e.g., s3://bucket/path, gs://bucket/path, /local/path).
                         maxLength: 2048
                         type: string
                         x-kubernetes-validations:

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -247,9 +247,15 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       storageUri:
-                        description: storageUri is the URI for the dataset provider.
+                        description: |-
+                          storageUri is the URI for the dataset provider.
+                          Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
                         maxLength: 2048
                         type: string
+                        x-kubernetes-validations:
+                        - message: storageUri must be a valid URI (scheme://...) or
+                            absolute path (/...)
+                          rule: self.matches('^([A-Za-z][A-Za-z0-9+.-]*://.*|/.*)$')
                     type: object
                   model:
                     description: model defines the configuration for the pre-trained
@@ -439,6 +445,10 @@ spec:
                         description: storageUri is the URI for the model provider.
                         maxLength: 2048
                         type: string
+                        x-kubernetes-validations:
+                        - message: storageUri must be a valid URI (scheme://...) or
+                            absolute path (/...)
+                          rule: self.matches('^([A-Za-z][A-Za-z0-9+.-]*://.*|/.*)$')
                     type: object
                 type: object
                 x-kubernetes-validations:
@@ -531,8 +541,9 @@ spec:
                                       name:
                                         description: name is the name of the replicated
                                           job to patch.
-                                        maxLength: 253
+                                        maxLength: 63
                                         minLength: 1
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       template:
                                         description: template patches the Job template

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -249,14 +249,14 @@ spec:
                       storageUri:
                         description: |-
                           storageUri is the URI for the dataset provider.
-                          If set, it may be empty, or it should be a valid URI format
-                          (e.g., s3://bucket/path, gs://bucket/path, /local/path).
+                          If set, it may be empty, or it must be a valid URI format
+                          (e.g., s3://bucket/path, gs://bucket/path).
                         maxLength: 2048
                         type: string
                         x-kubernetes-validations:
                         - message: storageUri may be empty, or it must be a valid
-                            URI (scheme://...) or absolute path (/...)
-                          rule: self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')
+                            URI (scheme://...)
+                          rule: self == '' || self.matches('^[A-Za-z][A-Za-z0-9+.-]*://.+$')
                     type: object
                   model:
                     description: model defines the configuration for the pre-trained
@@ -445,14 +445,14 @@ spec:
                       storageUri:
                         description: |-
                           storageUri is the URI for the model provider.
-                          If set, it may be empty, or it should be a valid URI format
-                          (e.g., s3://bucket/path, gs://bucket/path, /local/path).
+                          If set, it may be empty, or it must be a valid URI format
+                          (e.g., s3://bucket/path, gs://bucket/path).
                         maxLength: 2048
                         type: string
                         x-kubernetes-validations:
-                        - message: storageUri must be a valid URI (scheme://...) or
-                            absolute path (/...)
-                          rule: self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')
+                        - message: storageUri may be empty, or it must be a valid
+                            URI (scheme://...)
+                          rule: self == '' || self.matches('^[A-Za-z][A-Za-z0-9+.-]*://.+$')
                     type: object
                 type: object
                 x-kubernetes-validations:
@@ -545,7 +545,7 @@ spec:
                                       name:
                                         description: name is the name of the replicated
                                           job to patch.
-                                        maxLength: 63
+                                        maxLength: 253
                                         minLength: 1
                                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -547,7 +547,6 @@ spec:
                                           job to patch.
                                         maxLength: 253
                                         minLength: 1
-                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       template:
                                         description: template patches the Job template

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -194,8 +194,9 @@ type Initializer struct {
 // which contains this label: `trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer`
 type DatasetInitializer struct {
 	// storageUri is the URI for the dataset provider.
-	// Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
-	// +kubebuilder:validation:XValidation:rule="self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')",message="storageUri must be a valid URI (scheme://...) or absolute path (/...)"
+	// If set, it may be empty, or it should be a valid URI format
+	// (e.g., s3://bucket/path, gs://bucket/path, /local/path).
+	// +kubebuilder:validation:XValidation:rule="self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')",message="storageUri may be empty, or it must be a valid URI (scheme://...) or absolute path (/...)"
 	// +kubebuilder:validation:MaxLength=2048
 	// +optional
 	StorageUri *string `json:"storageUri,omitempty"`

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -219,6 +219,7 @@ type DatasetInitializer struct {
 // which contains this label: `trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer`
 type ModelInitializer struct {
 	// storageUri is the URI for the model provider.
+	// Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
 	// +kubebuilder:validation:XValidation:rule="self.matches('^([A-Za-z][A-Za-z0-9+.-]*://.*|/.*)$')",message="storageUri must be a valid URI (scheme://...) or absolute path (/...)"
 	// +kubebuilder:validation:MaxLength=2048
 	// +optional

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -220,7 +220,8 @@ type DatasetInitializer struct {
 // which contains this label: `trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer`
 type ModelInitializer struct {
 	// storageUri is the URI for the model provider.
-	// Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
+	// If set, it may be empty, or it should be a valid URI format
+	// (e.g., s3://bucket/path, gs://bucket/path, /local/path).
 	// +kubebuilder:validation:XValidation:rule="self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')",message="storageUri must be a valid URI (scheme://...) or absolute path (/...)"
 	// +kubebuilder:validation:MaxLength=2048
 	// +optional

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -194,6 +194,8 @@ type Initializer struct {
 // which contains this label: `trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer`
 type DatasetInitializer struct {
 	// storageUri is the URI for the dataset provider.
+	// Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
+	// +kubebuilder:validation:XValidation:rule="self.matches('^([A-Za-z][A-Za-z0-9+.-]*://.*|/.*)$')",message="storageUri must be a valid URI (scheme://...) or absolute path (/...)"
 	// +kubebuilder:validation:MaxLength=2048
 	// +optional
 	StorageUri *string `json:"storageUri,omitempty"`
@@ -217,6 +219,7 @@ type DatasetInitializer struct {
 // which contains this label: `trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer`
 type ModelInitializer struct {
 	// storageUri is the URI for the model provider.
+	// +kubebuilder:validation:XValidation:rule="self.matches('^([A-Za-z][A-Za-z0-9+.-]*://.*|/.*)$')",message="storageUri must be a valid URI (scheme://...) or absolute path (/...)"
 	// +kubebuilder:validation:MaxLength=2048
 	// +optional
 	StorageUri *string `json:"storageUri,omitempty"`
@@ -340,7 +343,8 @@ type JobSetSpecPatch struct {
 type ReplicatedJobPatch struct {
 	// name is the name of the replicated job to patch.
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	// +kubebuilder:validation:MaxLength=63
 	// +required
 	Name string `json:"name,omitempty"`
 

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -346,7 +346,6 @@ type JobSetSpecPatch struct {
 type ReplicatedJobPatch struct {
 	// name is the name of the replicated job to patch.
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 	// +kubebuilder:validation:MaxLength=253
 	// +required
 	Name string `json:"name,omitempty"`

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -195,7 +195,7 @@ type Initializer struct {
 type DatasetInitializer struct {
 	// storageUri is the URI for the dataset provider.
 	// Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
-	// +kubebuilder:validation:XValidation:rule="self.matches('^([A-Za-z][A-Za-z0-9+.-]*://.*|/.*)$')",message="storageUri must be a valid URI (scheme://...) or absolute path (/...)"
+	// +kubebuilder:validation:XValidation:rule="self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')",message="storageUri must be a valid URI (scheme://...) or absolute path (/...)"
 	// +kubebuilder:validation:MaxLength=2048
 	// +optional
 	StorageUri *string `json:"storageUri,omitempty"`
@@ -220,7 +220,7 @@ type DatasetInitializer struct {
 type ModelInitializer struct {
 	// storageUri is the URI for the model provider.
 	// Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
-	// +kubebuilder:validation:XValidation:rule="self.matches('^([A-Za-z][A-Za-z0-9+.-]*://.*|/.*)$')",message="storageUri must be a valid URI (scheme://...) or absolute path (/...)"
+	// +kubebuilder:validation:XValidation:rule="self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')",message="storageUri must be a valid URI (scheme://...) or absolute path (/...)"
 	// +kubebuilder:validation:MaxLength=2048
 	// +optional
 	StorageUri *string `json:"storageUri,omitempty"`

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -194,9 +194,9 @@ type Initializer struct {
 // which contains this label: `trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer`
 type DatasetInitializer struct {
 	// storageUri is the URI for the dataset provider.
-	// If set, it may be empty, or it should be a valid URI format
-	// (e.g., s3://bucket/path, gs://bucket/path, /local/path).
-	// +kubebuilder:validation:XValidation:rule="self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')",message="storageUri may be empty, or it must be a valid URI (scheme://...) or absolute path (/...)"
+	// If set, it may be empty, or it must be a valid URI format
+	// (e.g., s3://bucket/path, gs://bucket/path).
+	// +kubebuilder:validation:XValidation:rule="self == '' || self.matches('^[A-Za-z][A-Za-z0-9+.-]*://.+$')",message="storageUri may be empty, or it must be a valid URI (scheme://...)"
 	// +kubebuilder:validation:MaxLength=2048
 	// +optional
 	StorageUri *string `json:"storageUri,omitempty"`
@@ -220,9 +220,9 @@ type DatasetInitializer struct {
 // which contains this label: `trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer`
 type ModelInitializer struct {
 	// storageUri is the URI for the model provider.
-	// If set, it may be empty, or it should be a valid URI format
-	// (e.g., s3://bucket/path, gs://bucket/path, /local/path).
-	// +kubebuilder:validation:XValidation:rule="self == '' || self.matches('^([A-Za-z][A-Za-z0-9+.+-]*://.+|/.*)$')",message="storageUri must be a valid URI (scheme://...) or absolute path (/...)"
+	// If set, it may be empty, or it must be a valid URI format
+	// (e.g., s3://bucket/path, gs://bucket/path).
+	// +kubebuilder:validation:XValidation:rule="self == '' || self.matches('^[A-Za-z][A-Za-z0-9+.-]*://.+$')",message="storageUri may be empty, or it must be a valid URI (scheme://...)"
 	// +kubebuilder:validation:MaxLength=2048
 	// +optional
 	StorageUri *string `json:"storageUri,omitempty"`
@@ -347,7 +347,7 @@ type ReplicatedJobPatch struct {
 	// name is the name of the replicated job to patch.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
-	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:MaxLength=253
 	// +required
 	Name string `json:"name,omitempty"`
 

--- a/pkg/apis/trainer/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/trainer/v1alpha1/zz_generated.openapi.go
@@ -1108,7 +1108,7 @@ func schema_pkg_apis_trainer_v1alpha1_ModelInitializer(ref common.ReferenceCallb
 				Properties: map[string]spec.Schema{
 					"storageUri": {
 						SchemaProps: spec.SchemaProps{
-							Description: "storageUri is the URI for the model provider.",
+							Description: "storageUri is the URI for the model provider. Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/trainer/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/trainer/v1alpha1/zz_generated.openapi.go
@@ -639,7 +639,7 @@ func schema_pkg_apis_trainer_v1alpha1_DatasetInitializer(ref common.ReferenceCal
 				Properties: map[string]spec.Schema{
 					"storageUri": {
 						SchemaProps: spec.SchemaProps{
-							Description: "storageUri is the URI for the dataset provider.",
+							Description: "storageUri is the URI for the dataset provider. Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/trainer/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/trainer/v1alpha1/zz_generated.openapi.go
@@ -639,7 +639,7 @@ func schema_pkg_apis_trainer_v1alpha1_DatasetInitializer(ref common.ReferenceCal
 				Properties: map[string]spec.Schema{
 					"storageUri": {
 						SchemaProps: spec.SchemaProps{
-							Description: "storageUri is the URI for the dataset provider. If set, it may be empty, or it should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path).",
+							Description: "storageUri is the URI for the dataset provider. If set, it may be empty, or it must be a valid URI format (e.g., s3://bucket/path, gs://bucket/path).",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1108,7 +1108,7 @@ func schema_pkg_apis_trainer_v1alpha1_ModelInitializer(ref common.ReferenceCallb
 				Properties: map[string]spec.Schema{
 					"storageUri": {
 						SchemaProps: spec.SchemaProps{
-							Description: "storageUri is the URI for the model provider. If set, it may be empty, or it should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path).",
+							Description: "storageUri is the URI for the model provider. If set, it may be empty, or it must be a valid URI format (e.g., s3://bucket/path, gs://bucket/path).",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/trainer/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/trainer/v1alpha1/zz_generated.openapi.go
@@ -639,7 +639,7 @@ func schema_pkg_apis_trainer_v1alpha1_DatasetInitializer(ref common.ReferenceCal
 				Properties: map[string]spec.Schema{
 					"storageUri": {
 						SchemaProps: spec.SchemaProps{
-							Description: "storageUri is the URI for the dataset provider. Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)",
+							Description: "storageUri is the URI for the dataset provider. If set, it may be empty, or it should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path).",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1108,7 +1108,7 @@ func schema_pkg_apis_trainer_v1alpha1_ModelInitializer(ref common.ReferenceCallb
 				Properties: map[string]spec.Schema{
 					"storageUri": {
 						SchemaProps: spec.SchemaProps{
-							Description: "storageUri is the URI for the model provider. Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)",
+							Description: "storageUri is the URI for the model provider. If set, it may be empty, or it should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path).",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/client/applyconfiguration/trainer/v1alpha1/datasetinitializer.go
+++ b/pkg/client/applyconfiguration/trainer/v1alpha1/datasetinitializer.go
@@ -29,8 +29,8 @@ import (
 // which contains this label: `trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer`
 type DatasetInitializerApplyConfiguration struct {
 	// storageUri is the URI for the dataset provider.
-	// If set, it may be empty, or it should be a valid URI format
-	// (e.g., s3://bucket/path, gs://bucket/path, /local/path).
+	// If set, it may be empty, or it must be a valid URI format
+	// (e.g., s3://bucket/path, gs://bucket/path).
 	StorageUri *string `json:"storageUri,omitempty"`
 	// env is the list of environment variables to set in the dataset initializer container.
 	// These values will be merged with the TrainingRuntime's dataset initializer environments.

--- a/pkg/client/applyconfiguration/trainer/v1alpha1/datasetinitializer.go
+++ b/pkg/client/applyconfiguration/trainer/v1alpha1/datasetinitializer.go
@@ -29,7 +29,8 @@ import (
 // which contains this label: `trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer`
 type DatasetInitializerApplyConfiguration struct {
 	// storageUri is the URI for the dataset provider.
-	// Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
+	// If set, it may be empty, or it should be a valid URI format
+	// (e.g., s3://bucket/path, gs://bucket/path, /local/path).
 	StorageUri *string `json:"storageUri,omitempty"`
 	// env is the list of environment variables to set in the dataset initializer container.
 	// These values will be merged with the TrainingRuntime's dataset initializer environments.

--- a/pkg/client/applyconfiguration/trainer/v1alpha1/datasetinitializer.go
+++ b/pkg/client/applyconfiguration/trainer/v1alpha1/datasetinitializer.go
@@ -29,6 +29,7 @@ import (
 // which contains this label: `trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer`
 type DatasetInitializerApplyConfiguration struct {
 	// storageUri is the URI for the dataset provider.
+	// Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
 	StorageUri *string `json:"storageUri,omitempty"`
 	// env is the list of environment variables to set in the dataset initializer container.
 	// These values will be merged with the TrainingRuntime's dataset initializer environments.

--- a/pkg/client/applyconfiguration/trainer/v1alpha1/modelinitializer.go
+++ b/pkg/client/applyconfiguration/trainer/v1alpha1/modelinitializer.go
@@ -29,6 +29,7 @@ import (
 // which contains this label: `trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer`
 type ModelInitializerApplyConfiguration struct {
 	// storageUri is the URI for the model provider.
+	// Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
 	StorageUri *string `json:"storageUri,omitempty"`
 	// env is the list of environment variables to set in the model initializer container.
 	// These values will be merged with the TrainingRuntime's model initializer environments.

--- a/pkg/client/applyconfiguration/trainer/v1alpha1/modelinitializer.go
+++ b/pkg/client/applyconfiguration/trainer/v1alpha1/modelinitializer.go
@@ -29,7 +29,8 @@ import (
 // which contains this label: `trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer`
 type ModelInitializerApplyConfiguration struct {
 	// storageUri is the URI for the model provider.
-	// Should be a valid URI format (e.g., s3://bucket/path, gs://bucket/path, /local/path)
+	// If set, it may be empty, or it should be a valid URI format
+	// (e.g., s3://bucket/path, gs://bucket/path, /local/path).
 	StorageUri *string `json:"storageUri,omitempty"`
 	// env is the list of environment variables to set in the model initializer container.
 	// These values will be merged with the TrainingRuntime's model initializer environments.

--- a/pkg/client/applyconfiguration/trainer/v1alpha1/modelinitializer.go
+++ b/pkg/client/applyconfiguration/trainer/v1alpha1/modelinitializer.go
@@ -29,8 +29,8 @@ import (
 // which contains this label: `trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer`
 type ModelInitializerApplyConfiguration struct {
 	// storageUri is the URI for the model provider.
-	// If set, it may be empty, or it should be a valid URI format
-	// (e.g., s3://bucket/path, gs://bucket/path, /local/path).
+	// If set, it may be empty, or it must be a valid URI format
+	// (e.g., s3://bucket/path, gs://bucket/path).
 	StorageUri *string `json:"storageUri,omitempty"`
 	// env is the list of environment variables to set in the model initializer container.
 	// These values will be merged with the TrainingRuntime's model initializer environments.

--- a/test/integration/webhooks/trainjob_test.go
+++ b/test/integration/webhooks/trainjob_test.go
@@ -299,64 +299,6 @@ var _ = ginkgo.Describe("TrainJob Webhook", ginkgo.Ordered, func() {
 				},
 				gomega.Succeed(),
 			),
-			ginkgo.Entry("Should fail with invalid replicated job name",
-				func() *trainer.TrainJob {
-					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
-						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
-						RuntimePatches([]trainer.RuntimePatch{
-							{
-								Manager: "test.io/manager",
-								TrainingRuntimeSpec: &trainer.TrainingRuntimeSpecPatch{
-									Template: &trainer.JobSetTemplatePatch{
-										Spec: &trainer.JobSetSpecPatch{
-											ReplicatedJobs: []trainer.ReplicatedJobPatch{
-												{
-													Name: "-bad-name",
-												},
-											},
-										},
-									},
-								},
-							},
-						}).
-						Obj()
-				},
-				testingutil.BeInvalidError(),
-			),
-
-			ginkgo.Entry("Should succeed with valid replicated job name",
-				func() *trainer.TrainJob {
-					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
-						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
-						RuntimePatches([]trainer.RuntimePatch{
-							{
-								Manager: "test.io/manager",
-								TrainingRuntimeSpec: &trainer.TrainingRuntimeSpecPatch{
-									Template: &trainer.JobSetTemplatePatch{
-										Spec: &trainer.JobSetSpecPatch{
-											ReplicatedJobs: []trainer.ReplicatedJobPatch{
-												{
-													Name: "node",
-													Template: &trainer.JobTemplatePatch{
-														Spec: &trainer.JobSpecPatch{
-															Template: &trainer.PodTemplatePatch{
-																Spec: &trainer.PodSpecPatch{
-																	ServiceAccountName: ptr.To("custom-sa"),
-																},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						}).
-						Obj()
-				},
-				gomega.Succeed(),
-			),
 		)
 		ginkgo.DescribeTable("RFC1035-compliant TrainJob name validation", func(trainJob func() *trainer.TrainJob, errorMatcher gomega.OmegaMatcher) {
 			gomega.Expect(k8sClient.Create(ctx, trainJob())).Should(errorMatcher)

--- a/test/integration/webhooks/trainjob_test.go
+++ b/test/integration/webhooks/trainjob_test.go
@@ -213,6 +213,40 @@ var _ = ginkgo.Describe("TrainJob Webhook", ginkgo.Ordered, func() {
 				},
 				testingutil.BeInvalidError(),
 			),
+			ginkgo.Entry("Should succeed with empty dataset storageUri",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), runtimeName).
+						Initializer(
+							testingutil.MakeTrainJobInitializerWrapper().
+								DatasetInitializer(
+									testingutil.MakeTrainJobDatasetInitializerWrapper().
+										StorageUri("").
+										Obj(),
+								).
+								Obj(),
+						).
+						Obj()
+				},
+				gomega.Succeed(),
+			),
+			ginkgo.Entry("Should fail with dataset storageUri missing path",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), runtimeName).
+						Initializer(
+							testingutil.MakeTrainJobInitializerWrapper().
+								DatasetInitializer(
+									testingutil.MakeTrainJobDatasetInitializerWrapper().
+										StorageUri("s3://").
+										Obj(),
+								).
+								Obj(),
+						).
+						Obj()
+				},
+				testingutil.BeInvalidError(),
+			),
 			ginkgo.Entry("Should succeed with valid dataset storageUri",
 				func() *trainer.TrainJob {
 					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).

--- a/test/integration/webhooks/trainjob_test.go
+++ b/test/integration/webhooks/trainjob_test.go
@@ -196,6 +196,133 @@ var _ = ginkgo.Describe("TrainJob Webhook", ginkgo.Ordered, func() {
 						Obj()
 				},
 				testingutil.BeForbiddenError()),
+			ginkgo.Entry("Should fail with invalid dataset storageUri",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), runtimeName).
+						Initializer(
+							testingutil.MakeTrainJobInitializerWrapper().
+								DatasetInitializer(
+									testingutil.MakeTrainJobDatasetInitializerWrapper().
+										StorageUri("invalid-uri").
+										Obj(),
+								).
+								Obj(),
+						).
+						Obj()
+				},
+				testingutil.BeInvalidError(),
+			),
+			ginkgo.Entry("Should succeed with valid dataset storageUri",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), runtimeName).
+						Initializer(
+							testingutil.MakeTrainJobInitializerWrapper().
+								DatasetInitializer(
+									testingutil.MakeTrainJobDatasetInitializerWrapper().
+										StorageUri("s3://bucket/path").
+										Obj(),
+								).
+								Obj(),
+						).
+						Obj()
+				},
+				gomega.Succeed(),
+			),
+			ginkgo.Entry("Should fail with invalid model storageUri",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), runtimeName).
+						Initializer(
+							testingutil.MakeTrainJobInitializerWrapper().
+								ModelInitializer(
+									testingutil.MakeTrainJobModelInitializerWrapper().
+										StorageUri("invalid-uri").
+										Obj(),
+								).
+								Obj(),
+						).
+						Obj()
+				},
+				testingutil.BeInvalidError(),
+			),
+
+			ginkgo.Entry("Should succeed with valid model storageUri",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), runtimeName).
+						Initializer(
+							testingutil.MakeTrainJobInitializerWrapper().
+								ModelInitializer(
+									testingutil.MakeTrainJobModelInitializerWrapper().
+										StorageUri("gs://bucket/model").
+										Obj(),
+								).
+								Obj(),
+						).
+						Obj()
+				},
+				gomega.Succeed(),
+			),
+			ginkgo.Entry("Should fail with invalid replicated job name",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
+						RuntimePatches([]trainer.RuntimePatch{
+							{
+								Manager: "test.io/manager",
+								TrainingRuntimeSpec: &trainer.TrainingRuntimeSpecPatch{
+									Template: &trainer.JobSetTemplatePatch{
+										Spec: &trainer.JobSetSpecPatch{
+											ReplicatedJobs: []trainer.ReplicatedJobPatch{
+												{
+													Name: "-bad-name",
+												},
+											},
+										},
+									},
+								},
+							},
+						}).
+						Obj()
+				},
+				testingutil.BeInvalidError(),
+			),
+
+			ginkgo.Entry("Should succeed with valid replicated job name",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
+						RuntimePatches([]trainer.RuntimePatch{
+							{
+								Manager: "test.io/manager",
+								TrainingRuntimeSpec: &trainer.TrainingRuntimeSpecPatch{
+									Template: &trainer.JobSetTemplatePatch{
+										Spec: &trainer.JobSetSpecPatch{
+											ReplicatedJobs: []trainer.ReplicatedJobPatch{
+												{
+													Name: "node",
+													Template: &trainer.JobTemplatePatch{
+														Spec: &trainer.JobSpecPatch{
+															Template: &trainer.PodTemplatePatch{
+																Spec: &trainer.PodSpecPatch{
+																	ServiceAccountName: ptr.To("custom-sa"),
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						}).
+						Obj()
+				},
+				gomega.Succeed(),
+			),
 		)
 		ginkgo.DescribeTable("RFC1035-compliant TrainJob name validation", func(trainJob func() *trainer.TrainJob, errorMatcher gomega.OmegaMatcher) {
 			gomega.Expect(k8sClient.Create(ctx, trainJob())).Should(errorMatcher)


### PR DESCRIPTION
Add regex pattern validation for StorageUri fields in DatasetInitializer
Add name format validation for ReplicatedJobPatch.Name to match Kubernetes naming conventions.
Add integration tests.