### PR TITLE
feat: implement runtime snapshot mechanism (KEP-2599)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	sigs.k8s.io/kind v0.31.0
 	sigs.k8s.io/scheduler-plugins v0.34.4-devel-sg
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
+	sigs.k8s.io/yaml v1.6.0
 	volcano.sh/apis v1.13.1-0.20251028070205-46d20c0699e7
 )
 
@@ -92,5 +93,4 @@ require (
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/pkg/runtime/core/clustertrainingruntime.go
+++ b/pkg/runtime/core/clustertrainingruntime.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -57,8 +58,21 @@ func NewClusterTrainingRuntime(context.Context, client.Client, client.FieldIndex
 
 func (r *ClusterTrainingRuntime) NewObjects(ctx context.Context, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
 	var clTrainingRuntime trainer.ClusterTrainingRuntime
-	if err := r.client.Get(ctx, client.ObjectKey{Name: trainJob.Spec.RuntimeRef.Name}, &clTrainingRuntime); err != nil {
-		return nil, fmt.Errorf("%w: %w", errorNotFoundSpecifiedClusterTrainingRuntime, err)
+	// Try to get runtime from snapshot first
+	if err := getRuntimeSnapshot(ctx, r.client, trainJob, &clTrainingRuntime); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("getting runtime snapshot: %w", err)
+		}
+
+		// Snapshot doesn't exist, load runtime from API server
+		if err := r.client.Get(ctx, client.ObjectKey{Name: trainJob.Spec.RuntimeRef.Name}, &clTrainingRuntime); err != nil {
+			return nil, fmt.Errorf("%w: %w", errorNotFoundSpecifiedClusterTrainingRuntime, err)
+		}
+
+		// Create snapshot for future reconciliations
+		if err := createRuntimeSnapshot(ctx, r.client, trainJob, &clTrainingRuntime); err != nil {
+			return nil, fmt.Errorf("creating runtime snapshot: %w", err)
+		}
 	}
 
 	info, err := r.RuntimeInfo(trainJob, clTrainingRuntime.Spec.Template, clTrainingRuntime.Spec.MLPolicy, clTrainingRuntime.Spec.PodGroupPolicy)

--- a/pkg/runtime/core/core.go
+++ b/pkg/runtime/core/core.go
@@ -28,7 +28,7 @@ import (
 
 // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainingruntimes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=clustertrainingruntimes,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;create;update;patch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=create;get;list;watch;update;patch
 
 var runtimes map[string]runtime.Runtime
 

--- a/pkg/runtime/core/core.go
+++ b/pkg/runtime/core/core.go
@@ -28,6 +28,7 @@ import (
 
 // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainingruntimes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=clustertrainingruntimes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;create;update;patch
 
 var runtimes map[string]runtime.Runtime
 

--- a/pkg/runtime/core/snapshot.go
+++ b/pkg/runtime/core/snapshot.go
@@ -34,8 +34,9 @@ const (
 	runtimeDataKey        = "runtime"
 )
 
-// getRuntimeSnapshot retrieves the runtime snapshot from the ConfigMap, and populate the value in runtimeObj.
-// Returns an error if the snapshot ConfigMap doesn't exist or if the data is invalid.
+// getRuntimeSnapshot retrieves the runtime snapshot from the ConfigMap and unmarshalls the value into runtimeObj.
+// Returns an error if the snapshot ConfigMap doesn't exist or if the data is invalid. The value of runtimeObj is
+// only valid if no error was returned.
 func getRuntimeSnapshot(ctx context.Context, c client.Client, trainJob *trainer.TrainJob, runtimeObj client.Object) error {
 	cm := &corev1.ConfigMap{}
 	cmKey := client.ObjectKey{
@@ -89,7 +90,7 @@ func getRuntimeSnapshot(ctx context.Context, c client.Client, trainJob *trainer.
 
 // createRuntimeSnapshot creates a ConfigMap containing a YAML-serialized snapshot of the runtime configuration.
 // The ConfigMap is owned by the TrainJob and will be automatically deleted when the TrainJob is deleted.
-// Uses Server-Side Apply for idempotent creation.
+// An existing configmap will be overwritten. Callers must only invoke this when no snapshot exists.
 func createRuntimeSnapshot(ctx context.Context, c client.Client, trainJob *trainer.TrainJob, runtimeObj client.Object) error {
 	// Serialize the runtime object to YAML
 	runtimeYAML, err := yaml.Marshal(runtimeObj)

--- a/pkg/runtime/core/snapshot.go
+++ b/pkg/runtime/core/snapshot.go
@@ -1,0 +1,110 @@
+/*
+Copyright The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+)
+
+const (
+	runtimeSnapshotSuffix = "-runtime-snapshot"
+	runtimeDataKey        = "runtime"
+)
+
+// getRuntimeSnapshot retrieves the runtime snapshot from the ConfigMap, and populate the value in runtimeObj.
+// Returns an error if the snapshot ConfigMap doesn't exist or if the data is invalid.
+func getRuntimeSnapshot(ctx context.Context, c client.Client, trainJob *trainer.TrainJob, runtimeObj client.Object) error {
+	cm := &corev1.ConfigMap{}
+	cmKey := client.ObjectKey{
+		Name:      trainJob.Name + runtimeSnapshotSuffix,
+		Namespace: trainJob.Namespace,
+	}
+
+	if err := c.Get(ctx, cmKey, cm); err != nil {
+		return err
+	}
+
+	// Read the runtime data from ConfigMap
+	runtimeYAML, ok := cm.Data[runtimeDataKey]
+	if !ok {
+		return fmt.Errorf("invalid runtime snapshot: snapshot ConfigMap missing %q data key", runtimeDataKey)
+	}
+
+	// Unmarshal YAML into the runtime type
+	if err := yaml.Unmarshal([]byte(runtimeYAML), runtimeObj); err != nil {
+		return fmt.Errorf("invalid runtime snapshot: unable to unmarshall the snapshot: %w", err)
+	}
+
+	// Validate snapshot matches expected RuntimeRef
+	snapshotGVK := runtimeObj.GetObjectKind().GroupVersionKind()
+	if snapshotGVK.Kind != *trainJob.Spec.RuntimeRef.Kind ||
+		snapshotGVK.Group != *trainJob.Spec.RuntimeRef.APIGroup ||
+		runtimeObj.GetName() != trainJob.Spec.RuntimeRef.Name {
+		return fmt.Errorf(
+			"invalid runtime snapshot: the snapshot refers to the wrong runtime: expecting a runtime with name, api group and kind of %q, %q, %q but found runtime with name, api group and kind of %q, %q, %q",
+			trainJob.Spec.RuntimeRef.Name,
+			*trainJob.Spec.RuntimeRef.APIGroup,
+			*trainJob.Spec.RuntimeRef.Kind,
+			runtimeObj.GetName(),
+			snapshotGVK.Group,
+			snapshotGVK.Kind,
+		)
+	}
+
+	return nil
+}
+
+// createRuntimeSnapshot creates a ConfigMap containing a YAML-serialized snapshot of the runtime configuration.
+// The ConfigMap is owned by the TrainJob and will be automatically deleted when the TrainJob is deleted.
+// Uses Server-Side Apply for idempotent creation.
+func createRuntimeSnapshot(ctx context.Context, c client.Client, trainJob *trainer.TrainJob, runtimeObj client.Object) error {
+	// Serialize the runtime object to YAML
+	runtimeYAML, err := yaml.Marshal(runtimeObj)
+	if err != nil {
+		return fmt.Errorf("marshaling runtime to YAML: %w", err)
+	}
+
+	// Create ConfigMap ApplyConfiguration with runtime snapshot
+	cmAC := corev1ac.ConfigMap(trainJob.Name+runtimeSnapshotSuffix, trainJob.Namespace).
+		WithOwnerReferences(
+			metav1ac.OwnerReference().
+				WithAPIVersion(trainer.GroupVersion.String()).
+				WithKind(trainer.TrainJobKind).
+				WithName(trainJob.Name).
+				WithUID(trainJob.UID).
+				WithController(true).
+				WithBlockOwnerDeletion(true),
+		).
+		WithData(map[string]string{
+			runtimeDataKey: string(runtimeYAML),
+		})
+
+	if err := c.Apply(ctx, cmAC, client.FieldOwner("trainer"), client.ForceOwnership); err != nil {
+		return fmt.Errorf("applying runtime snapshot ConfigMap: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/runtime/core/snapshot.go
+++ b/pkg/runtime/core/snapshot.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -46,6 +47,11 @@ func getRuntimeSnapshot(ctx context.Context, c client.Client, trainJob *trainer.
 
 	if err := c.Get(ctx, cmKey, cm); err != nil {
 		return err
+	}
+
+	// Validate snapshot belongs to this TrainJob
+	if owner := metav1.GetControllerOf(cm); owner == nil || owner.UID != trainJob.UID {
+		return fmt.Errorf("invalid runtime snapshot: a snapshot configmap exists but is owned by another object")
 	}
 
 	// Read the runtime data from ConfigMap

--- a/pkg/runtime/core/snapshot.go
+++ b/pkg/runtime/core/snapshot.go
@@ -55,19 +55,29 @@ func getRuntimeSnapshot(ctx context.Context, c client.Client, trainJob *trainer.
 
 	// Unmarshal YAML into the runtime type
 	if err := yaml.Unmarshal([]byte(runtimeYAML), runtimeObj); err != nil {
-		return fmt.Errorf("invalid runtime snapshot: unable to unmarshall the snapshot: %w", err)
+		return fmt.Errorf("invalid runtime snapshot: unable to unmarshal the snapshot: %w", err)
 	}
 
 	// Validate snapshot matches expected RuntimeRef
 	snapshotGVK := runtimeObj.GetObjectKind().GroupVersionKind()
-	if snapshotGVK.Kind != *trainJob.Spec.RuntimeRef.Kind ||
-		snapshotGVK.Group != *trainJob.Spec.RuntimeRef.APIGroup ||
-		runtimeObj.GetName() != trainJob.Spec.RuntimeRef.Name {
+	kindMismatch := trainJob.Spec.RuntimeRef.Kind != nil && snapshotGVK.Kind != *trainJob.Spec.RuntimeRef.Kind
+	groupMismatch := trainJob.Spec.RuntimeRef.APIGroup != nil && snapshotGVK.Group != *trainJob.Spec.RuntimeRef.APIGroup
+	nameMismatch := runtimeObj.GetName() != trainJob.Spec.RuntimeRef.Name
+
+	if kindMismatch || groupMismatch || nameMismatch {
+		expectedKind := "<any>"
+		if trainJob.Spec.RuntimeRef.Kind != nil {
+			expectedKind = *trainJob.Spec.RuntimeRef.Kind
+		}
+		expectedGroup := "<any>"
+		if trainJob.Spec.RuntimeRef.APIGroup != nil {
+			expectedGroup = *trainJob.Spec.RuntimeRef.APIGroup
+		}
 		return fmt.Errorf(
 			"invalid runtime snapshot: the snapshot refers to the wrong runtime: expecting a runtime with name, api group and kind of %q, %q, %q but found runtime with name, api group and kind of %q, %q, %q",
 			trainJob.Spec.RuntimeRef.Name,
-			*trainJob.Spec.RuntimeRef.APIGroup,
-			*trainJob.Spec.RuntimeRef.Kind,
+			expectedGroup,
+			expectedKind,
 			runtimeObj.GetName(),
 			snapshotGVK.Group,
 			snapshotGVK.Kind,

--- a/pkg/runtime/core/snapshot_test.go
+++ b/pkg/runtime/core/snapshot_test.go
@@ -1,0 +1,523 @@
+/*
+Copyright The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	"sigs.k8s.io/yaml"
+
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	"github.com/kubeflow/trainer/v2/pkg/constants"
+	testingutil "github.com/kubeflow/trainer/v2/pkg/util/testing"
+)
+
+func TestGetRuntimeSnapshot(t *testing.T) {
+	cases := map[string]struct {
+		trainJob          *trainer.TrainJob
+		configMap         *corev1.ConfigMap
+		inputRuntimeObj   client.Object
+		wantRuntimeObj    client.Object
+		wantError         string
+		wantNotFoundError bool
+	}{
+		"successfully retrieves ClusterTrainingRuntime snapshot from ConfigMap": {
+			trainJob: testingutil.MakeTrainJobWrapper("test-namespace", "test-job").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
+				Obj(),
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-job-runtime-snapshot",
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					runtimeDataKey: `apiVersion: trainer.kubeflow.org/v1alpha1
+kind: ClusterTrainingRuntime
+metadata:
+  name: test-runtime
+spec:
+  mlPolicy:
+    numNodes: 2
+    torch: {}
+  template:
+    spec:
+      replicatedJobs:
+      - name: node
+        template:
+          metadata:
+            labels:
+              trainer.kubeflow.org/trainjob-ancestor-step: trainer
+          spec:
+            template:
+              spec:
+                containers:
+                - name: node
+                  image: pytorch/pytorch:tag
+`,
+				},
+			},
+			inputRuntimeObj: &trainer.ClusterTrainingRuntime{},
+			wantRuntimeObj: &trainer.ClusterTrainingRuntime{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       trainer.ClusterTrainingRuntimeKind,
+					APIVersion: trainer.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-runtime",
+				},
+				Spec: trainer.TrainingRuntimeSpec{
+					MLPolicy: &trainer.MLPolicy{
+						NumNodes: ptr.To[int32](2),
+						MLPolicySource: trainer.MLPolicySource{
+							Torch: &trainer.TorchMLPolicySource{},
+						},
+					},
+					Template: trainer.JobSetTemplateSpec{
+						Spec: jobsetv1alpha2.JobSetSpec{
+							ReplicatedJobs: []jobsetv1alpha2.ReplicatedJob{
+								{
+									Name: "node",
+									Template: batchv1.JobTemplateSpec{
+										ObjectMeta: metav1.ObjectMeta{
+											Labels: map[string]string{
+												"trainer.kubeflow.org/trainjob-ancestor-step": "trainer",
+											},
+										},
+										Spec: batchv1.JobSpec{
+											Template: corev1.PodTemplateSpec{
+												Spec: corev1.PodSpec{
+													Containers: []corev1.Container{
+														{
+															Name:  "node",
+															Image: "pytorch/pytorch:tag",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"successfully retrieves TrainingRuntime snapshot from ConfigMap": {
+			trainJob: testingutil.MakeTrainJobWrapper("test-namespace", "test-job").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
+				Obj(),
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-job-runtime-snapshot",
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					runtimeDataKey: `apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainingRuntime
+metadata:
+  name: test-runtime
+  namespace: test-namespace
+spec:
+  mlPolicy:
+    numNodes: 2
+    torch: {}
+  template:
+    spec:
+      replicatedJobs:
+      - name: node
+        template:
+          metadata:
+            labels:
+              trainer.kubeflow.org/trainjob-ancestor-step: trainer
+          spec:
+            template:
+              spec:
+                containers:
+                - name: node
+                  image: pytorch/pytorch:tag
+`,
+				},
+			},
+			inputRuntimeObj: &trainer.TrainingRuntime{},
+			wantRuntimeObj: &trainer.TrainingRuntime{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       trainer.TrainingRuntimeKind,
+					APIVersion: trainer.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-runtime",
+					Namespace: "test-namespace",
+				},
+				Spec: trainer.TrainingRuntimeSpec{
+					MLPolicy: &trainer.MLPolicy{
+						NumNodes: ptr.To[int32](2),
+						MLPolicySource: trainer.MLPolicySource{
+							Torch: &trainer.TorchMLPolicySource{},
+						},
+					},
+					Template: trainer.JobSetTemplateSpec{
+						Spec: jobsetv1alpha2.JobSetSpec{
+							ReplicatedJobs: []jobsetv1alpha2.ReplicatedJob{
+								{
+									Name: "node",
+									Template: batchv1.JobTemplateSpec{
+										ObjectMeta: metav1.ObjectMeta{
+											Labels: map[string]string{
+												"trainer.kubeflow.org/trainjob-ancestor-step": "trainer",
+											},
+										},
+										Spec: batchv1.JobSpec{
+											Template: corev1.PodTemplateSpec{
+												Spec: corev1.PodSpec{
+													Containers: []corev1.Container{
+														{
+															Name:  "node",
+															Image: "pytorch/pytorch:tag",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"returns not found error when ConfigMap does not exist": {
+			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
+				Obj(),
+			configMap:         nil,
+			inputRuntimeObj:   &trainer.ClusterTrainingRuntime{},
+			wantNotFoundError: true,
+		},
+		"returns error when ConfigMap is missing runtime data key": {
+			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
+				Obj(),
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-job" + runtimeSnapshotSuffix,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Data: map[string]string{
+					"wrong-key": "",
+				},
+			},
+			inputRuntimeObj: &trainer.ClusterTrainingRuntime{},
+			wantError:       "invalid runtime snapshot: snapshot ConfigMap missing \"runtime\" data key",
+		},
+		"returns error when ConfigMap contains invalid YAML": {
+			trainJob: testingutil.MakeTrainJobWrapper("test-namespace", "test-job").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
+				Obj(),
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-job" + runtimeSnapshotSuffix,
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					runtimeDataKey: "invalid: yaml: content:\n  - broken",
+				},
+			},
+			inputRuntimeObj: &trainer.ClusterTrainingRuntime{},
+			wantError:       "invalid runtime snapshot: unable to unmarshall the snapshot",
+		},
+		"returns error when snapshot runtime name does not match RuntimeRef": {
+			trainJob: testingutil.MakeTrainJobWrapper("test-namespace", "test-job").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
+				Obj(),
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-job" + runtimeSnapshotSuffix,
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					runtimeDataKey: `apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainingRuntime
+metadata:
+  name: other-runtime
+  namespace: test-namespace
+spec:
+  mlPolicy:
+    numNodes: 1
+  template:
+    spec:
+      replicatedJobs: []
+`,
+				},
+			},
+			inputRuntimeObj: &trainer.TrainingRuntime{},
+			wantError:       "invalid runtime snapshot: the snapshot refers to the wrong runtime: expecting a runtime with name, api group and kind of \"test-runtime\", \"trainer.kubeflow.org\", \"TrainingRuntime\" but found runtime with name, api group and kind of \"other-runtime\", \"trainer.kubeflow.org\", \"TrainingRuntime\"",
+		},
+		"returns error when snapshot runtime kind does not match RuntimeRef": {
+			trainJob: testingutil.MakeTrainJobWrapper("test-namespace", "test-job").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
+				Obj(),
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-job" + runtimeSnapshotSuffix,
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					runtimeDataKey: `apiVersion: trainer.kubeflow.org/v1alpha1
+kind: ClusterTrainingRuntime
+metadata:
+  name: test-runtime
+spec:
+  mlPolicy:
+    numNodes: 1
+  template:
+    spec:
+      replicatedJobs: []
+`,
+				},
+			},
+			inputRuntimeObj: &trainer.TrainingRuntime{},
+			wantError:       "invalid runtime snapshot: the snapshot refers to the wrong runtime: expecting a runtime with name, api group and kind of \"test-runtime\", \"trainer.kubeflow.org\", \"TrainingRuntime\" but found runtime with name, api group and kind of \"test-runtime\", \"trainer.kubeflow.org\", \"ClusterTrainingRuntime\"",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			clientBuilder := testingutil.NewClientBuilder()
+			if tc.configMap != nil {
+				clientBuilder = clientBuilder.WithObjects(tc.configMap)
+			}
+			c := clientBuilder.Build()
+
+			runtimeObj := tc.inputRuntimeObj.DeepCopyObject().(client.Object)
+			err := getRuntimeSnapshot(ctx, c, tc.trainJob, runtimeObj)
+
+			if tc.wantRuntimeObj != nil {
+				// check runtime object read from the configmap is correct
+				if diff := cmp.Diff(tc.wantRuntimeObj, runtimeObj); diff != "" {
+					t.Errorf("Unexpected retrieved runtime object (-want +got):\n%s", diff)
+				}
+
+				// check the runtime matches the TrainJob RuntimeRef
+				gvk := runtimeObj.GetObjectKind().GroupVersionKind()
+				if tc.trainJob.Spec.RuntimeRef.Kind != nil && gvk.Kind != *tc.trainJob.Spec.RuntimeRef.Kind {
+					t.Errorf("Runtime kind mismatch: expected %s, got %s", *tc.trainJob.Spec.RuntimeRef.Kind, gvk.Kind)
+				}
+				if tc.trainJob.Spec.RuntimeRef.APIGroup != nil && gvk.Group != *tc.trainJob.Spec.RuntimeRef.APIGroup {
+					t.Errorf("Runtime group mismatch: expected %s, got %s", *tc.trainJob.Spec.RuntimeRef.APIGroup, gvk.Group)
+				}
+			}
+
+			if tc.wantError != "" {
+				if err == nil {
+					t.Fatalf("Expected error containing %q, got nil", tc.wantError)
+				}
+
+				if !strings.Contains(err.Error(), tc.wantError) {
+					t.Errorf("Expected error containing %q, got %q", tc.wantError, err.Error())
+				}
+			}
+
+			if tc.wantNotFoundError {
+				if !apierrors.IsNotFound(err) {
+					t.Errorf("Expected not found error but got %q", err.Error())
+				}
+			}
+
+		})
+	}
+}
+
+func TestCreateRuntimeSnapshot(t *testing.T) {
+	resRequests := corev1.ResourceList{
+		corev1.ResourceCPU: resource.MustParse("1"),
+	}
+
+	clusterRuntime := testingutil.MakeClusterTrainingRuntimeWrapper("test-runtime").
+		RuntimeSpec(
+			testingutil.MakeTrainingRuntimeSpecWrapper(testingutil.MakeClusterTrainingRuntimeWrapper("test-runtime").Spec).
+				Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+				Obj(),
+		).Obj()
+
+	namespacedRuntime := testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "test-ns-runtime").
+		RuntimeSpec(
+			testingutil.MakeTrainingRuntimeSpecWrapper(testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "test-ns-runtime").Spec).
+				Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+				Obj(),
+		).Obj()
+
+	cases := map[string]struct {
+		trainJob   *trainer.TrainJob
+		runtimeObj client.Object
+		existingCM *corev1.ConfigMap // Pre-existing ConfigMap to test idempotency
+	}{
+		"successfully creates snapshot ConfigMap for ClusterTrainingRuntime": {
+			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				UID("test-uid").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
+				Obj(),
+			runtimeObj: clusterRuntime,
+		},
+		"successfully creates snapshot ConfigMap for TrainingRuntime": {
+			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				UID("test-uid").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-ns-runtime").
+				Obj(),
+			runtimeObj: namespacedRuntime,
+		},
+		"idempotently updates existing snapshot ConfigMap": {
+			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				UID("test-uid").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
+				Obj(),
+			runtimeObj: clusterRuntime,
+			existingCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-job" + runtimeSnapshotSuffix,
+					Namespace: metav1.NamespaceDefault,
+				},
+				Data: map[string]string{
+					runtimeDataKey: "old-data",
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			clientBuilder := testingutil.NewClientBuilder()
+			if tc.existingCM != nil {
+				clientBuilder = clientBuilder.WithObjects(tc.existingCM)
+			}
+			c := clientBuilder.Build()
+
+			err := createRuntimeSnapshot(ctx, c, tc.trainJob, tc.runtimeObj)
+			if err != nil {
+				t.Fatalf("Unexpected error creating snapshot: %v", err)
+			}
+
+			// Verify ConfigMap was created/updated
+			cm := &corev1.ConfigMap{}
+			cmKey := client.ObjectKey{
+				Name:      tc.trainJob.Name + runtimeSnapshotSuffix,
+				Namespace: tc.trainJob.Namespace,
+			}
+			if err := c.Get(ctx, cmKey, cm); err != nil {
+				t.Fatalf("Failed to get created ConfigMap: %v", err)
+			}
+
+			// Verify owner reference
+			if len(cm.OwnerReferences) == 0 {
+				t.Fatal("ConfigMap should have owner reference")
+			}
+
+			// Verify runtime data is stored correctly
+			runtimeYAML, ok := cm.Data[runtimeDataKey]
+			if !ok {
+				t.Fatalf("ConfigMap missing %q data key", runtimeDataKey)
+			}
+
+			// Verify YAML can be unmarshaled back to runtime object
+			var unmarshalledRuntime interface{}
+			switch tc.runtimeObj.(type) {
+			case *trainer.ClusterTrainingRuntime:
+				unmarshalledRuntime = &trainer.ClusterTrainingRuntime{}
+			case *trainer.TrainingRuntime:
+				unmarshalledRuntime = &trainer.TrainingRuntime{}
+			}
+
+			if err := yaml.Unmarshal([]byte(runtimeYAML), unmarshalledRuntime); err != nil {
+				t.Fatalf("Failed to unmarshal stored YAML: %v", err)
+			}
+
+			// Verify the unmarshalled runtime matches the original
+			if diff := cmp.Diff(tc.runtimeObj, unmarshalledRuntime); diff != "" {
+				t.Errorf("Runtime content mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRuntimeSnapshotRoundTrip(t *testing.T) {
+	// Test that a runtime can be stored and retrieved without data loss
+	resRequests := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("2"),
+		corev1.ResourceMemory: resource.MustParse("4Gi"),
+	}
+
+	originalRuntime := testingutil.MakeClusterTrainingRuntimeWrapper("complex-runtime").
+		RuntimeSpec(
+			testingutil.MakeTrainingRuntimeSpecWrapper(testingutil.MakeClusterTrainingRuntimeWrapper("complex-runtime").Spec).
+				Container(constants.Node, constants.Node, "test:runtime:v1.2.3", []string{"torchrun", "train.py"}, []string{"--epochs=10"}, resRequests).
+				WithMLPolicy(
+					testingutil.MakeMLPolicyWrapper().
+						WithNumNodes(4).
+						Obj(),
+				).
+				Obj(),
+		).Obj()
+
+	trainJob := testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+		UID("test-uid-12345").
+		RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "complex-runtime").
+		Obj()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	c := testingutil.NewClientBuilder().Build()
+
+	// Store the runtime
+	if err := createRuntimeSnapshot(ctx, c, trainJob, originalRuntime); err != nil {
+		t.Fatalf("Failed to create snapshot: %v", err)
+	}
+
+	// Retrieve the runtime
+	retrievedRuntime := &trainer.ClusterTrainingRuntime{}
+	if err := getRuntimeSnapshot(ctx, c, trainJob, retrievedRuntime); err != nil {
+		t.Fatalf("Failed to get snapshot: %v", err)
+	}
+
+	// Verify round-trip preserves data
+	if diff := cmp.Diff(originalRuntime.Spec, retrievedRuntime.Spec); diff != "" {
+		t.Errorf("Runtime spec mismatch after round-trip (-want +got):\n%s", diff)
+	}
+
+	// Verify metadata is preserved
+	if originalRuntime.Name != retrievedRuntime.Name {
+		t.Errorf("Runtime name mismatch: expected %s, got %s", originalRuntime.Name, retrievedRuntime.Name)
+	}
+}

--- a/pkg/runtime/core/snapshot_test.go
+++ b/pkg/runtime/core/snapshot_test.go
@@ -48,12 +48,19 @@ func TestGetRuntimeSnapshot(t *testing.T) {
 	}{
 		"successfully retrieves ClusterTrainingRuntime snapshot from ConfigMap": {
 			trainJob: testingutil.MakeTrainJobWrapper("test-namespace", "test-job").
+				UID("uid-test-job-runtime-snapshot").
 				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
 				Obj(),
 			configMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-job-runtime-snapshot",
 					Namespace: "test-namespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							UID:        "uid-test-job-runtime-snapshot",
+							Controller: ptr.To(true),
+						},
+					},
 				},
 				Data: map[string]string{
 					runtimeDataKey: `apiVersion: trainer.kubeflow.org/v1alpha1
@@ -130,12 +137,19 @@ spec:
 		},
 		"successfully retrieves TrainingRuntime snapshot from ConfigMap": {
 			trainJob: testingutil.MakeTrainJobWrapper("test-namespace", "test-job").
+				UID("uid-test-job-runtime-snapshot").
 				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
 				Obj(),
 			configMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-job-runtime-snapshot",
 					Namespace: "test-namespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							UID:        "uid-test-job-runtime-snapshot",
+							Controller: ptr.To(true),
+						},
+					},
 				},
 				Data: map[string]string{
 					runtimeDataKey: `apiVersion: trainer.kubeflow.org/v1alpha1
@@ -214,20 +228,69 @@ spec:
 		},
 		"returns not found error when ConfigMap does not exist": {
 			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				UID("uid-test-job-runtime-snapshot").
 				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
 				Obj(),
 			configMap:         nil,
 			inputRuntimeObj:   &trainer.ClusterTrainingRuntime{},
 			wantNotFoundError: true,
 		},
+		"returns error when ConfigMap is not owned and controlled by the TrainJob": {
+			trainJob: testingutil.MakeTrainJobWrapper("test-namespace", "test-job").
+				UID("uid-test-job-runtime-snapshot").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
+				Obj(),
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-job-runtime-snapshot",
+					Namespace:       "test-namespace",
+					OwnerReferences: nil, // No owner reference
+				},
+				Data: map[string]string{
+					runtimeDataKey: `apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainingRuntime
+metadata:
+  name: test-runtime
+  namespace: test-namespace
+spec:
+  mlPolicy:
+    numNodes: 2
+    torch: {}
+  template:
+    spec:
+      replicatedJobs:
+      - name: node
+        template:
+          metadata:
+            labels:
+              trainer.kubeflow.org/trainjob-ancestor-step: trainer
+          spec:
+            template:
+              spec:
+                containers:
+                - name: node
+                  image: pytorch/pytorch:tag
+`,
+				},
+			},
+			inputRuntimeObj: &trainer.TrainingRuntime{},
+			wantError:       "invalid runtime snapshot: a snapshot configmap exists but is owned by another object",
+		},
 		"returns error when ConfigMap is missing runtime data key": {
 			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				UID("uid-test-job-runtime-snapshot").
 				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
 				Obj(),
 			configMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-job" + runtimeSnapshotSuffix,
 					Namespace: metav1.NamespaceDefault,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							UID:        "uid-test-job-runtime-snapshot",
+							Controller: ptr.To(true),
+						},
+					},
 				},
 				Data: map[string]string{
 					"wrong-key": "",
@@ -238,12 +301,19 @@ spec:
 		},
 		"returns error when ConfigMap contains invalid YAML": {
 			trainJob: testingutil.MakeTrainJobWrapper("test-namespace", "test-job").
+				UID("uid-test-job-runtime-snapshot").
 				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
 				Obj(),
 			configMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-job" + runtimeSnapshotSuffix,
 					Namespace: "test-namespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							UID:        "uid-test-job-runtime-snapshot",
+							Controller: ptr.To(true),
+						},
+					},
 				},
 				Data: map[string]string{
 					runtimeDataKey: "invalid: yaml: content:\n  - broken",
@@ -254,12 +324,19 @@ spec:
 		},
 		"returns error when snapshot runtime name does not match RuntimeRef": {
 			trainJob: testingutil.MakeTrainJobWrapper("test-namespace", "test-job").
+				UID("uid-test-job-runtime-snapshot").
 				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
 				Obj(),
 			configMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-job" + runtimeSnapshotSuffix,
 					Namespace: "test-namespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							UID:        "uid-test-job-runtime-snapshot",
+							Controller: ptr.To(true),
+						},
+					},
 				},
 				Data: map[string]string{
 					runtimeDataKey: `apiVersion: trainer.kubeflow.org/v1alpha1
@@ -281,12 +358,19 @@ spec:
 		},
 		"returns error when snapshot runtime kind does not match RuntimeRef": {
 			trainJob: testingutil.MakeTrainJobWrapper("test-namespace", "test-job").
+				UID("uid-test-job-runtime-snapshot").
 				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
 				Obj(),
 			configMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-job" + runtimeSnapshotSuffix,
 					Namespace: "test-namespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							UID:        "uid-test-job-runtime-snapshot",
+							Controller: ptr.To(true),
+						},
+					},
 				},
 				Data: map[string]string{
 					runtimeDataKey: `apiVersion: trainer.kubeflow.org/v1alpha1

--- a/pkg/runtime/core/snapshot_test.go
+++ b/pkg/runtime/core/snapshot_test.go
@@ -250,7 +250,7 @@ spec:
 				},
 			},
 			inputRuntimeObj: &trainer.ClusterTrainingRuntime{},
-			wantError:       "invalid runtime snapshot: unable to unmarshall the snapshot",
+			wantError:       "invalid runtime snapshot: unable to unmarshal the snapshot",
 		},
 		"returns error when snapshot runtime name does not match RuntimeRef": {
 			trainJob: testingutil.MakeTrainJobWrapper("test-namespace", "test-job").

--- a/pkg/runtime/core/trainingruntime.go
+++ b/pkg/runtime/core/trainingruntime.go
@@ -24,6 +24,7 @@ import (
 	"maps"
 	"sort"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -83,10 +84,24 @@ func NewTrainingRuntime(ctx context.Context, c client.Client, indexer client.Fie
 
 func (r *TrainingRuntime) NewObjects(ctx context.Context, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
 	var trainingRuntime trainer.TrainingRuntime
-	err := r.client.Get(ctx, client.ObjectKey{Namespace: trainJob.Namespace, Name: trainJob.Spec.RuntimeRef.Name}, &trainingRuntime)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %w", errorNotFoundSpecifiedTrainingRuntime, err)
+	// Try to get runtime from snapshot first
+	if err := getRuntimeSnapshot(ctx, r.client, trainJob, &trainingRuntime); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("unable to get runtime snapshot: %w", err)
+		}
+
+		// Snapshot doesn't exist, load runtime from API server
+		err := r.client.Get(ctx, client.ObjectKey{Namespace: trainJob.Namespace, Name: trainJob.Spec.RuntimeRef.Name}, &trainingRuntime)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", errorNotFoundSpecifiedTrainingRuntime, err)
+		}
+
+		// Create snapshot for future reconciliations
+		if err := createRuntimeSnapshot(ctx, r.client, trainJob, &trainingRuntime); err != nil {
+			return nil, fmt.Errorf("creating runtime snapshot: %w", err)
+		}
 	}
+
 	info, err := r.RuntimeInfo(trainJob, trainingRuntime.Spec.Template, trainingRuntime.Spec.MLPolicy, trainingRuntime.Spec.PodGroupPolicy)
 	if err != nil {
 		return nil, err

--- a/proposals/2170-kubeflow-trainer-v2/README.md
+++ b/proposals/2170-kubeflow-trainer-v2/README.md
@@ -1157,14 +1157,11 @@ support them. For example, runtimes for [Jax](https://jax.readthedocs.io/en/late
 After initial implementation, we will support TensorFlow, XGboost, and PaddlePaddle runtimes, but
 it is out of scope for this KEP.
 
-The `TrainingRuntime` is immutable, and so to make a change, a new version of the `TrainingRuntime`
-must be created and then the user must change the `TrainJob` to point to the new version.
-This provides control as to how changes to runtimes propagate to existing training jobs.
-For example, when training is running for a long time (e.g. 1-2 months).
-
-In the future implementation, we will introduce a revision control mechanism similar to
-[Kubernetes Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#updating-a-deployment)
-to control versions of `TrainingRuntime` and enable rolling updates.
+When a `TrainJob` is created, the Training Operator captures a snapshot of the referenced
+`TrainingRuntime` or `ClusterTrainingRuntime` configuration. This snapshot mechanism decouples the
+runtime lifecycle from running TrainJobs, allowing platform administrators to update or delete
+runtimes without affecting existing jobs.
+See [KEP-2599](../2599-mutable-runtimes/README.md) for the snapshot implementation details.
 
 We are going to create two CRDs: `TrainingRuntime` and `ClusterTrainingRuntime`. These runtimes have
 exactly the same APIs, but the first one is the namespace-scoped, the second is the cluster-scoped.
@@ -1942,6 +1939,7 @@ spec:
 - 2026-02-23 Removed `numProcPerNode` from `TorchMLPolicySource`; `TrainJob.Trainer.numProcPerNode`
   now accepts only int values (torch plugin defaults to `auto`)
 - 2025-10-09 Replace PodTemplateOverrides with RuntimePatches API
+- 2026-06-08 Removed runtime immutability requirement; runtime lifecycle decoupled from TrainJobs via snapshot mechanism ([KEP-2599](../2599-mutable-runtimes/README.md))
 
 ## Alternatives
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -687,5 +688,181 @@ var _ = ginkgo.Describe("TrainJob e2e", func() {
 				}, util.TimeoutE2E, util.Interval).Should(gomega.Succeed())
 			})
 		})
+	})
+
+	ginkgo.When("Updating a runtime", func() {
+		// These tests ensure that a TrainJob is using a "snapshot" of the runtime from creation time, rather than
+		// the latest value of the runtime.
+		// This is testing the "snapshot" mechanism from docs/proposals/2599-mutable-runtimes/README.md.
+
+		const (
+			// These images are arbitrary, but are chosen to be small and to come from
+			// the kubernetes registry to avoid Docker Hub rate limits in CI.
+			initialImage = "registry.k8s.io/pause:3.9"
+			updatedImage = "registry.k8s.io/pause:3.10"
+		)
+
+		initialRuntimeSpec := trainer.TrainingRuntimeSpec{
+			Template: trainer.JobSetTemplateSpec{
+				Spec: jobsetv1alpha2.JobSetSpec{
+					ReplicatedJobs: []jobsetv1alpha2.ReplicatedJob{
+						{
+							Name: constants.Node,
+							Template: batchv1.JobTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Labels: map[string]string{
+										constants.LabelTrainJobAncestor: constants.AncestorTrainer,
+									},
+								},
+								Spec: batchv1.JobSpec{
+									Template: corev1.PodTemplateSpec{
+										Spec: corev1.PodSpec{
+											Containers: []corev1.Container{
+												{
+													Name:    constants.Node,
+													Image:   initialImage,
+													Command: []string{"/pause"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		updateRuntimeImage := func(spec *trainer.TrainingRuntimeSpec, newImage string) {
+			for i, rJob := range spec.Template.Spec.ReplicatedJobs {
+				if rJob.Name == constants.Node {
+					spec.Template.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.Containers[0].Image = newImage
+				}
+			}
+		}
+
+		ginkgo.DescribeTable("a suspended TrainJob should use the original runtime configuration and not pick up the new configuration",
+			func(runtimeFactory func() client.Object, runtimeKind string) {
+				runtime := runtimeFactory()
+
+				ginkgo.By("Creating a "+runtimeKind, func() {
+					gomega.Expect(k8sClient.Create(ctx, runtime)).Should(gomega.Succeed())
+				})
+
+				ginkgo.DeferCleanup(func() {
+					_ = k8sClient.Delete(ctx, runtime)
+				})
+
+				// Create a TrainJob that references the runtime
+				trainJob := testingutil.MakeTrainJobWrapper(ns.Name, "e2e-test-runtime-update").
+					RuntimeRef(trainer.SchemeGroupVersion.WithKind(runtimeKind), runtime.GetName()).
+					Obj()
+
+				ginkgo.By("Creating a TrainJob that references the "+runtimeKind, func() {
+					gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Waiting for TrainJob jobs to become active", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						gotTrainJob := &trainer.TrainJob{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainJob), gotTrainJob)).Should(gomega.Succeed())
+						g.Expect(gotTrainJob.Status.JobsStatus).ShouldNot(gomega.BeEmpty())
+						for _, jobStatus := range gotTrainJob.Status.JobsStatus {
+							g.Expect(*jobStatus.Active).Should(gomega.BeNumerically(">", 0))
+						}
+					}, util.TimeoutE2E, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Pausing the TrainJob", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						gotTrainJob := &trainer.TrainJob{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainJob), gotTrainJob)).Should(gomega.Succeed())
+						gotTrainJob.Spec.Suspend = ptr.To(true)
+						g.Expect(k8sClient.Update(ctx, gotTrainJob)).Should(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Waiting for TrainJob to be suspended", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						gotTrainJob := &trainer.TrainJob{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainJob), gotTrainJob)).Should(gomega.Succeed())
+						g.Expect(gotTrainJob.Status.JobsStatus).ShouldNot(gomega.BeEmpty())
+						for _, jobStatus := range gotTrainJob.Status.JobsStatus {
+							g.Expect(*jobStatus.Suspended).Should(gomega.BeNumerically(">", 0))
+						}
+					}, util.TimeoutE2E, util.Interval).Should(gomega.Succeed())
+				})
+
+				// Container image is NOT in JobSet's allowed mutable fields for suspended JobSets
+				// (only annotations, labels, nodeSelector, tolerations, schedulingGates are allowed)
+				ginkgo.By("Updating the runtime with a new container image", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						// Get the runtime with the correct type based on the runtime object
+						gotRuntime := runtime.DeepCopyObject().(client.Object)
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(runtime), gotRuntime)).Should(gomega.Succeed())
+
+						switch runtimeKind {
+						case trainer.TrainingRuntimeKind:
+							r := gotRuntime.(*trainer.TrainingRuntime)
+							updateRuntimeImage(&r.Spec, updatedImage)
+						case trainer.ClusterTrainingRuntimeKind:
+							r := gotRuntime.(*trainer.ClusterTrainingRuntime)
+							updateRuntimeImage(&r.Spec, updatedImage)
+						default:
+							ginkgo.Fail("unexpected runtime kind: " + runtimeKind)
+						}
+
+						g.Expect(k8sClient.Update(ctx, gotRuntime)).Should(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Restarting the TrainJob by unpausing it", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						gotTrainJob := &trainer.TrainJob{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainJob), gotTrainJob)).Should(gomega.Succeed())
+						gotTrainJob.Spec.Suspend = ptr.To(false)
+						g.Expect(k8sClient.Update(ctx, gotTrainJob)).Should(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				// This will fail if the TrainJob uses the updated runtime rather than the snapshot as the controller will
+				// try to update the JobSet image which is immutable.
+				ginkgo.By("Verifying the TrainJob jobs become active after resuming", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						gotTrainJob := &trainer.TrainJob{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainJob), gotTrainJob)).Should(gomega.Succeed())
+						g.Expect(gotTrainJob.Status.JobsStatus).ShouldNot(gomega.BeEmpty())
+						// Expect jobs to be active (not suspended)
+						for _, jobStatus := range gotTrainJob.Status.JobsStatus {
+							g.Expect(*jobStatus.Active).Should(gomega.BeNumerically(">", 0))
+						}
+					}, util.TimeoutE2E, util.Interval).Should(gomega.Succeed())
+				})
+			},
+			ginkgo.Entry("TrainingRuntime",
+				func() client.Object {
+					return &trainer.TrainingRuntime{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: ns.Name,
+							Name:      "test-runtime",
+						},
+						Spec: *initialRuntimeSpec.DeepCopy(),
+					}
+				},
+				trainer.TrainingRuntimeKind,
+			),
+			ginkgo.Entry("ClusterTrainingRuntime",
+				func() client.Object {
+					return &trainer.ClusterTrainingRuntime{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "cluster-runtime",
+						},
+						Spec: *initialRuntimeSpec.DeepCopy(),
+					}
+				},
+				trainer.ClusterTrainingRuntimeKind,
+			),
+		)
 	})
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -693,7 +693,7 @@ var _ = ginkgo.Describe("TrainJob e2e", func() {
 	ginkgo.When("Updating a runtime", func() {
 		// These tests ensure that a TrainJob is using a "snapshot" of the runtime from creation time, rather than
 		// the latest value of the runtime.
-		// This is testing the "snapshot" mechanism from docs/proposals/2599-mutable-runtimes/README.md.
+		// This is testing the "snapshot" mechanism from proposals/2599-mutable-runtimes/README.md.
 
 		const (
 			// These images are arbitrary, but are chosen to be small and to come from
@@ -837,6 +837,20 @@ var _ = ginkgo.Describe("TrainJob e2e", func() {
 						for _, jobStatus := range gotTrainJob.Status.JobsStatus {
 							g.Expect(*jobStatus.Active).Should(gomega.BeNumerically(">", 0))
 						}
+					}, util.TimeoutE2E, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Verifying the Runtime snapshot is garbage collected", func() {
+					snapshot := &corev1.ConfigMap{}
+					snapshotKey := client.ObjectKey{Name: trainJob.Name + "-runtime-snapshot", Namespace: ns.Name}
+
+					// check snapshot exists before deleting to avoid false-positive test result
+					gomega.Expect(k8sClient.Get(ctx, snapshotKey, snapshot)).Should(gomega.Succeed())
+
+					// delete the TrainJob and wait for GC
+					gomega.Expect(k8sClient.Delete(ctx, trainJob)).Should(gomega.Succeed())
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, snapshotKey, snapshot)).Should(testingutil.BeNotFoundError())
 					}, util.TimeoutE2E, util.Interval).Should(gomega.Succeed())
 				})
 			},

--- a/test/integration/controller/trainjob_controller_test.go
+++ b/test/integration/controller/trainjob_controller_test.go
@@ -2551,5 +2551,202 @@ alpha-node-0-1.alpha slots=8
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
+
+		ginkgo.Context("Integration Tests for Runtime Snapshots", func() {
+			ginkgo.It("Should create snapshot ConfigMap with correct structure and ownerReference for a TrainingRuntime", func() {
+				ginkgo.By("Creating TrainingRuntime and TrainJob")
+				gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), trainingRuntime)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+
+				ginkgo.By("Checking if snapshot ConfigMap is created with correct structure")
+				snapshotKey := client.ObjectKey{
+					Name:      trainJob.Name + "-runtime-snapshot",
+					Namespace: trainJob.Namespace,
+				}
+				gomega.Eventually(func(g gomega.Gomega) {
+					cm := &corev1.ConfigMap{}
+					g.Expect(k8sClient.Get(ctx, snapshotKey, cm)).Should(gomega.Succeed())
+
+					// Verify ConfigMap has correct owner reference
+					g.Expect(cm.OwnerReferences).Should(gomega.HaveLen(1))
+					ownerRef := cm.OwnerReferences[0]
+					g.Expect(ownerRef.APIVersion).Should(gomega.Equal(trainer.GroupVersion.String()))
+					g.Expect(ownerRef.Kind).Should(gomega.Equal(trainer.TrainJobKind))
+					g.Expect(ownerRef.Name).Should(gomega.Equal(trainJob.Name))
+					g.Expect(ownerRef.UID).Should(gomega.Equal(trainJob.UID))
+					g.Expect(ownerRef.Controller).Should(gomega.Equal(ptr.To(true)))
+					g.Expect(ownerRef.BlockOwnerDeletion).Should(gomega.Equal(ptr.To(true)))
+
+					// Verify ConfigMap has runtime data
+					g.Expect(cm.Data).Should(gomega.HaveKey("runtime"))
+					runtimeYAML := cm.Data["runtime"]
+					g.Expect(runtimeYAML).ShouldNot(gomega.BeEmpty())
+
+					// Verify YAML contains expected runtime configuration
+					g.Expect(runtimeYAML).Should(gomega.ContainSubstring("kind: TrainingRuntime"))
+					g.Expect(runtimeYAML).Should(gomega.ContainSubstring("name: alpha"))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.It("Should create snapshot ConfigMap with correct structure and ownerReference for a ClusterTrainingRuntime", func() {
+				ginkgo.By("Creating ClusterTrainingRuntime and TrainJob")
+				clusterTrainingRuntime := testingutil.MakeClusterTrainingRuntimeWrapper("cluster-training-runtime").Obj()
+				gomega.Expect(k8sClient.Create(ctx, clusterTrainingRuntime)).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterTrainingRuntime), clusterTrainingRuntime)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				trainJob := testingutil.MakeTrainJobWrapper(ns.Name, "test-job").
+					RuntimeRef(trainer.GroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), clusterTrainingRuntime.Name).
+					Obj()
+				gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+
+				ginkgo.By("Checking if snapshot ConfigMap is created with correct structure")
+				snapshotKey := client.ObjectKey{
+					Name:      trainJob.Name + "-runtime-snapshot",
+					Namespace: trainJob.Namespace,
+				}
+				gomega.Eventually(func(g gomega.Gomega) {
+					cm := &corev1.ConfigMap{}
+					g.Expect(k8sClient.Get(ctx, snapshotKey, cm)).Should(gomega.Succeed())
+
+					// Verify ConfigMap has correct owner reference
+					g.Expect(cm.OwnerReferences).Should(gomega.HaveLen(1))
+					ownerRef := cm.OwnerReferences[0]
+					g.Expect(ownerRef.APIVersion).Should(gomega.Equal(trainer.GroupVersion.String()))
+					g.Expect(ownerRef.Kind).Should(gomega.Equal(trainer.TrainJobKind))
+					g.Expect(ownerRef.Name).Should(gomega.Equal(trainJob.Name))
+					g.Expect(ownerRef.UID).Should(gomega.Equal(trainJob.UID))
+					g.Expect(ownerRef.Controller).Should(gomega.Equal(ptr.To(true)))
+					g.Expect(ownerRef.BlockOwnerDeletion).Should(gomega.Equal(ptr.To(true)))
+
+					// Verify ConfigMap has runtime data
+					g.Expect(cm.Data).Should(gomega.HaveKey("runtime"))
+					runtimeYAML := cm.Data["runtime"]
+					g.Expect(runtimeYAML).ShouldNot(gomega.BeEmpty())
+
+					// Verify YAML contains expected runtime configuration
+					g.Expect(runtimeYAML).Should(gomega.ContainSubstring("kind: ClusterTrainingRuntime"))
+					g.Expect(runtimeYAML).Should(gomega.ContainSubstring("name: cluster-training-runtime"))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.It("Should use the runtime snapshot during reconciliation rather than the current runtime contents", func() {
+				const (
+					originalLabelValue = "snapshot-v1"
+					updatedLabelValue  = "snapshot-v2"
+				)
+
+				ginkgo.By("Creating TrainingRuntime with a discriminating label")
+				trainingRuntime.Spec.Template.Labels = map[string]string{
+					"snapshot-test-marker": originalLabelValue,
+				}
+				gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), trainingRuntime)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Creating suspended TrainJob which creates a snapshot")
+				gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+
+				ginkgo.By("Waiting for snapshot ConfigMap to be created")
+				snapshotKey := client.ObjectKey{
+					Name:      trainJob.Name + "-runtime-snapshot",
+					Namespace: trainJob.Namespace,
+				}
+				gomega.Eventually(func(g gomega.Gomega) {
+					cm := &corev1.ConfigMap{}
+					g.Expect(k8sClient.Get(ctx, snapshotKey, cm)).Should(gomega.Succeed())
+					g.Expect(cm.Data["runtime"]).Should(gomega.ContainSubstring(originalLabelValue))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Verifying initial JobSet is suspended and has the original label from snapshot")
+				gomega.Eventually(func(g gomega.Gomega) {
+					jobSet := &jobsetv1alpha2.JobSet{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
+					g.Expect(*jobSet.Spec.Suspend).Should(gomega.BeTrue())
+					g.Expect(jobSet.Labels).Should(gomega.HaveKeyWithValue("snapshot-test-marker", originalLabelValue))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Updating the TrainingRuntime with a different label value")
+				gomega.Eventually(func(g gomega.Gomega) {
+					updatedRuntime := &trainer.TrainingRuntime{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), updatedRuntime)).Should(gomega.Succeed())
+					updatedRuntime.Spec.Template.Labels["snapshot-test-marker"] = updatedLabelValue
+					g.Expect(k8sClient.Update(ctx, updatedRuntime)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Triggering reconciliation by unsuspending the TrainJob")
+				gomega.Eventually(func(g gomega.Gomega) {
+					gotTrainJob := &trainer.TrainJob{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, gotTrainJob)).Should(gomega.Succeed())
+					gotTrainJob.Spec.Suspend = ptr.To(false)
+					g.Expect(k8sClient.Update(ctx, gotTrainJob)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Verifying JobSet suspend is updated but labels are not updated")
+				gomega.Eventually(func(g gomega.Gomega) {
+					jobSet := &jobsetv1alpha2.JobSet{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
+					g.Expect(*jobSet.Spec.Suspend).Should(gomega.BeFalse())
+					// Should still have original value from snapshot
+					g.Expect(jobSet.Labels).Should(gomega.HaveKeyWithValue("snapshot-test-marker", originalLabelValue),
+						"JobSet should use snapshot label value, not updated runtime value")
+					// Explicitly verify it's NOT the updated value
+					g.Expect(jobSet.Labels["snapshot-test-marker"]).ShouldNot(gomega.Equal(updatedLabelValue),
+						"JobSet should not pick up the updated runtime label")
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.It("Should create snapshots for existing TrainJobs that were created before the snapshot feature was added", func() {
+				ginkgo.By("Creating TrainingRuntime and TrainJob")
+				gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), trainingRuntime)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+
+				ginkgo.By("Waiting for initial snapshot to be created")
+				snapshotKey := client.ObjectKey{
+					Name:      trainJob.Name + "-runtime-snapshot",
+					Namespace: trainJob.Namespace,
+				}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, snapshotKey, &corev1.ConfigMap{})).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Simulating migration by deleting the snapshot ConfigMap")
+				cm := &corev1.ConfigMap{}
+				gomega.Expect(k8sClient.Get(ctx, snapshotKey, cm)).Should(gomega.Succeed())
+				gomega.Expect(k8sClient.Delete(ctx, cm)).Should(gomega.Succeed())
+
+				ginkgo.By("Verifying snapshot is gone")
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, snapshotKey, &corev1.ConfigMap{})).Should(testingutil.BeNotFoundError())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Triggering reconciliation to recreate snapshot")
+				gomega.Eventually(func(g gomega.Gomega) {
+					gotTrainJob := &trainer.TrainJob{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, gotTrainJob)).Should(gomega.Succeed())
+					if gotTrainJob.Annotations == nil {
+						gotTrainJob.Annotations = make(map[string]string)
+					}
+					gotTrainJob.Annotations["migration-test"] = "trigger"
+					g.Expect(k8sClient.Update(ctx, gotTrainJob)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Verifying snapshot ConfigMap is recreated")
+				gomega.Eventually(func(g gomega.Gomega) {
+					cm := &corev1.ConfigMap{}
+					g.Expect(k8sClient.Get(ctx, snapshotKey, cm)).Should(gomega.Succeed())
+					g.Expect(cm.Data).Should(gomega.HaveKey("runtime"))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
 	})
 })

--- a/test/integration/controller/trainjob_controller_test.go
+++ b/test/integration/controller/trainjob_controller_test.go
@@ -2699,6 +2699,13 @@ alpha-node-0-1.alpha slots=8
 					g.Expect(jobSet.Labels["snapshot-test-marker"]).ShouldNot(gomega.Equal(updatedLabelValue),
 						"JobSet should not pick up the updated runtime label")
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				ginkgo.By("Verifying snapshot ConfigMap is unchanged")
+				gomega.Eventually(func(g gomega.Gomega) {
+					cm := &corev1.ConfigMap{}
+					g.Expect(k8sClient.Get(ctx, snapshotKey, cm)).Should(gomega.Succeed())
+					g.Expect(cm.Data["runtime"]).Should(gomega.ContainSubstring(originalLabelValue))
+					g.Expect(cm.Data["runtime"]).ShouldNot(gomega.ContainSubstring(updatedLabelValue))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.It("Should create snapshots for existing TrainJobs that were created before the snapshot feature was added", func() {


### PR DESCRIPTION
## Summary

This PR implements the runtime snapshot mechanism proposed in [KEP-2599](https://github.com/kubeflow/trainer/pull/3428), which decouples the lifecycle of `TrainingRuntime` and `ClusterTrainingRuntime` objects from the `TrainJobs` that reference them.

## Motivation

**Problem:** Platform administrators need to update runtimes (e.g., patch container images, update configurations) without impacting running or paused TrainJobs. The current implementation has only implementation-level protections, and the originally proposed solution of immutable runtimes with versioning creates operational friction through runtime proliferation.

**Solution:** When a TrainJob is first reconciled, the controller creates a ConfigMap containing a YAML snapshot of the referenced runtime configuration. All subsequent reconciliations use this snapshot rather than fetching the runtime from the API server. This provides:
- **Decoupled lifecycles**: Runtimes can be updated or deleted without affecting existing TrainJobs
- **Self-contained TrainJobs**: Each TrainJob's configuration is fully contained in resources it owns
- **Migration support**: Existing TrainJobs automatically create snapshots on first reconciliation after upgrade

## Implementation Details

**Core changes:**
- `pkg/runtime/core/snapshot.go`: Snapshot creation and retrieval utilities
- `pkg/runtime/core/trainingruntime.go`: Snapshot-first reconciliation for TrainingRuntime
- `pkg/runtime/core/clustertrainingruntime.go`: Snapshot-first reconciliation for ClusterTrainingRuntime
- ConfigMap named `{trainjob-name}-runtime-snapshot` stores YAML-formatted runtime with ownerReference for automatic cleanup

**KEP updates:**
- Updated KEP-2170 to reflect snapshot-based approach instead of immutable runtimes with versioning

## Testing

All automated tests are passing:

**E2E Tests** (`test/e2e/e2e_test.go`):
- ✅ **Regression test that fails without this implementation**: Test verifies that updating a runtime's container image while a TrainJob is paused does not break the job when it resumes. The test creates a TrainJob, pauses it, updates the runtime with a new image (an immutable field in suspended JobSets), then resumes the job. Without the snapshot mechanism, this scenario fails because the controller attempts to apply the updated image to the existing JobSet, violating Kubernetes immutability constraints. **This test exposes a previously unrealized bug where runtime updates could break paused/running TrainJobs.**
- ✅ Test coverage for both TrainingRuntime and ClusterTrainingRuntime variants

**Integration Tests** (`test/integration/controller/trainjob_controller_test.go`):
- ✅ Snapshot ConfigMap created with correct structure and ownerReference
- ✅ Migration scenario: TrainJob without snapshot creates one on reconciliation
- ✅ Snapshot used for reconciliation instead of current runtime state

**Unit Tests** (`pkg/runtime/core/snapshot_test.go`):
- ✅ Comprehensive coverage of snapshot utilities (523 lines)
- ✅ Tests for happy path, error conditions, and validation

## References

- **KEP-2599**: https://github.com/kubeflow/trainer/pull/3428
- **Related Issue**: #2599

## Checklist

- [x] Implementation complete
- [x] E2E tests added and passing
- [x] Integration tests added and passing
- [x] Unit tests added and passing
- [x] KEP documentation updated
- [x] No breaking changes to existing APIs

---

**Note:** This implementation was developed with assistance from Claude Code (Anthropic's AI coding assistant).