### PR TITLE
fix: use the CI image in helm e2e tests

### DIFF
--- a/hack/e2e-setup-cluster.sh
+++ b/hack/e2e-setup-cluster.sh
@@ -230,7 +230,7 @@ elif [ "${INSTALL_METHOD}" = "helm" ]; then
     --set runtimes.defaultEnabled=true \
     --set runtimes.xgboost.image.repository=${XGBOOST_RUNTIME_CI_IMAGE_NAME} \
     --set runtimes.xgboost.image.tag=${CI_IMAGE_TAG} \
-    --set controllerManager.image.tag=${CI_IMAGE_TAG} \
+    --set image.tag=${CI_IMAGE_TAG} \
     --set manager.config.featureGates.TrainJobStatus=true \
     --wait
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Fixes the helm e2e tests so they use the CI image.

The hack/e2e-setup-cluster.sh script was using the wrong value which meant the helm deploy was using the default image tag which is currently the 2.2.0 release image.  

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #3587

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
