### PR TITLE
chore(docs): Add targeted-file lint/format commands to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,23 @@ make vet                      # Vet the Go code
 make golangci-lint            # Verify the Go code
 ```
 
+### Targeted lint/format
+
+For quick feedback on specific files or packages instead of running project-wide `make` targets:
+
+```bash
+# Go
+make golangci-lint LINT_PKG=./pkg/controller/...             # Lint a single Go package
+go vet ./pkg/controller/...                                  # Vet a single Go package (package-level)
+gofmt -w path/to/file.go                                     # Format a single Go file
+
+# Python
+pre-commit run --files path/to/file.py                       # Run all hooks on a single file
+
+# Rust (crate-level: triggers on the file but formats/checks the entire crate)
+pre-commit run --files path/to/file.rs                       # Run all hooks on a single file
+```
+
 **Code generation** (always run after modifying the APIs):
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ HELM_DOCS ?= $(LOCALBIN)/helm-docs
 YQ ?= $(LOCALBIN)/yq
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 GOLANGCI_LINT_KAL ?= $(LOCALBIN)/golangci-lint-kube-api-linter
+LINT_PKG ?= ./...
 KUBE_LINTER ?= $(LOCALBIN)/kube-linter
 
 ##@ General
@@ -192,7 +193,7 @@ vet: ## Run go vet against the code.
 
 .PHONY: golangci-lint
 golangci-lint: golangci-lint-install golangci-lint-kal ## Run golangci-lint to verify Go files.
-	$(GOLANGCI_LINT) run --timeout 5m ./...
+	$(GOLANGCI_LINT) run --timeout 5m $(LINT_PKG)
 	$(GOLANGCI_LINT_KAL) run -v --config $(PROJECT_DIR)/.golangci-kal.yml
 
 .PHONY: verify-boilerplate


### PR DESCRIPTION
**What this PR does / why we need it**:
- AGENTS.md  only documented project-wide `make` targets for linting. When an AI agent (or contributor) changes a single file or package, running the full-project lint is slow and noisy. Documenting targeted single-file/package equivalents lets agents get fast, focused feedback on just the target paths it touched.
- This PR adds a **"Targeted lint/format"** section with commands for checking specific files or packages, giving agents and contributors faster feedback on just the code they changed.
- Adds a `LINT_PKG` variable to the Makefile (defaults to `./...`) so `make golangci-lint LINT_PKG=./pkg/controller/...` lints a single package using the project-local binary, avoiding PATH mismatches with globally installed versions.
- All commands were validated locally against the repo's actual tooling (Makefile, `.pre-commit-config.yaml`, `.golangci.yaml`).

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
