### PR TITLE
chore(test): add helm unit tests for torchtune llama3.2-1b runtime

### DIFF
--- a/charts/kubeflow-trainer/tests/runtimes/torchtune_llama3_2_1B_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torchtune_llama3_2_1B_test.yaml
@@ -53,6 +53,11 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
+      - isKind:
+          of: ClusterTrainingRuntime
+      - equal:
+          path: metadata.name
+          value: torchtune-llama3.2-1b
 
   - it: Should have correct framework label
     set:
@@ -96,13 +101,36 @@ tests:
           path: spec.template.spec.replicatedJobs[2].name
           value: node
 
-  - it: Should use correct model STORAGE_URI
+  - it: Should make the node job depend on both initializers completing
     set:
       runtimes:
         torchtuneDistributed:
           llama3_2_1B:
             enabled: true
     asserts:
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].dependsOn[0].name
+          value: dataset-initializer
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].dependsOn[0].status
+          value: Complete
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].dependsOn[1].name
+          value: model-initializer
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].dependsOn[1].status
+          value: Complete
+
+  - it: Should use correct dataset and model STORAGE_URI
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_1B:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.replicatedJobs[0].template.spec.template.spec.containers[0].env[0].value
+          value: hf://tatsu-lab/alpaca
       - equal:
           path: spec.template.spec.replicatedJobs[1].template.spec.template.spec.containers[0].env[0].value
           value: hf://meta-llama/Llama-3.2-1B-Instruct

--- a/charts/kubeflow-trainer/tests/runtimes/torchtune_llama3_2_1B_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torchtune_llama3_2_1B_test.yaml
@@ -1,0 +1,145 @@
+#
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test torchtune-llama3.2-1b ClusterTrainingRuntime
+templates:
+  - templates/runtimes/torchtune/llama3_2_1B.yaml
+release:
+  name: kubeflow-trainer
+  namespace: kubeflow-trainer
+tests:
+  - it: Should not render ClusterTrainingRuntime when llama3_2_1B.enabled is false
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_1B:
+            enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should render ClusterTrainingRuntime when llama3_2_1B.enabled is true
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_1B:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterTrainingRuntime
+      - equal:
+          path: metadata.name
+          value: torchtune-llama3.2-1b
+
+  - it: Should render ClusterTrainingRuntime when runtimes.defaultEnabled is true
+    set:
+      runtimes:
+        defaultEnabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: Should have correct framework label
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_1B:
+            enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["trainer.kubeflow.org/framework"]
+          value: torchtune
+
+  - it: Should have correct mlPolicy configuration
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_1B:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.mlPolicy.numNodes
+          value: 1
+      - equal:
+          path: spec.mlPolicy.torch
+          value: {}
+
+  - it: Should have dataset-initializer, model-initializer and node replicatedJobs
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_1B:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.replicatedJobs[0].name
+          value: dataset-initializer
+      - equal:
+          path: spec.template.spec.replicatedJobs[1].name
+          value: model-initializer
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].name
+          value: node
+
+  - it: Should use correct model STORAGE_URI
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_1B:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.replicatedJobs[1].template.spec.template.spec.containers[0].env[0].value
+          value: hf://meta-llama/Llama-3.2-1B-Instruct
+
+  - it: Should use the correct TorchTune recipe config in the node command
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_1B:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.replicatedJobs[2].template.spec.template.spec.containers[0].command
+          content: llama3_2/1B_full
+
+  - it: Should request GPU resources for the node container
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_1B:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].template.spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+          value: 2
+
+  - it: Should use custom image tag when specified
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_1B:
+            enabled: true
+          image:
+            registry: ghcr.io
+            repository: kubeflow/trainer/torchtune-trainer
+            tag: "v1.0.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].template.spec.template.spec.containers[0].image
+          value: ghcr.io/kubeflow/trainer/torchtune-trainer:v1.0.0

--- a/charts/kubeflow-trainer/tests/runtimes/torchtune_llama3_2_3B_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torchtune_llama3_2_3B_test.yaml
@@ -1,0 +1,173 @@
+#
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test torchtune-llama3.2-3b ClusterTrainingRuntime
+templates:
+  - templates/runtimes/torchtune/llama3_2_3B.yaml
+release:
+  name: kubeflow-trainer
+  namespace: kubeflow-trainer
+tests:
+  - it: Should not render ClusterTrainingRuntime when llama3_2_3B.enabled is false
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_3B:
+            enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should render ClusterTrainingRuntime when llama3_2_3B.enabled is true
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_3B:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterTrainingRuntime
+      - equal:
+          path: metadata.name
+          value: torchtune-llama3.2-3b
+
+  - it: Should render ClusterTrainingRuntime when runtimes.defaultEnabled is true
+    set:
+      runtimes:
+        defaultEnabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterTrainingRuntime
+      - equal:
+          path: metadata.name
+          value: torchtune-llama3.2-3b
+
+  - it: Should have correct framework label
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_3B:
+            enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["trainer.kubeflow.org/framework"]
+          value: torchtune
+
+  - it: Should have correct mlPolicy configuration
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_3B:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.mlPolicy.numNodes
+          value: 1
+      - equal:
+          path: spec.mlPolicy.torch
+          value: {}
+
+  - it: Should have dataset-initializer, model-initializer and node replicatedJobs
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_3B:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.replicatedJobs[0].name
+          value: dataset-initializer
+      - equal:
+          path: spec.template.spec.replicatedJobs[1].name
+          value: model-initializer
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].name
+          value: node
+
+  - it: Should make the node job depend on both initializers completing
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_3B:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].dependsOn[0].name
+          value: dataset-initializer
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].dependsOn[0].status
+          value: Complete
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].dependsOn[1].name
+          value: model-initializer
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].dependsOn[1].status
+          value: Complete
+
+  - it: Should use correct dataset and model STORAGE_URI
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_3B:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.replicatedJobs[0].template.spec.template.spec.containers[0].env[0].value
+          value: hf://tatsu-lab/alpaca
+      - equal:
+          path: spec.template.spec.replicatedJobs[1].template.spec.template.spec.containers[0].env[0].value
+          value: hf://meta-llama/Llama-3.2-3B-Instruct
+
+  - it: Should use the correct TorchTune recipe config in the node command
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_3B:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.replicatedJobs[2].template.spec.template.spec.containers[0].command
+          content: llama3_2/3B_full
+
+  - it: Should request GPU resources for the node container
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_3B:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].template.spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+          value: 2
+
+  - it: Should use custom image tag when specified
+    set:
+      runtimes:
+        torchtuneDistributed:
+          llama3_2_3B:
+            enabled: true
+          image:
+            registry: ghcr.io
+            repository: kubeflow/trainer/torchtune-trainer
+            tag: "v1.0.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].template.spec.template.spec.containers[0].image
+          value: ghcr.io/kubeflow/trainer/torchtune-trainer:v1.0.0

--- a/charts/kubeflow-trainer/tests/runtimes/torchtune_qwen2_5_1.5B_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torchtune_qwen2_5_1.5B_test.yaml
@@ -1,0 +1,173 @@
+#
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test torchtune-qwen2.5-1.5b ClusterTrainingRuntime
+templates:
+  - templates/runtimes/torchtune/qwen2_5_1.5B.yaml
+release:
+  name: kubeflow-trainer
+  namespace: kubeflow-trainer
+tests:
+  - it: Should not render ClusterTrainingRuntime when qwen2_5_1_5B.enabled is false
+    set:
+      runtimes:
+        torchtuneDistributed:
+          qwen2_5_1_5B:
+            enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should render ClusterTrainingRuntime when qwen2_5_1_5B.enabled is true
+    set:
+      runtimes:
+        torchtuneDistributed:
+          qwen2_5_1_5B:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterTrainingRuntime
+      - equal:
+          path: metadata.name
+          value: torchtune-qwen2.5-1.5b
+
+  - it: Should render ClusterTrainingRuntime when runtimes.defaultEnabled is true
+    set:
+      runtimes:
+        defaultEnabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterTrainingRuntime
+      - equal:
+          path: metadata.name
+          value: torchtune-qwen2.5-1.5b
+
+  - it: Should have correct framework label
+    set:
+      runtimes:
+        torchtuneDistributed:
+          qwen2_5_1_5B:
+            enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["trainer.kubeflow.org/framework"]
+          value: torchtune
+
+  - it: Should have correct mlPolicy configuration
+    set:
+      runtimes:
+        torchtuneDistributed:
+          qwen2_5_1_5B:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.mlPolicy.numNodes
+          value: 1
+      - equal:
+          path: spec.mlPolicy.torch
+          value: {}
+
+  - it: Should have dataset-initializer, model-initializer and node replicatedJobs
+    set:
+      runtimes:
+        torchtuneDistributed:
+          qwen2_5_1_5B:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.replicatedJobs[0].name
+          value: dataset-initializer
+      - equal:
+          path: spec.template.spec.replicatedJobs[1].name
+          value: model-initializer
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].name
+          value: node
+
+  - it: Should make the node job depend on both initializers completing
+    set:
+      runtimes:
+        torchtuneDistributed:
+          qwen2_5_1_5B:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].dependsOn[0].name
+          value: dataset-initializer
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].dependsOn[0].status
+          value: Complete
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].dependsOn[1].name
+          value: model-initializer
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].dependsOn[1].status
+          value: Complete
+
+  - it: Should use correct dataset and model STORAGE_URI
+    set:
+      runtimes:
+        torchtuneDistributed:
+          qwen2_5_1_5B:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.replicatedJobs[0].template.spec.template.spec.containers[0].env[0].value
+          value: hf://tatsu-lab/alpaca
+      - equal:
+          path: spec.template.spec.replicatedJobs[1].template.spec.template.spec.containers[0].env[0].value
+          value: hf://Qwen/Qwen2.5-1.5B-Instruct
+
+  - it: Should use the correct TorchTune recipe config in the node command
+    set:
+      runtimes:
+        torchtuneDistributed:
+          qwen2_5_1_5B:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.replicatedJobs[2].template.spec.template.spec.containers[0].command
+          content: qwen2_5/1.5B_full
+
+  - it: Should request GPU resources for the node container
+    set:
+      runtimes:
+        torchtuneDistributed:
+          qwen2_5_1_5B:
+            enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].template.spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+          value: 2
+
+  - it: Should use custom image tag when specified
+    set:
+      runtimes:
+        torchtuneDistributed:
+          qwen2_5_1_5B:
+            enabled: true
+          image:
+            registry: ghcr.io
+            repository: kubeflow/trainer/torchtune-trainer
+            tag: "v1.0.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.replicatedJobs[2].template.spec.template.spec.containers[0].image
+          value: ghcr.io/kubeflow/trainer/torchtune-trainer:v1.0.0


### PR DESCRIPTION
## Summary

Adds helm-unittest coverage for the TorchTune **Llama 3.2 1B** `ClusterTrainingRuntime`. The torchtune runtime templates had no Helm test coverage, unlike the other runtimes (torch, mlx, deepspeed, xgboost) under `charts/kubeflow-trainer/tests/runtimes/`. `make helm-unittest` runs in CI.

## Tests

10 cases: render gating (per-runtime `enabled` + `defaultEnabled`), kind/name, framework label, `mlPolicy`, the three `replicatedJobs`, model `STORAGE_URI`, recipe config, GPU limit, and custom image tag override. All green locally (`helm unittest`: 16 suites / 82 tests).