### PR TITLE
fix(runtimes): propagate PodSets.Count into TemplateSpec Parallelism/Completions

### DIFF
--- a/pkg/runtime/core/trainingruntime.go
+++ b/pkg/runtime/core/trainingruntime.go
@@ -109,6 +109,9 @@ func (r *TrainingRuntime) RuntimeInfo(
 	if err = r.framework.RunEnforceMLPolicyPlugins(info, trainJob); err != nil {
 		return nil, err
 	}
+	if err = r.framework.RunBuildParallelCountPlugins(info); err != nil {
+		return nil, err
+	}
 
 	if err = r.framework.RunEnforcePodGroupPolicyPlugins(info, trainJob); err != nil {
 		return nil, err

--- a/pkg/runtime/core/trainingruntime.go
+++ b/pkg/runtime/core/trainingruntime.go
@@ -109,10 +109,6 @@ func (r *TrainingRuntime) RuntimeInfo(
 	if err = r.framework.RunEnforceMLPolicyPlugins(info, trainJob); err != nil {
 		return nil, err
 	}
-	if err = r.framework.RunBuildParallelCountPlugins(info); err != nil {
-		return nil, err
-	}
-
 	if err = r.framework.RunEnforcePodGroupPolicyPlugins(info, trainJob); err != nil {
 		return nil, err
 	}

--- a/pkg/runtime/framework/core/framework.go
+++ b/pkg/runtime/framework/core/framework.go
@@ -43,6 +43,7 @@ type Framework struct {
 	customValidationPlugins      []framework.CustomValidationPlugin
 	watchExtensionPlugins        []framework.WatchExtensionPlugin
 	podNetworkPlugins            []framework.PodNetworkPlugin
+	buildParallelCountPlugins    []framework.BuildParallelCountPlugin
 	componentBuilderPlugins      []framework.ComponentBuilderPlugin
 	trainJobStatusPlugin         framework.TrainJobStatusPlugin
 }
@@ -76,6 +77,9 @@ func New(ctx context.Context, c client.Client, r fwkplugins.Registry, indexer cl
 		}
 		if p, ok := plugin.(framework.PodNetworkPlugin); ok {
 			f.podNetworkPlugins = append(f.podNetworkPlugins, p)
+		}
+		if p, ok := plugin.(framework.BuildParallelCountPlugin); ok {
+			f.buildParallelCountPlugins = append(f.buildParallelCountPlugins, p)
 		}
 		if p, ok := plugin.(framework.ComponentBuilderPlugin); ok {
 			f.componentBuilderPlugins = append(f.componentBuilderPlugins, p)
@@ -127,6 +131,15 @@ func (f *Framework) RunCustomValidationPlugins(ctx context.Context, info *runtim
 func (f *Framework) RunPodNetworkPlugins(info *runtime.Info, trainJob *trainer.TrainJob) error {
 	for _, plugin := range f.podNetworkPlugins {
 		if err := plugin.IdentifyPodNetwork(info, trainJob); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *Framework) RunBuildParallelCountPlugins(info *runtime.Info) error {
+	for _, plugin := range f.buildParallelCountPlugins {
+		if err := plugin.BuildParallelCount(info); err != nil {
 			return err
 		}
 	}

--- a/pkg/runtime/framework/core/framework.go
+++ b/pkg/runtime/framework/core/framework.go
@@ -43,7 +43,6 @@ type Framework struct {
 	customValidationPlugins      []framework.CustomValidationPlugin
 	watchExtensionPlugins        []framework.WatchExtensionPlugin
 	podNetworkPlugins            []framework.PodNetworkPlugin
-	buildParallelCountPlugins    []framework.BuildParallelCountPlugin
 	componentBuilderPlugins      []framework.ComponentBuilderPlugin
 	trainJobStatusPlugin         framework.TrainJobStatusPlugin
 }
@@ -77,9 +76,6 @@ func New(ctx context.Context, c client.Client, r fwkplugins.Registry, indexer cl
 		}
 		if p, ok := plugin.(framework.PodNetworkPlugin); ok {
 			f.podNetworkPlugins = append(f.podNetworkPlugins, p)
-		}
-		if p, ok := plugin.(framework.BuildParallelCountPlugin); ok {
-			f.buildParallelCountPlugins = append(f.buildParallelCountPlugins, p)
 		}
 		if p, ok := plugin.(framework.ComponentBuilderPlugin); ok {
 			f.componentBuilderPlugins = append(f.componentBuilderPlugins, p)
@@ -137,16 +133,12 @@ func (f *Framework) RunPodNetworkPlugins(info *runtime.Info, trainJob *trainer.T
 	return nil
 }
 
-func (f *Framework) RunBuildParallelCountPlugins(info *runtime.Info) error {
-	for _, plugin := range f.buildParallelCountPlugins {
-		if err := plugin.BuildParallelCount(info); err != nil {
-			return err
+func (f *Framework) RunComponentBuilderPlugins(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
+	for _, plugin := range f.componentBuilderPlugins {
+		if err := plugin.SyncParallelCount(info); err != nil {
+			return nil, err
 		}
 	}
-	return nil
-}
-
-func (f *Framework) RunComponentBuilderPlugins(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
 	var objs []apiruntime.ApplyConfiguration
 	for _, plugin := range f.componentBuilderPlugins {
 		components, err := plugin.Build(ctx, info, trainJob)

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -121,6 +121,9 @@ func TestNew(t *testing.T) {
 				podNetworkPlugins: []framework.PodNetworkPlugin{
 					&jobset.JobSet{},
 				},
+				buildParallelCountPlugins: []framework.BuildParallelCountPlugin{
+					&jobset.JobSet{},
+				},
 				componentBuilderPlugins: []framework.ComponentBuilderPlugin{
 					&flux.Flux{},
 					&coscheduling.CoScheduling{},

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -121,9 +121,6 @@ func TestNew(t *testing.T) {
 				podNetworkPlugins: []framework.PodNetworkPlugin{
 					&jobset.JobSet{},
 				},
-				buildParallelCountPlugins: []framework.BuildParallelCountPlugin{
-					&jobset.JobSet{},
-				},
 				componentBuilderPlugins: []framework.ComponentBuilderPlugin{
 					&flux.Flux{},
 					&coscheduling.CoScheduling{},

--- a/pkg/runtime/framework/interface.go
+++ b/pkg/runtime/framework/interface.go
@@ -56,6 +56,11 @@ type PodNetworkPlugin interface {
 	IdentifyPodNetwork(info *runtime.Info, trainJob *trainer.TrainJob) error
 }
 
+type BuildParallelCountPlugin interface {
+	Plugin
+	BuildParallelCount(info *runtime.Info) error
+}
+
 type ComponentBuilderPlugin interface {
 	Plugin
 	Build(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error)

--- a/pkg/runtime/framework/interface.go
+++ b/pkg/runtime/framework/interface.go
@@ -56,13 +56,10 @@ type PodNetworkPlugin interface {
 	IdentifyPodNetwork(info *runtime.Info, trainJob *trainer.TrainJob) error
 }
 
-type BuildParallelCountPlugin interface {
-	Plugin
-	BuildParallelCount(info *runtime.Info) error
-}
-
 type ComponentBuilderPlugin interface {
 	Plugin
+	// SyncParallelCount propagates PodSets.Count into template-level Parallelism/Completions.
+	SyncParallelCount(info *runtime.Info) error
 	Build(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error)
 }
 

--- a/pkg/runtime/framework/plugins/coscheduling/coscheduling.go
+++ b/pkg/runtime/framework/plugins/coscheduling/coscheduling.go
@@ -90,6 +90,8 @@ func (c *CoScheduling) EnforcePodGroupPolicy(info *runtime.Info, trainJob *train
 	return nil
 }
 
+func (c *CoScheduling) SyncParallelCount(_ *runtime.Info) error { return nil }
+
 func (c *CoScheduling) Build(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
 	if info == nil || info.RuntimePolicy.PodGroupPolicy == nil || info.RuntimePolicy.PodGroupPolicy.Coscheduling == nil || trainJob == nil {
 		return nil, nil

--- a/pkg/runtime/framework/plugins/flux/flux.go
+++ b/pkg/runtime/framework/plugins/flux/flux.go
@@ -210,6 +210,8 @@ func (f *Flux) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) e
 	return nil
 }
 
+func (f *Flux) SyncParallelCount(_ *runtime.Info) error { return nil }
+
 // Build creates the extra config map (configuration) and curve secret for Flux.
 func (f *Flux) Build(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
 

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -65,7 +65,6 @@ type JobSet struct {
 
 var _ framework.WatchExtensionPlugin = (*JobSet)(nil)
 var _ framework.PodNetworkPlugin = (*JobSet)(nil)
-var _ framework.BuildParallelCountPlugin = (*JobSet)(nil)
 var _ framework.ComponentBuilderPlugin = (*JobSet)(nil)
 var _ framework.TrainJobStatusPlugin = (*JobSet)(nil)
 var _ framework.CustomValidationPlugin = (*JobSet)(nil)
@@ -253,7 +252,7 @@ func (j *JobSet) IdentifyPodNetwork(info *runtime.Info, trainJob *trainer.TrainJ
 	return nil
 }
 
-func (j *JobSet) BuildParallelCount(info *runtime.Info) error {
+func (j *JobSet) SyncParallelCount(info *runtime.Info) error {
 	if info == nil {
 		return nil
 	}
@@ -309,10 +308,6 @@ func (j *JobSet) Build(ctx context.Context, info *runtime.Info, trainJob *traine
 	}
 
 	for psIdx, ps := range info.TemplateSpec.PodSets {
-		if ps.Count != nil {
-			jobSetSpec.ReplicatedJobs[psIdx].Template.Spec.Parallelism = ps.Count
-			jobSetSpec.ReplicatedJobs[psIdx].Template.Spec.Completions = ps.Count
-		}
 		apply.UpsertVolumes(&jobSetSpec.ReplicatedJobs[psIdx].Template.Spec.Template.Spec.Volumes, ps.Volumes...)
 		for containerIdx, container := range ps.Containers {
 			if len(container.Command) > 0 {

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -65,6 +65,7 @@ type JobSet struct {
 
 var _ framework.WatchExtensionPlugin = (*JobSet)(nil)
 var _ framework.PodNetworkPlugin = (*JobSet)(nil)
+var _ framework.BuildParallelCountPlugin = (*JobSet)(nil)
 var _ framework.ComponentBuilderPlugin = (*JobSet)(nil)
 var _ framework.TrainJobStatusPlugin = (*JobSet)(nil)
 var _ framework.CustomValidationPlugin = (*JobSet)(nil)
@@ -246,6 +247,29 @@ func (j *JobSet) IdentifyPodNetwork(info *runtime.Info, trainJob *trainer.TrainJ
 						return
 					}
 				}
+			}
+		}
+	}
+	return nil
+}
+
+func (j *JobSet) BuildParallelCount(info *runtime.Info) error {
+	if info == nil {
+		return nil
+	}
+	jobSetSpec, ok := runtime.TemplateSpecApply[jobsetv1alpha2ac.JobSetSpecApplyConfiguration](info)
+	if !ok || jobSetSpec == nil {
+		return nil
+	}
+	for _, ps := range info.TemplateSpec.PodSets {
+		if ps.Count == nil {
+			continue
+		}
+		for rJobIdx := range jobSetSpec.ReplicatedJobs {
+			if jobSetSpec.ReplicatedJobs[rJobIdx].Name != nil && *jobSetSpec.ReplicatedJobs[rJobIdx].Name == ps.Name {
+				jobSetSpec.ReplicatedJobs[rJobIdx].Template.Spec.Parallelism = ps.Count
+				jobSetSpec.ReplicatedJobs[rJobIdx].Template.Spec.Completions = ps.Count
+				break
 			}
 		}
 	}

--- a/pkg/runtime/framework/plugins/jobset/jobset_test.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset_test.go
@@ -1916,8 +1916,6 @@ func TestBuild(t *testing.T) {
 								Replicas: 0,
 								Template: batchv1.JobTemplateSpec{
 									Spec: batchv1.JobSpec{
-										Parallelism: ptr.To[int32](2),
-										Completions: ptr.To[int32](2),
 										Template: corev1.PodTemplateSpec{
 											Spec: corev1.PodSpec{
 												InitContainers: []corev1.Container{
@@ -2011,8 +2009,6 @@ func TestBuild(t *testing.T) {
 								Replicas: 0,
 								Template: batchv1.JobTemplateSpec{
 									Spec: batchv1.JobSpec{
-										Parallelism: ptr.To[int32](1),
-										Completions: ptr.To[int32](1),
 										Template: corev1.PodTemplateSpec{
 											Spec: corev1.PodSpec{
 												InitContainers: []corev1.Container{
@@ -2098,8 +2094,6 @@ func TestBuild(t *testing.T) {
 								Replicas: 0,
 								Template: batchv1.JobTemplateSpec{
 									Spec: batchv1.JobSpec{
-										Parallelism: ptr.To[int32](3),
-										Completions: ptr.To[int32](3),
 										Template: corev1.PodTemplateSpec{
 											Spec: corev1.PodSpec{
 												InitContainers: []corev1.Container{
@@ -2192,7 +2186,7 @@ func TestBuild(t *testing.T) {
 	}
 }
 
-func TestBuildParallelCount(t *testing.T) {
+func TestSyncParallelCount(t *testing.T) {
 	cases := map[string]struct {
 		info      *runtime.Info
 		wantInfo  *runtime.Info
@@ -2503,7 +2497,7 @@ func TestBuildParallelCount(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to initialize JobSet plugin: %v", err)
 			}
-			err = p.(framework.BuildParallelCountPlugin).BuildParallelCount(tc.info)
+			err = p.(framework.ComponentBuilderPlugin).SyncParallelCount(tc.info)
 			if diff := cmp.Diff(tc.wantError, err, cmpopts.EquateErrors()); len(diff) != 0 {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}
@@ -2511,7 +2505,7 @@ func TestBuildParallelCount(t *testing.T) {
 				cmpopts.SortSlices(func(a, b string) bool { return a < b }),
 				cmpopts.SortMaps(func(a, b string) bool { return a < b }),
 			); len(diff) != 0 {
-				t.Errorf("Unexpected Info from BuildParallelCount (-want,+got):\n%s", diff)
+				t.Errorf("Unexpected Info from SyncParallelCount (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/runtime/framework/plugins/jobset/jobset_test.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset_test.go
@@ -2191,3 +2191,328 @@ func TestBuild(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildParallelCount(t *testing.T) {
+	cases := map[string]struct {
+		info      *runtime.Info
+		wantInfo  *runtime.Info
+		wantError error
+	}{
+		"no action when info is nil": {},
+		"no action when template.spec is not JobSet": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:  constants.Node,
+							Count: ptr.To[int32](3),
+						},
+					},
+					ObjApply: batchv1ac.JobSpec(),
+				},
+			},
+			wantInfo: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:  constants.Node,
+							Count: ptr.To[int32](3),
+						},
+					},
+					ObjApply: batchv1ac.JobSpec(),
+				},
+			},
+		},
+		"parallelism and completions are synced for matching replicatedJob by name": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:  constants.Node,
+							Count: ptr.To[int32](4),
+						},
+					},
+					ObjApply: jobsetv1alpha2ac.JobSetSpec().
+						WithReplicatedJobs(
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithName(constants.Node).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(1).
+										WithCompletions(1).
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+						),
+				},
+			},
+			wantInfo: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:  constants.Node,
+							Count: ptr.To[int32](4),
+						},
+					},
+					ObjApply: jobsetv1alpha2ac.JobSetSpec().
+						WithReplicatedJobs(
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithName(constants.Node).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(4).
+										WithCompletions(4).
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+						),
+				},
+			},
+		},
+		"multiple podSets synced to corresponding replicatedJobs": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:  constants.Launcher,
+							Count: ptr.To[int32](1),
+						},
+						{
+							Name:  constants.Node,
+							Count: ptr.To[int32](5),
+						},
+					},
+					ObjApply: jobsetv1alpha2ac.JobSetSpec().
+						WithReplicatedJobs(
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithName(constants.Launcher).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(1).
+										WithCompletions(1).
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithName(constants.Node).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(2).
+										WithCompletions(2).
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+						),
+				},
+			},
+			wantInfo: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:  constants.Launcher,
+							Count: ptr.To[int32](1),
+						},
+						{
+							Name:  constants.Node,
+							Count: ptr.To[int32](5),
+						},
+					},
+					ObjApply: jobsetv1alpha2ac.JobSetSpec().
+						WithReplicatedJobs(
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithName(constants.Launcher).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(1).
+										WithCompletions(1).
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithName(constants.Node).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(5).
+										WithCompletions(5).
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+						),
+				},
+			},
+		},
+		"podSet with nil count is skipped": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name: constants.Node,
+						},
+					},
+					ObjApply: jobsetv1alpha2ac.JobSetSpec().
+						WithReplicatedJobs(
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithName(constants.Node).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(2).
+										WithCompletions(2).
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+						),
+				},
+			},
+			wantInfo: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name: constants.Node,
+						},
+					},
+					ObjApply: jobsetv1alpha2ac.JobSetSpec().
+						WithReplicatedJobs(
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithName(constants.Node).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(2).
+										WithCompletions(2).
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+						),
+				},
+			},
+		},
+		"podSet with no matching replicatedJob name is skipped": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:  "non-existent",
+							Count: ptr.To[int32](3),
+						},
+					},
+					ObjApply: jobsetv1alpha2ac.JobSetSpec().
+						WithReplicatedJobs(
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithName(constants.Node).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(1).
+										WithCompletions(1).
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+						),
+				},
+			},
+			wantInfo: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:  "non-existent",
+							Count: ptr.To[int32](3),
+						},
+					},
+					ObjApply: jobsetv1alpha2ac.JobSetSpec().
+						WithReplicatedJobs(
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithName(constants.Node).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(1).
+										WithCompletions(1).
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+						),
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			var cancel func()
+			ctx, cancel = context.WithCancel(ctx)
+			t.Cleanup(cancel)
+			cli := utiltesting.NewClientBuilder().Build()
+			p, err := New(ctx, cli, nil, nil)
+			if err != nil {
+				t.Fatalf("Failed to initialize JobSet plugin: %v", err)
+			}
+			err = p.(framework.BuildParallelCountPlugin).BuildParallelCount(tc.info)
+			if diff := cmp.Diff(tc.wantError, err, cmpopts.EquateErrors()); len(diff) != 0 {
+				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantInfo, tc.info,
+				cmpopts.SortSlices(func(a, b string) bool { return a < b }),
+				cmpopts.SortMaps(func(a, b string) bool { return a < b }),
+			); len(diff) != 0 {
+				t.Errorf("Unexpected Info from BuildParallelCount (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/runtime/framework/plugins/mpi/mpi.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi.go
@@ -253,6 +253,8 @@ func (m *MPI) ReconcilerBuilders() []runtime.ReconcilerBuilder {
 	}
 }
 
+func (m *MPI) SyncParallelCount(_ *runtime.Info) error { return nil }
+
 func (m *MPI) Build(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
 	if info == nil || info.RuntimePolicy.MLPolicySource == nil || info.RuntimePolicy.MLPolicySource.MPI == nil {
 		return nil, nil

--- a/pkg/runtime/framework/plugins/trainjobstatus/trainjobstatus.go
+++ b/pkg/runtime/framework/plugins/trainjobstatus/trainjobstatus.go
@@ -98,6 +98,8 @@ func (p *Status) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob)
 	return nil
 }
 
+func (p *Status) SyncParallelCount(_ *runtime.Info) error { return nil }
+
 func (p *Status) Build(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
 	if info == nil || trainJob == nil {
 		return nil, nil

--- a/pkg/runtime/framework/plugins/volcano/volcano.go
+++ b/pkg/runtime/framework/plugins/volcano/volcano.go
@@ -138,6 +138,8 @@ func (v *Volcano) EnforcePodGroupPolicy(info *runtime.Info, trainJob *trainer.Tr
 	return nil
 }
 
+func (v *Volcano) SyncParallelCount(_ *runtime.Info) error { return nil }
+
 func (v *Volcano) Build(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
 	if info == nil || info.RuntimePolicy.PodGroupPolicy == nil || info.RuntimePolicy.PodGroupPolicy.Volcano == nil || trainJob == nil {
 		return nil, nil

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -42,7 +42,7 @@ type Info struct {
 	// Scheduler parameters to add to the RuntimeJobTemplate.
 	Scheduler *Scheduler
 	// TemplateSpec is TrainingRuntime Template object.
-	// ObjApply podSpecs and this PodSets should be kept in sync by info.SyncPodSetsToTemplateSpec().
+	// ObjApply podSpecs and this PodSets should be kept in sync by the BuildParallelCountPlugin.
 	TemplateSpec TemplateSpec
 }
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -42,7 +42,7 @@ type Info struct {
 	// Scheduler parameters to add to the RuntimeJobTemplate.
 	Scheduler *Scheduler
 	// TemplateSpec is TrainingRuntime Template object.
-	// ObjApply podSpecs and this PodSets should be kept in sync by the BuildParallelCountPlugin.
+	// ObjApply podSpecs and this PodSets should be kept in sync by ComponentBuilderPlugin.SyncParallelCount.
 	TemplateSpec TemplateSpec
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The `RuntimeInfo()` helpers now correctly propagate `PodSets.Count` (set by `NumNodes` via ML policy plugins) into the JobSet template spec's `Parallelism`/`Completions` fields.

Previously, `ObjApply` stayed stale after `RunEnforceMLPolicyPlugins` updated `PodSets.Count`, forcing external consumers like Kueue to post-process the results.

This PR adds a `BuildParallelCountPlugin` interface to the runtime plugin framework. The JobSet plugin implements it with name-based matching between `PodSets` and `ReplicatedJobs`. It is called from `RuntimeInfo()` after `RunEnforceMLPolicyPlugins`.

Ref: kubernetes-sigs/kueue#8287
Ref: #3057

**Which issue(s) this PR fixes**:
Fixes #3042

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing