### PR TITLE
fix(operator): support multi-replica endpoint generation in IdentifyP…

### DIFF
--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -236,15 +236,15 @@ func (j *JobSet) IdentifyPodNetwork(info *runtime.Info, trainJob *trainer.TrainJ
 		subDomain = *jobSetNet.Subdomain
 	}
 	for rJobIdx, rJob := range spec.ReplicatedJobs {
-		// TODO: Support multiple replicas for replicated Jobs.
-		// REF: https://github.com/kubeflow/trainer/issues/2318
 		podCount := info.TemplateSpec.PodSets[rJobIdx].Count
-		rJobReplicas := constants.DefaultJobReplicas
+		rJobReplicas := ptr.Deref(rJob.Replicas, 1)
 		info.TemplateSpec.PodSets[rJobIdx].Endpoints = func(yield func(string) bool) {
-			for podIdx := range ptr.Deref(podCount, 1) {
-				endpoint := fmt.Sprintf("%s-%s-%d-%d.%s", trainJob.Name, *rJob.Name, rJobReplicas-1, podIdx, subDomain)
-				if !yield(endpoint) {
-					return
+			for replicaIdx := range int(rJobReplicas) {
+				for podIdx := range ptr.Deref(podCount, 1) {
+					endpoint := fmt.Sprintf("%s-%s-%d-%d.%s", trainJob.Name, *rJob.Name, replicaIdx, podIdx, subDomain)
+					if !yield(endpoint) {
+						return
+					}
 				}
 			}
 		}

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -237,9 +237,9 @@ func (j *JobSet) IdentifyPodNetwork(info *runtime.Info, trainJob *trainer.TrainJ
 	}
 	for rJobIdx, rJob := range spec.ReplicatedJobs {
 		podCount := info.TemplateSpec.PodSets[rJobIdx].Count
-		rJobReplicas := ptr.Deref(rJob.Replicas, 1)
+		rJobReplicas := ptr.Deref(rJob.Replicas, constants.DefaultJobReplicas)
 		info.TemplateSpec.PodSets[rJobIdx].Endpoints = func(yield func(string) bool) {
-			for replicaIdx := range int(rJobReplicas) {
+			for replicaIdx := 0; replicaIdx < int(rJobReplicas); replicaIdx++ {
 				for podIdx := range ptr.Deref(podCount, 1) {
 					endpoint := fmt.Sprintf("%s-%s-%d-%d.%s", trainJob.Name, *rJob.Name, replicaIdx, podIdx, subDomain)
 					if !yield(endpoint) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR resolves a limitation in the `IdentifyPodNetwork` function within `pkg/runtime/framework/plugins/jobset/jobset.go`. Previously, the operator hardcoded the number of replicated job replicas to 1 (`rJobReplicas := constants.DefaultJobReplicas`) and only generated network endpoints for replica index `0`.
With the introduction of multi-slice TPU support (where `replicas > 1` represents the slice count, e.g., in JobSet), this 1-replica assumption causes endpoint generation to fail for all slices other than the first one. 
This PR updates `IdentifyPodNetwork` to:
1. Retrieve the actual replica count from the `ReplicatedJob` configuration template.
2. Iterate over all replicas (slices) and pods to generate unique, correct network endpoints (e.g., `...-node-0-0...` to `...-node-3-7...`).
This is an essential follow-up fix to ensure complete multi-slice TPU support in the operator.
**Which issue(s) this PR fixes**:
Fixes #3407 (Companion/follow-up to #3408)
**Checklist:**
- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing 
*(Note: This is an internal operator networking fix, so no user-facing documentation changes are required. Checked for checklist completeness).*