### PR TITLE
fix(docs): restyle top nav and moved ads to footer

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1268,14 +1268,13 @@ a.link-preview {
     border-bottom: none !important;
 }
 
-/* EthicalAds: placed at the very bottom of the page via footer block */
+/* EthicalAds: horizontal text ad at page bottom via footer block */
 .ethical-ads-footer {
-    margin: 1.5rem auto 0;
+    margin: 2rem 0 0;
+    padding: 0.75rem 1rem;
+    width: 100%;
+    max-width: none;
+    border-top: 1px solid var(--color-foreground-border, #4a5568);
+    font-size: 0.85rem;
     text-align: center;
-    max-width: 400px;
-    padding: 1rem 0;
-}
-
-.ethical-ads-footer img {
-    border-radius: 6px;
 }

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -27,31 +27,14 @@ body {
    ============================================ */
 
 .announcement {
-    background: #2D3748 !important;
-    border-bottom: 1px solid #3a4560 !important;
+    background: var(--color-background-primary, #fff) !important;
+    border-bottom: 1px solid var(--color-background-border, #e2e8f0) !important;
     padding: 0 !important;
     position: fixed !important;
     top: 0 !important;
     left: 0 !important;
     right: 0 !important;
     z-index: 100 !important;
-}
-
-.top-nav-brand {
-    color: #e2e8f0 !important;
-}
-
-.top-nav-brand:hover {
-    color: #fff !important;
-}
-
-.top-nav-links a {
-    color: #cbd5e0 !important;
-}
-
-.top-nav-links a:hover {
-    color: #fff !important;
-    background: rgba(255,255,255,0.1);
 }
 
 .page {
@@ -89,13 +72,13 @@ body {
     align-items: center;
     gap: 0.5rem;
     text-decoration: none !important;
-    color: #e2e8f0 !important;
+    color: var(--color-foreground-primary, #1a202c) !important;
     font-weight: 600;
     font-size: 1.1rem;
 }
 
 .top-nav-brand:hover {
-    color: #fff !important;
+    color: var(--color-brand-primary, #4299e1) !important;
 }
 
 .top-nav-logo {
@@ -109,7 +92,7 @@ body {
 }
 
 .top-nav-links a {
-    color: #cbd5e0 !important;
+    color: var(--color-foreground-secondary, #2d3748) !important;
     text-decoration: none !important;
     padding: 0.4rem 0.75rem;
     border-radius: 4px;
@@ -118,8 +101,8 @@ body {
 }
 
 .top-nav-links a:hover {
-    color: #fff !important;
-    background: rgba(255, 255, 255, 0.1);
+    color: var(--color-brand-primary, #4299e1) !important;
+    background: var(--color-background-hover, rgba(0, 0, 0, 0.04));
 }
 
 @media (max-width: 768px) {
@@ -1270,3 +1253,29 @@ body.is-landing .sidebar-toggle {
 .community-card:nth-child(2).animate-on-scroll { transition-delay: 0.05s; }
 .community-card:nth-child(3).animate-on-scroll { transition-delay: 0.1s; }
 .community-card:nth-child(4).animate-on-scroll { transition-delay: 0.15s; }
+
+/* ============================================
+   READTHEDOCS ADDONS OVERRIDES
+   ============================================ */
+
+/* Force-disable link preview tooltips and dotted underlines */
+div[data-linkpreview-href],
+readthedocs-linkpreviews {
+    display: none !important;
+}
+
+a.link-preview {
+    border-bottom: none !important;
+}
+
+/* EthicalAds: placed at the very bottom of the page via footer block */
+.ethical-ads-footer {
+    margin: 1.5rem auto 0;
+    text-align: center;
+    max-width: 400px;
+    padding: 1rem 0;
+}
+
+.ethical-ads-footer img {
+    border-radius: 6px;
+}

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,0 +1,6 @@
+{% extends "!page.html" %}
+
+{% block footer %}
+{{ super() }}
+<div id="ethical-ad-placement" data-ea-publisher="readthedocs" data-ea-type="image" class="ethical-ads-footer"></div>
+{% endblock %}

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -2,5 +2,5 @@
 
 {% block footer %}
 {{ super() }}
-<div id="ethical-ad-placement" data-ea-publisher="readthedocs" data-ea-type="image" class="ethical-ads-footer"></div>
+<div id="ethical-ad-placement" data-ea-publisher="readthedocs" data-ea-type="text" class="ethical-ads-footer"></div>
 {% endblock %}

--- a/docs/_templates/sidebar/ethical-ads.html
+++ b/docs/_templates/sidebar/ethical-ads.html
@@ -1,0 +1,1 @@
+{# Empty override: removes ad from left sidebar. Ad is placed after content instead. #}


### PR DESCRIPTION
## Summary

Addresses feedback from @andreyvelich on the documentation website:

- **Light top navigation bar**: Restyled the top nav from a dark background
  to a light, theme-aware design matching the Kubeflow SDK site. Uses Furo
  CSS variables so it adapts correctly to both light and dark mode.
- **Ad placement**: Moved EthicalAds from the left sidebar to a horizontal
  text ad at the bottom of every page via Furo template overrides.
- **Link previews disabled**: Force-disabled RTD link preview hover popups
  via CSS.

## Changes

- `docs/_static/css/custom.css` — top nav light styling, link preview hiding,
  footer ad styling
  
<img width="1717" height="313" alt="image" src="https://github.com/user-attachments/assets/80303bdb-b744-4e3e-a005-38116f654c9d" />

- `docs/_templates/page.html` — Furo page override to place ad in footer
<img width="1063" height="165" alt="image" src="https://github.com/user-attachments/assets/9d19754a-631a-4110-9b7a-0081ea92b848" />


- `docs/_templates/sidebar/ethical-ads.html` — empty override to remove ad
  from sidebar

## Test plan

- [x] Verified on RTD branch build (`fix/docs-ads-topnav-linkpreview`)
- [x] Top nav is light in both light and dark mode
- [x] No link preview popups on internal link hover
- [x] Ad renders horizontally at page bottom, not in sidebar
- [x] Sphinx build passes with no warnings