### PR TITLE
chore(initializer): migrate dataset and model initializer Dockerfiles from pip to uv

### DIFF
--- a/cmd/initializers/dataset/Dockerfile
+++ b/cmd/initializers/dataset/Dockerfile
@@ -14,13 +14,16 @@
 
 FROM python:3.14-slim-bookworm
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
 WORKDIR /app
 
 # Copy the required Python modules.
-COPY cmd/initializers/dataset/requirements.txt .
+COPY cmd/initializers/dataset/pyproject.toml .
+COPY cmd/initializers/dataset/uv.lock .
 COPY pkg/initializers pkg/initializers
 
 # Install the needed packages.
-RUN pip install -r requirements.txt
+RUN uv sync --locked --no-dev --system
 
 ENTRYPOINT ["python", "-m", "pkg.initializers.dataset"]

--- a/cmd/initializers/model/Dockerfile
+++ b/cmd/initializers/model/Dockerfile
@@ -14,13 +14,16 @@
 
 FROM python:3.14-slim-bookworm
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
 WORKDIR /app
 
 # Copy the required Python modules.
-COPY cmd/initializers/model/requirements.txt .
+COPY cmd/initializers/model/pyproject.toml .
+COPY cmd/initializers/model/uv.lock .
 COPY pkg/initializers pkg/initializers
 
 # Install the needed packages.
-RUN pip install -r requirements.txt
+RUN uv sync --locked --no-dev --system
 
 ENTRYPOINT ["python", "-m", "pkg.initializers.model"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Migrates the dataset and model initializer Dockerfiles from pip to uv for installing Python dependencies, following the pip-tools to uv migration in #3541. 

This replaces `pip install -r requirements.txt` with `uv sync --frozen --no-dev` using the existing `pyproject.toml` and `uv.lock` files.

**Which issue(s) this PR fixes**:
Fixes #3589

**Checklist:**
- [ ] Docs included if any changes are user facing
