### PR TITLE
feat(api): add TPU utility to compute numNodes for multi-slice TPU

### DIFF
--- a/api/python_api/kubeflow_trainer_api/__init__.py
+++ b/api/python_api/kubeflow_trainer_api/__init__.py
@@ -13,4 +13,11 @@
 # limitations under the License.
 
 
+from kubeflow_trainer_api.tpu import get_num_nodes
+
 __version__ = "2.2.0"
+
+__all__ = [
+    "get_num_nodes",
+]
+

--- a/api/python_api/kubeflow_trainer_api/tpu.py
+++ b/api/python_api/kubeflow_trainer_api/tpu.py
@@ -1,0 +1,58 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def get_num_nodes(num_slices: int, topology: str, chips_per_host: int = 4) -> int:
+    """
+    Compute the total number of nodes (hosts) required across all TPU slices.
+
+    This utility function assists in configuring multi-slice TPU TrainJobs where the 
+    user wants to scale their training job across multiple physical TPU slices. It calculates 
+    the aggregate `num_nodes` based on the slice count and physical TPU topology dimensions.
+
+    Args:
+        num_slices: The number of TPU slices.
+        topology: The TPU topology string (e.g., "2x2", "2x4", "2x2x2", "2x2x4", "4x4").
+        chips_per_host: The number of TPU chips per VM host node. Defaults to 4.
+
+    Returns:
+        The total number of nodes (hosts) across all slices.
+
+    Raises:
+        ValueError: If topology is empty, improperly formatted, or if the total chips 
+                    in a slice is not evenly divisible by the chips_per_host.
+    """
+    if not topology:
+        raise ValueError("TPU topology must be specified.")
+
+    # Parse the topology dimensions (e.g. "2x2" or "2x2x2")
+    try:
+        dims = [int(d) for d in topology.lower().split("x")]
+    except ValueError:
+        raise ValueError(
+            f"Invalid topology format: '{topology}'. Must be formatted as 'AxB' or 'AxBxC' (e.g. '2x2', '2x2x2')."
+        )
+
+    # Calculate total TPU chips in a single slice
+    chips_per_slice = 1
+    for dim in dims:
+        chips_per_slice *= dim
+
+    # Validate that the topology can be cleanly allocated into VM hosts
+    if chips_per_slice % chips_per_host != 0:
+        raise ValueError(
+            f"Total TPU chips in slice ({chips_per_slice}) must be cleanly divisible by chips_per_host ({chips_per_host})."
+        )
+
+    hosts_per_slice = chips_per_slice // chips_per_host
+    return num_slices * hosts_per_slice

--- a/api/python_api/kubeflow_trainer_api/tpu_test.py
+++ b/api/python_api/kubeflow_trainer_api/tpu_test.py
@@ -1,0 +1,59 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from kubeflow_trainer_api.tpu import get_num_nodes
+
+class TestTPUUtils(unittest.TestCase):
+    def test_get_num_nodes_v5e(self):
+        # TPU v5e single-slice configurations
+        self.assertEqual(get_num_nodes(num_slices=1, topology="2x2"), 1)
+        self.assertEqual(get_num_nodes(num_slices=1, topology="2x4"), 2)
+        self.assertEqual(get_num_nodes(num_slices=1, topology="4x4"), 4)
+        
+        # TPU v5e multi-slice scaling
+        self.assertEqual(get_num_nodes(num_slices=2, topology="2x2"), 2)
+        self.assertEqual(get_num_nodes(num_slices=4, topology="2x4"), 8)
+        self.assertEqual(get_num_nodes(num_slices=2, topology="4x4"), 8)
+
+    def test_get_num_nodes_v4_v5p(self):
+        # TPU v4/v5p 3D topologies
+        self.assertEqual(get_num_nodes(num_slices=1, topology="2x2x2"), 2)
+        self.assertEqual(get_num_nodes(num_slices=3, topology="2x2x2"), 6)
+        self.assertEqual(get_num_nodes(num_slices=1, topology="2x2x4"), 4)
+        self.assertEqual(get_num_nodes(num_slices=2, topology="2x2x4"), 8)
+
+    def test_case_insensitivity(self):
+        self.assertEqual(get_num_nodes(num_slices=2, topology="2X4"), 4)
+        self.assertEqual(get_num_nodes(num_slices=1, topology="2X2X2"), 2)
+
+    def test_custom_chips_per_host(self):
+        # Custom chip VM host overrides (e.g. 8 chips per host)
+        self.assertEqual(get_num_nodes(num_slices=2, topology="4x4", chips_per_host=8), 4)
+
+    def test_invalid_topologies(self):
+        # Assert ValueError for invalid formats
+        with self.assertRaises(ValueError):
+            get_num_nodes(num_slices=1, topology="")
+        with self.assertRaises(ValueError):
+            get_num_nodes(num_slices=1, topology="invalid-topo")
+        with self.assertRaises(ValueError):
+            get_num_nodes(num_slices=1, topology="2x")
+
+        # Assert ValueError for indivisible layouts
+        with self.assertRaises(ValueError):
+            get_num_nodes(num_slices=1, topology="2x3")  # 6 chips not divisible by 4
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce a TPU utility function `get_num_nodes` in the Python API package to calculate the total number of VM hosts (`numNodes`) for multi-slice TPU configurations 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Issue #https://github.com/kubeflow/trainer/issues/3407

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
