### PR TITLE
fix(docs): improve top nav light mode contrast and add hero logo

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -89,13 +89,13 @@ body {
     align-items: center;
     gap: 0.5rem;
     text-decoration: none !important;
-    color: var(--kf-heading) !important;
+    color: #e2e8f0 !important;
     font-weight: 600;
     font-size: 1.1rem;
 }
 
 .top-nav-brand:hover {
-    color: var(--kf-blue) !important;
+    color: #fff !important;
 }
 
 .top-nav-logo {
@@ -109,7 +109,7 @@ body {
 }
 
 .top-nav-links a {
-    color: var(--kf-text) !important;
+    color: #cbd5e0 !important;
     text-decoration: none !important;
     padding: 0.4rem 0.75rem;
     border-radius: 4px;
@@ -118,8 +118,8 @@ body {
 }
 
 .top-nav-links a:hover {
-    color: var(--kf-blue-dark) !important;
-    background: rgba(66, 153, 225, 0.12);
+    color: #fff !important;
+    background: rgba(255, 255, 255, 0.1);
 }
 
 @media (max-width: 768px) {
@@ -713,6 +713,17 @@ body:has(.landing-page) .article-container {
     margin-bottom: 1.5rem;
     backdrop-filter: blur(4px);
     background: rgba(255,255,255,0.05);
+}
+
+body:has(.landing-page) img.hidden {
+    display: none !important;
+}
+
+.hero-logo {
+    width: 200px;
+    height: auto;
+    margin: 1.5rem 0 2rem;
+    filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.3));
 }
 
 .hero-title {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@
    <div class="hero-content">
    <div class="hero-badge">Open Source &middot; CNCF Project</div>
    <h1 class="hero-title">Kubeflow Trainer</h1>
+   <img class="hero-logo" src="_images/trainer-logo.svg" alt="Kubeflow Trainer" />
    <p class="hero-tagline">The Kubernetes-native platform for distributed AI training and LLM fine-tuning at any scale.</p>
    <div class="hero-actions">
    <a href="getting-started/index.html" class="btn btn-primary">Get Started <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg></a>
@@ -146,6 +147,13 @@
    </footer>
 
    </div>
+
+.. only:: html
+
+   .. Ensure Sphinx copies the logo to _images/
+   .. image:: images/trainer-logo.svg
+      :width: 0
+      :class: hidden
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
Fixes two issues on the live site (trainer.kubeflow.org):
- Top nav links were invisible in light mode (dark text on dark background)
- Added Kubeflow Trainer logo to the frontpage hero section
Ref: #3308 , #3255

<img width="872" height="179" alt="image" src="https://github.com/user-attachments/assets/c5ae106c-c948-4aa7-9799-19991aad1b09" />
<img width="1368" height="814" alt="image" src="https://github.com/user-attachments/assets/178a4f99-8f92-4118-a293-c56997367d4b" />

