### PR TITLE
fix(initializer): preserve model default ignore patterns

### DIFF
--- a/pkg/initializers/model/s3_test.py
+++ b/pkg/initializers/model/s3_test.py
@@ -22,6 +22,21 @@ import pkg.initializers.utils.utils as utils
 from pkg.initializers.model.s3 import S3
 
 
+def test_load_config_preserves_default_ignore_patterns(mock_env_vars):
+    mock_env_vars(STORAGE_URI="s3://models/path")
+
+    s3_model_instance = S3()
+    s3_model_instance.load_config()
+
+    assert s3_model_instance.config.ignore_patterns == [
+        "*.msgpack",
+        "*.h5",
+        "*.bin",
+        "*.pt",
+        "*.pth",
+    ]
+
+
 # Test cases for config loading
 @pytest.mark.parametrize(
     "test_name, test_config, expected",

--- a/pkg/initializers/utils/utils.py
+++ b/pkg/initializers/utils/utils.py
@@ -14,7 +14,7 @@
 
 import os
 from abc import ABC, abstractmethod
-from dataclasses import fields
+from dataclasses import MISSING, fields
 from typing import Dict
 
 STORAGE_URI_ENV = "STORAGE_URI"
@@ -62,11 +62,17 @@ def get_config_from_env(config) -> Dict:
         env_value = os.getenv(field.name.upper())
 
         if field.name == "ignore_patterns":
-            config_from_env[field.name] = (
-                [item.strip() for item in env_value.split(",") if item.strip()]
-                if env_value
-                else None
-            )
+            if env_value is None and (
+                field.default_factory is not MISSING
+                or (field.default is not MISSING and field.default is not None)
+            ):
+                continue
+            if env_value:
+                config_from_env[field.name] = [
+                    item.strip() for item in env_value.split(",") if item.strip()
+                ]
+            else:
+                config_from_env[field.name] = None
         else:
             config_from_env[field.name] = env_value if env_value else None
 

--- a/pkg/initializers/utils/utils_test.py
+++ b/pkg/initializers/utils/utils_test.py
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
+
 import pytest
 
 import pkg.initializers.types.types as types
 import pkg.initializers.utils.utils as utils
+
+
+@dataclass
+class IgnorePatternsWithDefault:
+    ignore_patterns: tuple[str, ...] = ("*.ckpt",)
 
 
 @pytest.mark.parametrize(
@@ -39,7 +46,6 @@ import pkg.initializers.utils.utils as utils
             {"STORAGE_URI": "hf://test"},
             {
                 "storage_uri": "hf://test",
-                "ignore_patterns": None,
                 "access_token": None,
             },
         ),
@@ -137,7 +143,6 @@ import pkg.initializers.utils.utils as utils
             {"STORAGE_URI": "s3://bucket/path"},
             {
                 "storage_uri": "s3://bucket/path",
-                "ignore_patterns": None,
                 "endpoint": None,
                 "access_key_id": None,
                 "secret_access_key": None,
@@ -151,3 +156,20 @@ def test_get_config_from_env(mock_env_vars, config_class, env_vars, expected):
     mock_env_vars(**env_vars)
     result = utils.get_config_from_env(config_class)
     assert result == expected
+
+
+def test_get_config_from_env_preserves_default_value(mock_env_vars):
+    mock_env_vars(IGNORE_PATTERNS=None)
+
+    result = utils.get_config_from_env(IgnorePatternsWithDefault)
+
+    assert result == {}
+    assert IgnorePatternsWithDefault(**result).ignore_patterns == ("*.ckpt",)
+
+
+def test_get_config_from_env_empty_ignore_patterns_clears_default(mock_env_vars):
+    mock_env_vars(STORAGE_URI="s3://bucket/path", IGNORE_PATTERNS="")
+
+    result = utils.get_config_from_env(types.S3ModelInitializer)
+
+    assert result["ignore_patterns"] is None


### PR DESCRIPTION
Small fix, but real.

Bug:
`get_config_from_env()` sets `ignore_patterns=None` when `IGNORE_PATTERNS` is unset.
That wipes the dataclass defaults for model initializers.

Why this matters:
`S3().load_config()` then leaves `ignore_patterns` empty, so S3 model downloads can pull `.bin` and `.pt` files too. Kinda sneaky, and pretty easy to hit with mixed checkpoint dirs.

Fix:
Keep the default-factory value for `ignore_patterns` when the env var is missing.
Added a regression test on the real `S3().load_config()` path.

Repro before this patch:
```python
import os
from pkg.initializers.model.s3 import S3

os.environ["STORAGE_URI"] = "s3://models/path"
os.environ.pop("IGNORE_PATTERNS", None)

s3 = S3()
s3.load_config()
print(s3.config.ignore_patterns)
```

Before: `None`
After: `['*.msgpack', '*.h5', '*.bin', '*.pt', '*.pth']`

Checks:
`PYTHONPATH=$(pwd) pytest -q pkg/initializers/utils/utils_test.py pkg/initializers/model/s3_test.py pkg/initializers/model/huggingface_test.py`
