### PR TITLE
fix: do not declare webhook cert data in Helm chart Secret

### DIFF
--- a/charts/kubeflow-trainer/templates/webhook/secret.yaml
+++ b/charts/kubeflow-trainer/templates/webhook/secret.yaml
@@ -21,8 +21,3 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "trainer.webhook.labels" . | nindent 4 }}
-data:
-  ca.crt: ""
-  ca.key: ""
-  tls.crt: ""
-  tls.key: ""

--- a/charts/kubeflow-trainer/tests/webhook/secret_test.yaml
+++ b/charts/kubeflow-trainer/tests/webhook/secret_test.yaml
@@ -31,3 +31,8 @@ tests:
           kind: Secret
           name: kubeflow-trainer-webhook-cert
           namespace: kubeflow-system
+
+  - it: Should not declare certificate data, which is owned by the cert rotator
+    asserts:
+      - notExists:
+          path: data


### PR DESCRIPTION
The webhook certificate Secret declared empty `ca.crt`, `ca.key`, `tls.crt`, and `tls.key` keys. Under Helm v4, which defaults to server-side apply, this makes Helm the field manager of those keys and conflicts with the cert-controller rotator that owns and writes them at runtime — breaking `helm upgrade`. Since the rotator only updates the Secret (never creates it), the fix keeps the empty Secret object but removes the `data` block, mirroring the same fix in kubernetes-sigs/jobset#1248.

_This PR was created using AI tools._