### PR TITLE
[release-2.2] fix(examples): use namespaced SQuAD dataset (#3560)

### DIFF
--- a/cmd/trainers/torchtune/requirements.txt
+++ b/cmd/trainers/torchtune/requirements.txt
@@ -1,4 +1,4 @@
 torchao==0.15.0
 torchtune==0.6.1
-bitsandbytes>=0.41.1
-kagglehub>=0.4.0
+bitsandbytes>=0.49.2
+kagglehub<1.0.0

--- a/examples/pytorch/question-answering/fine-tune-distilbert.ipynb
+++ b/examples/pytorch/question-answering/fine-tune-distilbert.ipynb
@@ -166,7 +166,7 @@
     "    )\n",
     "\n",
     "    # Download the dataset and tokenizer\n",
-    "    squad = load_dataset(\"squad\", split=\"train[:100]\")    \n",
+    "    squad = load_dataset(\"rajpurkar/squad\", split=\"train[:100]\")    \n",
     "\n",
     "    squad = squad.train_test_split(test_size=0.2, shuffle=False)\n",
     "    \n",


### PR DESCRIPTION
Cherry-pick this e2e fix to the release-2.2 branch: https://github.com/kubeflow/trainer/pull/3560


/assign @tenzen-y @astefanutti @XploY04 @Krishna-kg732   