### PR TITLE
feat: auto-create PodDisruptionBudget for gang-scheduled TrainJobs

### DIFF
--- a/charts/kubeflow-trainer/templates/rbac/clusterrole.yaml
+++ b/charts/kubeflow-trainer/templates/rbac/clusterrole.yaml
@@ -91,6 +91,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - scheduling.volcano.sh
   - scheduling.x-k8s.io
   resources:

--- a/manifests/base/rbac/role.yaml
+++ b/manifests/base/rbac/role.yaml
@@ -74,6 +74,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - scheduling.volcano.sh
   - scheduling.x-k8s.io
   resources:

--- a/pkg/runtime/core/clustertrainingruntime_test.go
+++ b/pkg/runtime/core/clustertrainingruntime_test.go
@@ -120,6 +120,11 @@ func TestClusterTrainingRuntimeNewObjects(t *testing.T) {
 					}).
 					SchedulingTimeout(120).
 					Obj(),
+				testingutil.MakePodDisruptionBudgetWrapper("test-job", metav1.NamespaceDefault).
+					MinAvailable(100). // 100 trainer replicas; initializers are excluded.
+					MatchLabels(map[string]string{jobsetv1alpha2.JobSetNameKey: "test-job"}).
+					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
+					Obj(),
 			},
 		},
 		"missing trainingRuntime resource": {

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -115,6 +115,11 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					}).
 					SchedulingTimeout(120).
 					Obj(),
+				testingutil.MakePodDisruptionBudgetWrapper("test-job", metav1.NamespaceDefault).
+					MinAvailable(30). // 30 trainer replicas; initializers are excluded.
+					MatchLabels(map[string]string{jobsetv1alpha2.JobSetNameKey: "test-job"}).
+					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
+					Obj(),
 			},
 		},
 		"succeeded to build JobSet with NumNodes from the Runtime and container from the TrainJob.": {

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/jobset"
 	jobsetplgconsts "github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/jobset/constants"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/mpi"
+	"github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/pdb"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/plainml"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/torch"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/volcano"
@@ -84,6 +85,7 @@ func TestNew(t *testing.T) {
 					flux.Name:         &flux.Flux{},
 					volcano.Name:      &volcano.Volcano{},
 					mpi.Name:          &mpi.MPI{},
+					pdb.Name:          &pdb.PodDisruptionBudget{},
 					plainml.Name:      &plainml.PlainML{},
 					torch.Name:        &torch.Torch{},
 					jobset.Name:       &jobset.JobSet{},
@@ -117,6 +119,7 @@ func TestNew(t *testing.T) {
 					&volcano.Volcano{},
 					&jobset.JobSet{},
 					&mpi.MPI{},
+					&pdb.PodDisruptionBudget{},
 				},
 				podNetworkPlugins: []framework.PodNetworkPlugin{
 					&jobset.JobSet{},
@@ -127,6 +130,7 @@ func TestNew(t *testing.T) {
 					&volcano.Volcano{},
 					&jobset.JobSet{},
 					&mpi.MPI{},
+					&pdb.PodDisruptionBudget{},
 				},
 				trainJobStatusPlugin: &jobset.JobSet{},
 			},
@@ -148,7 +152,7 @@ func TestNew(t *testing.T) {
 	}
 	cmpOpts := []cmp.Option{
 		cmp.AllowUnexported(Framework{}),
-		cmpopts.IgnoreUnexported(coscheduling.CoScheduling{}, flux.Flux{}, volcano.Volcano{}, mpi.MPI{}, plainml.PlainML{}, torch.Torch{}, jobset.JobSet{}, xgboost.XGBoost{}),
+		cmpopts.IgnoreUnexported(coscheduling.CoScheduling{}, flux.Flux{}, volcano.Volcano{}, mpi.MPI{}, plainml.PlainML{}, torch.Torch{}, jobset.JobSet{}, xgboost.XGBoost{}, pdb.PodDisruptionBudget{}),
 		cmpopts.IgnoreFields(flux.Flux{}, "client", "scheme"),
 		cmpopts.IgnoreFields(coscheduling.CoScheduling{}, "client"),
 		cmpopts.IgnoreFields(volcano.Volcano{}, "client"),
@@ -1762,6 +1766,11 @@ test-job-node-0-1.test-job slots=1
 						corev1.ResourceMemory: resource.MustParse("8Gi"),
 					}).
 					Obj(),
+				testingutil.MakePodDisruptionBudgetWrapper("test-job", metav1.NamespaceDefault).
+					MinAvailable(100). // 100 trainer replicas; initializers are excluded.
+					MatchLabels(map[string]string{jobsetv1alpha2.JobSetNameKey: "test-job"}).
+					ControllerReference(trainer.SchemeGroupVersion.WithKind("TrainJob"), "test-job", "uid").
+					Obj(),
 			},
 		},
 		"succeeded to build PodGroup and JobSet with NumNodes from TrainJob with volcano plugin": {
@@ -2210,6 +2219,11 @@ test-job-node-0-1.test-job slots=1
 						corev1.ResourceMemory: resource.MustParse("4Gi"),
 					}).
 					Obj(),
+				testingutil.MakePodDisruptionBudgetWrapper("test-volcano-job", metav1.NamespaceDefault).
+					MinAvailable(100). // 100 trainer replicas; initializers are excluded.
+					MatchLabels(map[string]string{jobsetv1alpha2.JobSetNameKey: "test-volcano-job"}).
+					ControllerReference(trainer.SchemeGroupVersion.WithKind("TrainJob"), "test-volcano-job", "uid").
+					Obj(),
 			},
 		},
 		"an empty registry": {},
@@ -2300,6 +2314,7 @@ func TestWatchExtensionPlugins(t *testing.T) {
 				&volcano.Volcano{},
 				&jobset.JobSet{},
 				&mpi.MPI{},
+				&pdb.PodDisruptionBudget{},
 			},
 		},
 		"an empty registry": {
@@ -2308,7 +2323,7 @@ func TestWatchExtensionPlugins(t *testing.T) {
 	}
 	cmpOpts := []cmp.Option{
 		cmpopts.SortSlices(func(a, b framework.Plugin) bool { return a.Name() < b.Name() }),
-		cmpopts.IgnoreUnexported(coscheduling.CoScheduling{}, volcano.Volcano{}, jobset.JobSet{}, mpi.MPI{}, flux.Flux{}),
+		cmpopts.IgnoreUnexported(coscheduling.CoScheduling{}, volcano.Volcano{}, jobset.JobSet{}, mpi.MPI{}, flux.Flux{}, pdb.PodDisruptionBudget{}),
 		cmpopts.IgnoreFields(flux.Flux{}, "client", "scheme"),
 	}
 	for name, tc := range cases {

--- a/pkg/runtime/framework/plugins/pdb/pdb.go
+++ b/pkg/runtime/framework/plugins/pdb/pdb.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2025 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pdb
+
+import (
+	"context"
+
+	policyv1 "k8s.io/api/policy/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
+	policyv1ac "k8s.io/client-go/applyconfigurations/policy/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+
+	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	"github.com/kubeflow/trainer/v2/pkg/constants"
+	"github.com/kubeflow/trainer/v2/pkg/runtime"
+	"github.com/kubeflow/trainer/v2/pkg/runtime/framework"
+)
+
+// PodDisruptionBudget builds a PodDisruptionBudget that protects the pods of a
+// gang-scheduled TrainJob from voluntary disruptions (node drains, cluster
+// autoscaler scale-downs). Distributed training is tightly coupled: every rank
+// must be available for the job to make progress, so evicting a single pod
+// stalls the whole gang until it is restarted from the last checkpoint.
+type PodDisruptionBudget struct {
+	client client.Client
+}
+
+var _ framework.ComponentBuilderPlugin = (*PodDisruptionBudget)(nil)
+var _ framework.WatchExtensionPlugin = (*PodDisruptionBudget)(nil)
+
+const Name = "PodDisruptionBudget"
+
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
+
+func New(_ context.Context, client client.Client, _ client.FieldIndexer, _ *configapi.Configuration) (framework.Plugin, error) {
+	return &PodDisruptionBudget{
+		client: client,
+	}, nil
+}
+
+func (p *PodDisruptionBudget) Name() string {
+	return Name
+}
+
+// Build creates a PodDisruptionBudget for gang-scheduled, multi-pod TrainJobs.
+// The budget's minAvailable equals the number of training replicas (the trainer
+// PodSets), which is the long-lived gang that must stay available for the job to
+// make progress. Short-lived initializer pods are deliberately excluded: they
+// run to completion and stop being Ready, so counting them would make the PDB
+// permanently unsatisfiable (currentHealthy could never reach minAvailable).
+func (p *PodDisruptionBudget) Build(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
+	// Only gang-scheduled TrainJobs declare all-or-nothing semantics, so we
+	// scope the PDB to them to avoid blocking node maintenance for ordinary
+	// workloads.
+	if info == nil || trainJob == nil || info.RuntimePolicy.PodGroupPolicy == nil {
+		return nil, nil
+	}
+
+	var trainerReplicas int32
+	for _, ps := range info.TemplateSpec.PodSets {
+		if ptr.Deref(ps.Ancestor, "") == constants.AncestorTrainer && ps.Count != nil {
+			trainerReplicas += *ps.Count
+		}
+	}
+
+	// A PodDisruptionBudget is only meaningful for distributed (multi-pod)
+	// TrainJobs. Protecting a single pod would block routine node maintenance
+	// without providing gang-availability guarantees.
+	if trainerReplicas <= 1 {
+		return nil, nil
+	}
+
+	pdb := policyv1ac.PodDisruptionBudget(trainJob.Name, trainJob.Namespace).
+		WithSpec(policyv1ac.PodDisruptionBudgetSpec().
+			WithMinAvailable(intstr.FromInt32(trainerReplicas)).
+			WithSelector(metav1ac.LabelSelector().
+				WithMatchLabels(map[string]string{
+					jobsetv1alpha2.JobSetNameKey: trainJob.Name,
+				}))).
+		WithOwnerReferences(metav1ac.OwnerReference().
+			WithAPIVersion(trainer.GroupVersion.String()).
+			WithKind(trainer.TrainJobKind).
+			WithName(trainJob.Name).
+			WithUID(trainJob.UID).
+			WithController(true).
+			WithBlockOwnerDeletion(true))
+
+	return []apiruntime.ApplyConfiguration{pdb}, nil
+}
+
+func (p *PodDisruptionBudget) ReconcilerBuilders() []runtime.ReconcilerBuilder {
+	return []runtime.ReconcilerBuilder{
+		func(b *builder.Builder, cl client.Client, cache cache.Cache) *builder.Builder {
+			return b.Watches(
+				&policyv1.PodDisruptionBudget{},
+				handler.EnqueueRequestForOwner(
+					p.client.Scheme(), p.client.RESTMapper(), &trainer.TrainJob{}, handler.OnlyControllerOwner(),
+				),
+			)
+		},
+	}
+}

--- a/pkg/runtime/framework/plugins/pdb/pdb_test.go
+++ b/pkg/runtime/framework/plugins/pdb/pdb_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2025 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pdb
+
+import (
+	"cmp"
+	"testing"
+
+	gocmp "github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2/ktesting"
+	"k8s.io/utils/ptr"
+	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	"github.com/kubeflow/trainer/v2/pkg/constants"
+	"github.com/kubeflow/trainer/v2/pkg/runtime"
+	"github.com/kubeflow/trainer/v2/pkg/runtime/framework"
+	utiltesting "github.com/kubeflow/trainer/v2/pkg/util/testing"
+)
+
+func TestPodDisruptionBudget(t *testing.T) {
+	objCmpOpts := []gocmp.Option{
+		cmpopts.SortSlices(func(a, b apiruntime.Object) int {
+			return cmp.Compare(a.GetObjectKind().GroupVersionKind().String(), b.GetObjectKind().GroupVersionKind().String())
+		}),
+	}
+
+	cases := map[string]struct {
+		info     *runtime.Info
+		trainJob *trainer.TrainJob
+		wantObjs []apiruntime.Object
+	}{
+		"no action when pod group policy is nil": {
+			info: &runtime.Info{
+				RuntimePolicy: runtime.RuntimePolicy{},
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{Name: constants.Node, Count: ptr.To[int32](2)},
+					},
+				},
+			},
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				UID("test-uid").
+				Obj(),
+		},
+		"no action for single trainer-replica gang job": {
+			info: &runtime.Info{
+				RuntimePolicy: runtime.RuntimePolicy{
+					PodGroupPolicy: &trainer.PodGroupPolicy{},
+				},
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{Name: constants.Node, Ancestor: ptr.To(constants.AncestorTrainer), Count: ptr.To[int32](1)},
+					},
+				},
+			},
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				UID("test-uid").
+				Obj(),
+		},
+		"pdb counts only trainer replicas, excluding initializers": {
+			info: &runtime.Info{
+				RuntimePolicy: runtime.RuntimePolicy{
+					PodGroupPolicy: &trainer.PodGroupPolicy{},
+				},
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{Name: constants.DatasetInitializer, Ancestor: ptr.To(constants.DatasetInitializer), Count: ptr.To[int32](1)},
+						{Name: constants.Node, Ancestor: ptr.To(constants.AncestorTrainer), Count: ptr.To[int32](3)},
+					},
+				},
+			},
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				UID("test-uid").
+				Obj(),
+			wantObjs: []apiruntime.Object{
+				utiltesting.MakePodDisruptionBudgetWrapper("test-job", metav1.NamespaceDefault).
+					MinAvailable(3).
+					MatchLabels(map[string]string{jobsetv1alpha2.JobSetNameKey: "test-job"}).
+					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "test-uid").
+					Obj(),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			cli := utiltesting.NewClientBuilder().Build()
+			p, err := New(ctx, cli, nil, nil)
+			if err != nil {
+				t.Fatalf("New failed: %v", err)
+			}
+
+			objs, err := p.(framework.ComponentBuilderPlugin).Build(ctx, tc.info, tc.trainJob)
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+
+			typedObjs, err := utiltesting.ToObject(cli.Scheme(), objs...)
+			if err != nil {
+				t.Fatalf("ToObject failed: %v", err)
+			}
+			if diff := gocmp.Diff(tc.wantObjs, typedObjs, objCmpOpts...); len(diff) != 0 {
+				t.Errorf("Unexpected objects from Build (-want, +got): %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/runtime/framework/plugins/registry.go
+++ b/pkg/runtime/framework/plugins/registry.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/jax"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/jobset"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/mpi"
+	"github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/pdb"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/plainml"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/torch"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/trainjobstatus"
@@ -44,6 +45,7 @@ func NewRegistry() Registry {
 		flux.Name:         flux.New,
 		volcano.Name:      volcano.New,
 		mpi.Name:          mpi.New,
+		pdb.Name:          pdb.New,
 		plainml.Name:      plainml.New,
 		torch.Name:        torch.New,
 		jobset.Name:       jobset.New,

--- a/pkg/util/testing/wrapper.go
+++ b/pkg/util/testing/wrapper.go
@@ -21,9 +21,11 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 	schedulerpluginsv1alpha1 "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
@@ -1508,4 +1510,53 @@ func (s *SecretWrapper) ControllerReference(gvk schema.GroupVersionKind, name, u
 
 func (s *SecretWrapper) Obj() *corev1.Secret {
 	return &s.Secret
+}
+
+type PodDisruptionBudgetWrapper struct {
+	policyv1.PodDisruptionBudget
+}
+
+func MakePodDisruptionBudgetWrapper(name, ns string) *PodDisruptionBudgetWrapper {
+	return &PodDisruptionBudgetWrapper{
+		PodDisruptionBudget: policyv1.PodDisruptionBudget{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: policyv1.SchemeGroupVersion.String(),
+				Kind:       "PodDisruptionBudget",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+			},
+		},
+	}
+}
+
+func (p *PodDisruptionBudgetWrapper) MinAvailable(minAvailable int32) *PodDisruptionBudgetWrapper {
+	v := intstr.FromInt32(minAvailable)
+	p.Spec.MinAvailable = &v
+	return p
+}
+
+func (p *PodDisruptionBudgetWrapper) MatchLabels(matchLabels map[string]string) *PodDisruptionBudgetWrapper {
+	if p.Spec.Selector == nil {
+		p.Spec.Selector = &metav1.LabelSelector{}
+	}
+	p.Spec.Selector.MatchLabels = matchLabels
+	return p
+}
+
+func (p *PodDisruptionBudgetWrapper) ControllerReference(gvk schema.GroupVersionKind, name, uid string) *PodDisruptionBudgetWrapper {
+	p.OwnerReferences = append(p.OwnerReferences, metav1.OwnerReference{
+		APIVersion:         gvk.GroupVersion().String(),
+		Kind:               gvk.Kind,
+		Name:               name,
+		UID:                types.UID(uid),
+		Controller:         ptr.To(true),
+		BlockOwnerDeletion: ptr.To(true),
+	})
+	return p
+}
+
+func (p *PodDisruptionBudgetWrapper) Obj() *policyv1.PodDisruptionBudget {
+	return &p.PodDisruptionBudget
 }

--- a/test/integration/controller/trainjob_controller_test.go
+++ b/test/integration/controller/trainjob_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -188,6 +189,17 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 								corev1.ResourceMemory: resource.MustParse("408Gi"),
 							}).
 							SchedulingTimeout(100).
+							ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), trainJobKey.Name, string(trainJob.UID)).
+							Obj(),
+						util.IgnoreObjectMetadata))
+
+					ginkgo.By("Checking if the PodDisruptionBudget is created")
+					pdb := &policyv1.PodDisruptionBudget{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, pdb)).Should(gomega.Succeed())
+					g.Expect(pdb).Should(gomega.BeComparableTo(
+						testingutil.MakePodDisruptionBudgetWrapper(trainJobKey.Name, ns.Name).
+							MinAvailable(100). // 100 trainer replicas; initializers are excluded.
+							MatchLabels(map[string]string{jobsetv1alpha2.JobSetNameKey: trainJobKey.Name}).
 							ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), trainJobKey.Name, string(trainJob.UID)).
 							Obj(),
 						util.IgnoreObjectMetadata))


### PR DESCRIPTION
## What this PR does

Adds a `PodDisruptionBudget` `ComponentBuilderPlugin` that protects gang-scheduled TrainJobs from voluntary disruptions (node drains, cluster-autoscaler scale-downs). For a TrainJob with a `PodGroupPolicy` and more than one trainer replica, it builds a `policy/v1` PodDisruptionBudget with `minAvailable` = trainer-replica count, a selector on the JobSet's pods (`jobset.sigs.k8s.io/jobset-name`), and a controller `OwnerReference` to the TrainJob. The plugin also watches PDBs so the controller reconciles drift. Plugin-only — **no API/CRD change**.

Fixes #3304

## Why

Distributed training is tightly coupled: every rank must stay available for the job to make progress. A single voluntary eviction stalls the whole gang until it restarts from the last checkpoint, and no PDB was created anywhere in the project.

## Design notes / open questions for reviewers

- **Trigger:** gated on `PodGroupPolicy != nil` (gang-scheduled jobs), symmetric with the coscheduling plugin. The issue text says "any distributed TrainJob" — I went narrower/conservative on purpose; happy to broaden to all multi-pod jobs if preferred.
- **`minAvailable` = trainer replicas only** (initializers excluded — they run to completion and stop being Ready, which would otherwise make the PDB permanently unsatisfiable). This matches the issue's "total number of training *replicas*."
- **@tariq-hasan's question** on the issue (plugin vs. `TrainJob`/`TrainingRuntime` API change) is still open — this PR takes the plugin-only path. Glad to add a config gate instead if maintainers prefer opt-in.

## Testing

- Table-driven unit tests for the plugin (`pdb_test.go`); updated framework/runtime build tests; integration assertion in `trainjob_controller_test.go`.
- Locally: `go build ./...`, `go vet`, `gofmt`, and all `pkg/`+`cmd/` unit tests pass. Integration/e2e run in CI (envtest not bootstrapped locally).
- RBAC regenerated via `controller-gen` (`manifests/base/rbac/role.yaml` + chart `clusterrole.yaml`).

---

🤖 Assisted by Claude Code (Anthropic); authored, reviewed, and verified by me.
