### PR TITLE
fix: migrate to newer name for cncf runners

### DIFF
--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -13,7 +13,7 @@ jobs:
   build-and-publish:
     name: Build and Publish Images
     if: github.repository == 'kubeflow/trainer'
-    runs-on: oracle-vm-16cpu-64gb-x86-64
+    runs-on: cncf-ubuntu-16-64-x86
 
     env:
       SHOULD_PUBLISH: ${{ github.event_name == 'push' }}

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   cpu-e2e-test:
     name: CPU E2E Test
-    runs-on: oracle-vm-16cpu-64gb-x86-64
+    runs-on: cncf-ubuntu-16-64-x86
     env:
       GOPATH: ${{ github.workspace }}/go
     defaults:

--- a/.github/workflows/test-helm.yaml
+++ b/.github/workflows/test-helm.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: oracle-vm-16cpu-64gb-x86-64
+    runs-on: cncf-ubuntu-16-64-x86
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
**What this PR does / why we need it**:
Renamed the CNCF CI runners with its new names. 
Ref: https://cloud-native.slack.com/docs/T08PSQ7BQ/F09QFEJFPR8

Fyi: GPU runner name is still same.

**Which issue(s) this PR fixes** 
Fixes #3555

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
