### PR TITLE
fix(ci): Update Python API models version in make release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,8 +54,6 @@ jobs:
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "is-prerelease=${IS_PRERELEASE}" >> $GITHUB_OUTPUT
 
-
-
   tests:
     needs:
       - prepare
@@ -76,7 +74,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Run Python unit tests
         run: make test-python
@@ -96,7 +94,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install build tooling
         run: |
@@ -154,13 +152,6 @@ jobs:
           # Update Helm chart version.
           sed -i "s/^version: .*/version: ${VERSION}/" charts/kubeflow-trainer/Chart.yaml
           echo "Updated Helm chart version to $VERSION"
-
-          # Update Python API __version__.
-          # Normalize semver RC format to PEP 440: 2.2.0-rc.1 -> 2.2.0rc1
-          PY_VERSION=$(echo "$VERSION" | sed 's/-rc\.\([0-9]*\)/rc\1/')
-          sed -i "s/^__version__ = \".*\"/__version__ = \"${PY_VERSION}\"/" \
-            api/python_api/kubeflow_trainer_api/__init__.py
-          echo "Updated Python API __version__ to $PY_VERSION"
 
           # Update newTag in all manifest kustomization files.
           find manifests -type f -name '*.yaml' -exec sed -i "s/newTag: .*/newTag: $TAG/" {} +

--- a/Makefile
+++ b/Makefile
@@ -259,16 +259,27 @@ release: ## Create a release commit. Usage: make release VERSION=vX.Y.Z [GITHUB_
 	@if echo "$(VERSION)" | grep -E -q '\-rc\.[0-9]+$$'; then \
 		echo "Skipping changelog generation for RC release $(VERSION)"; \
 	else \
+		git fetch upstream --tags --prune; \
 		MAJOR_MINOR=$$(echo "$(VERSION)" | sed 's/^v//' | cut -d. -f1,2); \
 		CHANGELOG_PATH="CHANGELOG/CHANGELOG-$$MAJOR_MINOR.md"; \
 		RELEASE_BRANCH="release-$$MAJOR_MINOR"; \
-		PREV_TAG=$$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-rc*' "$$RELEASE_BRANCH" 2>/dev/null || true); \
-		if [ -n "$$PREV_TAG" ]; then \
-			CLIFF_SCOPE="$$PREV_TAG..$$RELEASE_BRANCH"; \
-			echo "Generating changelog for $(VERSION) (range: $$CLIFF_SCOPE)"; \
-		else \
+		RELEASE_SHA=$$(git rev-parse --verify --quiet "refs/heads/$$RELEASE_BRANCH" \
+			|| git rev-parse --verify --quiet "refs/remotes/upstream/$$RELEASE_BRANCH"); \
+		if [ -n "$$RELEASE_SHA" ]; then \
+			PREV_TAG=$$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*rc*' "$$RELEASE_SHA" 2>/dev/null || true); \
+			if [ -n "$$PREV_TAG" ]; then \
+				CLIFF_SCOPE="$$PREV_TAG..$$RELEASE_SHA"; \
+				echo "Generating changelog for $(VERSION) (range: $$PREV_TAG..$$RELEASE_BRANCH @ $$RELEASE_SHA)"; \
+			else \
+				CLIFF_SCOPE="--unreleased"; \
+				echo "Generating changelog for $(VERSION) (no prior tag on $$RELEASE_BRANCH; using --unreleased)"; \
+			fi; \
+		elif [ ! -f "$$CHANGELOG_PATH" ]; then \
 			CLIFF_SCOPE="--unreleased"; \
-			echo "Generating changelog for $(VERSION) (no prior tag on $$RELEASE_BRANCH; using --unreleased)"; \
+			echo "Generating changelog for $(VERSION) (new release line $$MAJOR_MINOR, branch $$RELEASE_BRANCH not created yet; using --unreleased)"; \
+		else \
+			echo "Error: branch $$RELEASE_BRANCH not found locally or on upstream, but $$CHANGELOG_PATH exists. Run: git fetch upstream $$RELEASE_BRANCH"; \
+			exit 1; \
 		fi; \
 		CLIFF_CMD="docker run --rm -u $$(id -u):$$(id -g) -v $(PROJECT_DIR):/app"; \
 		if [ -n "$(GITHUB_TOKEN)" ]; then \
@@ -278,8 +289,8 @@ release: ## Create a release commit. Usage: make release VERSION=vX.Y.Z [GITHUB_
 		if [ -f "$$CHANGELOG_PATH" ]; then \
 			$$CLIFF_CMD --prepend "$$CHANGELOG_PATH"; \
 		else \
-			mkdir -p CHANGELOG; \
 			$$CLIFF_CMD -o "$$CHANGELOG_PATH"; \
+			printf '%s\n' "$$(cat "$$CHANGELOG_PATH")" > "$$CHANGELOG_PATH"; \
 		fi; \
 		echo "Changelog generated at $$CHANGELOG_PATH"; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -283,6 +283,8 @@ release: ## Create a release commit. Usage: make release VERSION=vX.Y.Z [GITHUB_
 		fi; \
 		echo "Changelog generated at $$CHANGELOG_PATH"; \
 	fi
+	@echo "Regenerating files for $(VERSION)"
+	@$(MAKE) generate
 	@echo ""
 	@echo "Release commit for $(VERSION) is ready."
 	@echo "Review the changelog changes, then commit with:"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -63,7 +63,8 @@ make release VERSION=vX.Y.Z-rc.N GITHUB_TOKEN=<token>
 This will:
 
 1. Update `VERSION` to `vX.Y.Z`.
-2. Generate `CHANGELOG/CHANGELOG-X.Y.md` using `git-cliff` (skipped for RC releases).
+1. Update Python API models version to `X.Y.Z`
+1. Generate `CHANGELOG/CHANGELOG-X.Y.md` using `git-cliff` (skipped for RC releases).
 
 After reviewing the changes, create a signed commit and open a PR to the appropriate branch
 (e.g. `master` or `release-X.Y`):
@@ -83,7 +84,6 @@ When the `VERSION` change is merged, the
 4. Creates the `release-X.Y` branch (if it doesn't exist).
 5. Updates release assets on the release branch:
    - Helm chart version in `Chart.yaml`.
-   - Python API `__version__`.
    - Image tags and `configMapGenerator` version in manifests.
 6. Publishes the Python package to [PyPI](https://pypi.org/project/kubeflow-trainer-api/)
    using OIDC trusted publishing.


### PR DESCRIPTION
We should also upgrade the Python API models as part of `make release` command instead of GitHub CI action.

Ref: https://github.com/kubeflow/trainer/pull/3600

Otherwise, the pre-commit checks are failing.

/assign @Krishna-kg732 @tenzen-y @astefanutti @robert-bell @akshaychitneni @Sridhar1030 