### PR TITLE
chore: rename lifecycle/needs-triage to needs-triage in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Tell us about a problem you are experiencing with Kubeflow Trainer
-labels: ["kind/bug", "lifecycle/needs-triage"]
+labels: ["kind/bug", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest an idea for Kubeflow Trainer
-labels: ["kind/feature", "lifecycle/needs-triage"]
+labels: ["kind/feature", "needs-triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Renames `lifecycle/needs-triage` to bare `needs-triage` in issue templates,
aligning with the k8s convention and the prow config change in
[GoogleCloudPlatform/oss-test-infra#2594](https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2594)

After the oss-test-infra change lands, `/label needs-triage` and
`/remove-label needs-triage` will work as prow slash commands across
all kubeflow repos.

Part of: https://github.com/kubeflow/mcp-server/pull/3#discussion_r3221022098