### PR TITLE
fix(operator): guard against nil trainer PodSet in JAX EnforceMLPolicy

### DIFF
--- a/pkg/runtime/framework/plugins/jax/jax.go
+++ b/pkg/runtime/framework/plugins/jax/jax.go
@@ -62,7 +62,7 @@ func (j *Jax) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) er
 	// Find the trainer PodSet
 	trainerPS := info.FindPodSetByAncestor(constants.AncestorTrainer)
 	// Set the number of nodes (JAX processes/hosts) from TrainJob
-	if trainerPS.Count != nil && trainJob.Spec.Trainer != nil && trainJob.Spec.Trainer.NumNodes != nil {
+	if trainerPS != nil && trainerPS.Count != nil && trainJob.Spec.Trainer != nil && trainJob.Spec.Trainer.NumNodes != nil {
 		*trainerPS.Count = *trainJob.Spec.Trainer.NumNodes
 	}
 

--- a/pkg/runtime/framework/plugins/jax/jax_test.go
+++ b/pkg/runtime/framework/plugins/jax/jax_test.go
@@ -65,6 +65,35 @@ func TestJAXEnforceMLPolicy(t *testing.T) {
 				),
 			),
 		},
+		"no panic when JAX policy is set but trainer PodSet is absent": {
+			info: runtime.NewInfo(
+				runtime.WithMLPolicySource(
+					utiltesting.MakeMLPolicyWrapper().
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							JAXPolicy().
+							Obj(),
+						).
+						Obj(),
+				),
+				// Intentionally no trainer PodSet to exercise the nil-guard.
+			),
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				Trainer(
+					utiltesting.MakeTrainJobTrainerWrapper().
+						NumNodes(2).
+						Obj()).
+				Obj(),
+			wantInfo: runtime.NewInfo(
+				runtime.WithMLPolicySource(
+					utiltesting.MakeMLPolicyWrapper().
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							JAXPolicy().
+							Obj(),
+						).
+						Obj(),
+				),
+			),
+		},
 		"single node JAX training": {
 			info: runtime.NewInfo(
 				runtime.WithMLPolicySource(


### PR DESCRIPTION
**What this PR does / why we need it**:

`EnforceMLPolicy` in the JAX plugin calls `info.FindPodSetByAncestor(constants.AncestorTrainer)` which returns `*PodSet` and can be `nil` if no replicatedJob carries the `trainer` ancestor label. The next line dereferences it directly (`trainerPS.Count != nil`), causing a nil pointer dereference panic at runtime.

The fix adds a `trainerPS != nil` guard, matching the pattern already used in the Torch plugin. The XGBoost plugin uses a similar early-return guard too -- the JAX plugin was just missing it.

**Reproduce**:

Create a `ClusterTrainingRuntime` with JAX `mlPolicy` but without a replicatedJob labeled `trainer.kubeflow.org/trainjob-ancestor-step: trainer`, then submit a `TrainJob` against it. The controller panics when processing `EnforceMLPolicy`.

Or run the new unit test case `no panic when JAX policy is set but trainer PodSet is absent` after reverting the one-line fix -- it will panic.

**Which issue(s) this PR fixes**:
Fixes #