### PR TITLE
ci(boilerplate): enhance copyright boilerplate enforcement

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Bug Report
 description: Tell us about a problem you are experiencing with Kubeflow Trainer
 labels: ["kind/bug", "needs-triage"]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 blank_issues_enabled: true
 
 contact_links:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Feature Request
 description: Suggest an idea for Kubeflow Trainer
 labels: ["kind/feature", "needs-triage"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: 2
 updates:
   # Go modules

--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Build and Publish Images
 
 on:

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Check PR Title
 
 on:

--- a/.github/workflows/code-quality-check.yaml
+++ b/.github/workflows/code-quality-check.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Code Quality Checks
 
 on:

--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Approve Workflow Runs
 
 permissions:

--- a/.github/workflows/github-stale.yaml
+++ b/.github/workflows/github-stale.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
 #
 # You can adjust the behavior by modifying this file.

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This workflow runs govulncheck on PRs to detect known reachable CVEs across the entire Go module.
 # It triggers when any Go source file or Go dependencies (go.mod, go.sum) change.
 # Results are posted as an informational PR comment for new regressions only.

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: OSV-Scanner Vulnerability Scan
 
 on:

--- a/.github/workflows/publish-helm-charts.yaml
+++ b/.github/workflows/publish-helm-charts.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Publish Helm Charts
 
 on:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Release
 
 on:

--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Composite action to publish Kubeflow Trainer images.
 name: Build And Publish Container Images
 description: Build Multiplatform Supporting Container Images

--- a/.github/workflows/template-setup-clusters/action.yaml
+++ b/.github/workflows/template-setup-clusters/action.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Setup E2E Cluster
 description: Checks out code, sets up Go and Python, installs dependencies, and creates a Kind cluster
 

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: E2E Tests
 
 on:

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Unit and Integration Test - Go
 
 on:

--- a/.github/workflows/test-helm.yaml
+++ b/.github/workflows/test-helm.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Unit and E2E Test - Helm
 
 on:

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Unit and Integration Test - Python
 
 on:

--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Unit and Integration Test - Rust
 
 on:

--- a/.github/workflows/validate-lockfile.yaml
+++ b/.github/workflows/validate-lockfile.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Validate Python Lockfiles
 
 on:

--- a/.github/workflows/welcome-new-contributors.yaml
+++ b/.github/workflows/welcome-new-contributors.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Welcome New Contributors
 
 on:

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "2"
 run:
   allow-parallel-runners: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # golangci-lint configuration file
 # see: https://golangci-lint.run/usage/configuration/
 

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # KubeLinter configuration file
 # For more information, see https://docs.kubelinter.io/#/configuring-kubelinter
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # ReadTheDocs build configuration
 # Kubeflow Trainer Documentation System
 

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ golangci-lint: golangci-lint-install golangci-lint-kal ## Run golangci-lint to v
 
 .PHONY: verify-boilerplate
 verify-boilerplate: ## Verify copyright boilerplate headers in source files.
-	python3 hack/boilerplate/boilerplate.py
+	python3 hack/boilerplate/boilerplate.py --base-ref "$(TARGET_BRANCH)"
 
 # Instructions to run tests.
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ endif
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 REPO := github.com/kubeflow/trainer
 TRAINER_CHART_DIR := $(PROJECT_DIR)/charts/kubeflow-trainer
+# Year-less copyright header prepended to generated manifests (controller-gen
+# emits none). Single source of truth shared with the boilerplate verifier.
+BOILERPLATE_HEADER := $(PROJECT_DIR)/hack/boilerplate/boilerplate.sh.txt
 # Location to install tool binaries
 LOCALBIN ?= $(PROJECT_DIR)/bin
 
@@ -169,6 +172,14 @@ manifests: controller-gen ## Generate manifests.
 		output:crd:artifacts:config=manifests/base/crds \
 		output:rbac:artifacts:config=manifests/base/rbac \
 		output:webhook:artifacts:config=manifests/base/webhook
+	@# controller-gen emits no license header. Prepend the year-less
+	@# boilerplate to each generated manifest. controller-gen rewrites these
+	@# files in full on every run, so prepending here once is idempotent.
+	@for f in manifests/base/crds/trainer.kubeflow.org_*.yaml \
+			manifests/base/rbac/role.yaml \
+			manifests/base/webhook/manifests.yaml; do \
+		{ cat $(BOILERPLATE_HEADER); echo; cat "$$f"; } > "$$f.tmp" && mv "$$f.tmp" "$$f"; \
+	done
 	cp -f manifests/base/crds/trainer.kubeflow.org_*.yaml $(TRAINER_CHART_DIR)/crds/
 
 .PHONY: generate

--- a/charts/kubeflow-trainer/Chart.yaml
+++ b/charts/kubeflow-trainer/Chart.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2025 The Kubeflow authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 apiVersion: v2
 

--- a/charts/kubeflow-trainer/README.md.gotmpl
+++ b/charts/kubeflow-trainer/README.md.gotmpl
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2026 The Kubeflow authors.
+Copyright 2026 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
+++ b/charts/kubeflow-trainer/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainingruntimes.yaml
+++ b/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainingruntimes.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/kubeflow-trainer/templates/_helpers.tpl
+++ b/charts/kubeflow-trainer/templates/_helpers.tpl
@@ -1,5 +1,5 @@
-{{/*
-Copyright 2025 The Kubeflow authors.
+{{- /*
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-*/}}
+*/ -}}
 
 {{/*
 Expand the name of the chart.

--- a/charts/kubeflow-trainer/templates/data-cache/cluster-role.yaml
+++ b/charts/kubeflow-trainer/templates/data-cache/cluster-role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/manager/_helpers.tpl
+++ b/charts/kubeflow-trainer/templates/manager/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/manager/configmap.yaml
+++ b/charts/kubeflow-trainer/templates/manager/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/manager/deployment.yaml
+++ b/charts/kubeflow-trainer/templates/manager/deployment.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/manager/service.yaml
+++ b/charts/kubeflow-trainer/templates/manager/service.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/rbac/_helpers.tpl
+++ b/charts/kubeflow-trainer/templates/rbac/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/rbac/clusterrole.yaml
+++ b/charts/kubeflow-trainer/templates/rbac/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/rbac/clusterrole_binding.yaml
+++ b/charts/kubeflow-trainer/templates/rbac/clusterrole_binding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/rbac/public_configmap_role.yaml
+++ b/charts/kubeflow-trainer/templates/rbac/public_configmap_role.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/rbac/public_configmap_role_binding.yaml
+++ b/charts/kubeflow-trainer/templates/rbac/public_configmap_role_binding.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/rbac/service_account.yaml
+++ b/charts/kubeflow-trainer/templates/rbac/service_account.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/runtimes/data-cache/torch-distributed-with-cache.yaml
+++ b/charts/kubeflow-trainer/templates/runtimes/data-cache/torch-distributed-with-cache.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2026 The Kubeflow authors.
+Copyright 2026 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/runtimes/deepspeed-distributed.yaml
+++ b/charts/kubeflow-trainer/templates/runtimes/deepspeed-distributed.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/runtimes/jax-distributed.yaml
+++ b/charts/kubeflow-trainer/templates/runtimes/jax-distributed.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2026 The Kubeflow authors.
+Copyright 2026 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/runtimes/mlx-distributed.yaml
+++ b/charts/kubeflow-trainer/templates/runtimes/mlx-distributed.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2026 The Kubeflow authors.
+Copyright 2026 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/runtimes/torch-distributed.yaml
+++ b/charts/kubeflow-trainer/templates/runtimes/torch-distributed.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/runtimes/torchtune/llama3_2_1B.yaml
+++ b/charts/kubeflow-trainer/templates/runtimes/torchtune/llama3_2_1B.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2026 The Kubeflow authors.
+Copyright 2026 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/runtimes/torchtune/llama3_2_3B.yaml
+++ b/charts/kubeflow-trainer/templates/runtimes/torchtune/llama3_2_3B.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2026 The Kubeflow authors.
+Copyright 2026 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/runtimes/torchtune/qwen2_5_1.5B.yaml
+++ b/charts/kubeflow-trainer/templates/runtimes/torchtune/qwen2_5_1.5B.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2026 The Kubeflow authors.
+Copyright 2026 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/runtimes/xgboost-distributed.yaml
+++ b/charts/kubeflow-trainer/templates/runtimes/xgboost-distributed.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2026 The Kubeflow authors.
+Copyright 2026 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/webhook/_helpers.tpl
+++ b/charts/kubeflow-trainer/templates/webhook/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/webhook/mutating_webhook_configuration.yaml
+++ b/charts/kubeflow-trainer/templates/webhook/mutating_webhook_configuration.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/webhook/secret.yaml
+++ b/charts/kubeflow-trainer/templates/webhook/secret.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/webhook/validating_webhook_configuration.yaml
+++ b/charts/kubeflow-trainer/templates/webhook/validating_webhook_configuration.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow authors.
+Copyright 2025 The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/tests/data-cache/cluster_role_test.yaml
+++ b/charts/kubeflow-trainer/tests/data-cache/cluster_role_test.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2025 The Kubeflow authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test data-cache ClusterRole
 templates:

--- a/charts/kubeflow-trainer/tests/manager/configmap_test.yaml
+++ b/charts/kubeflow-trainer/tests/manager/configmap_test.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 suite: test manager configmap
 templates:
   - manager/configmap.yaml

--- a/charts/kubeflow-trainer/tests/manager/deployment_test.yaml
+++ b/charts/kubeflow-trainer/tests/manager/deployment_test.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2025 The Kubeflow authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test manager Deployment
 

--- a/charts/kubeflow-trainer/tests/manager/service_test.yaml
+++ b/charts/kubeflow-trainer/tests/manager/service_test.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2025 The Kubeflow authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test manager Service
 

--- a/charts/kubeflow-trainer/tests/rbac/clusterrole_binding_test.yaml
+++ b/charts/kubeflow-trainer/tests/rbac/clusterrole_binding_test.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2025 The Kubeflow authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test manager ClusterRoleBinding
 

--- a/charts/kubeflow-trainer/tests/rbac/clusterrole_test.yaml
+++ b/charts/kubeflow-trainer/tests/rbac/clusterrole_test.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2025 The Kubeflow authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test manager ClusterRole
 

--- a/charts/kubeflow-trainer/tests/rbac/service_account_test.yaml
+++ b/charts/kubeflow-trainer/tests/rbac/service_account_test.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2025 The Kubeflow authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test manager ServiceAccount
 

--- a/charts/kubeflow-trainer/tests/runtimes/deepspeed_distributed_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/deepspeed_distributed_test.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2025 The Kubeflow authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test deepspeed-distributed ClusterTrainingRuntime
 templates:

--- a/charts/kubeflow-trainer/tests/runtimes/mlx_distributed_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/mlx_distributed_test.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2025 The Kubeflow authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test mlx-distributed ClusterTrainingRuntime
 templates:

--- a/charts/kubeflow-trainer/tests/runtimes/torch_distributed_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torch_distributed_test.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2025 The Kubeflow authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test torch-distributed ClusterTrainingRuntime
 templates:

--- a/charts/kubeflow-trainer/tests/runtimes/torch_distributed_with_cache_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torch_distributed_with_cache_test.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2025 The Kubeflow authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test torch-distributed-with-cache ClusterTrainingRuntime
 templates:

--- a/charts/kubeflow-trainer/tests/runtimes/torchtune_llama3_2_1B_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torchtune_llama3_2_1B_test.yaml
@@ -1,4 +1,3 @@
-#
 # Copyright The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test torchtune-llama3.2-1b ClusterTrainingRuntime
 templates:

--- a/charts/kubeflow-trainer/tests/runtimes/torchtune_llama3_2_3B_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torchtune_llama3_2_3B_test.yaml
@@ -1,4 +1,3 @@
-#
 # Copyright The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test torchtune-llama3.2-3b ClusterTrainingRuntime
 templates:

--- a/charts/kubeflow-trainer/tests/runtimes/torchtune_qwen2_5_1.5B_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torchtune_qwen2_5_1.5B_test.yaml
@@ -1,4 +1,3 @@
-#
 # Copyright The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test torchtune-qwen2.5-1.5b ClusterTrainingRuntime
 templates:

--- a/charts/kubeflow-trainer/tests/runtimes/xgboost_distributed_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/xgboost_distributed_test.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2026 The Kubeflow authors.
+# Copyright 2026 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test xgboost-distributed ClusterTrainingRuntime
 templates:

--- a/charts/kubeflow-trainer/tests/webhook/mutating_webhook_configuration_test.yaml
+++ b/charts/kubeflow-trainer/tests/webhook/mutating_webhook_configuration_test.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2025 The Kubeflow authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test MutatingWebhookConfiguration
 

--- a/charts/kubeflow-trainer/tests/webhook/secret_test.yaml
+++ b/charts/kubeflow-trainer/tests/webhook/secret_test.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2025 The Kubeflow authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test webhook Secret
 

--- a/charts/kubeflow-trainer/tests/webhook/validating_webhook_configuration_test.yaml
+++ b/charts/kubeflow-trainer/tests/webhook/validating_webhook_configuration_test.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2025 The Kubeflow authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 suite: Test ValidatingWebhookConfiguration
 

--- a/charts/kubeflow-trainer/values.yaml
+++ b/charts/kubeflow-trainer/values.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright 2026 The Kubeflow authors.
+# Copyright 2026 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 # Default values for trainer.
 # This is a YAML-formatted file.

--- a/examples/flux/flux-interactive.yaml
+++ b/examples/flux/flux-interactive.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This example deploys the LAMMPS Molecular Dynamic Simulator
 # with MPI orchestrated by the Flux workload manager on 4 nodes.
 # This is "interactive" mode, so you can shell in to execute lmp.

--- a/examples/flux/flux-runtime.yaml
+++ b/examples/flux/flux-runtime.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:

--- a/examples/flux/lammps-train-gpus.yaml
+++ b/examples/flux/lammps-train-gpus.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This was developed on AWS g4dn.xlarge, Tesla T4 GPUs
 # eksctl create cluster --config-file ./eks-config-gpu.yaml
 # eksctl delete cluster --config-file ./eks-config-gpu.yaml  --wait

--- a/examples/flux/lammps-train-job.yaml
+++ b/examples/flux/lammps-train-job.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This example deploys the LAMMPS Molecular Dynamic Simulator
 # with MPI orchestrated by the Flux workload manager on 4 nodes.
 # The problem size is defined by the coordinates x,y,z, and the

--- a/examples/yaml/01-multi-node.yaml
+++ b/examples/yaml/01-multi-node.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Example 1: Multi-Node Distributed Training
 #
 # Multi-node distributed PyTorch training on the default torch-distributed

--- a/examples/yaml/02-runtime-patches.yaml
+++ b/examples/yaml/02-runtime-patches.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Example 2: Runtime Patches
 #
 # Pod customization with the runtimePatches API. Each patch is keyed by a

--- a/examples/yaml/03-kueue-integration.yaml
+++ b/examples/yaml/03-kueue-integration.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Advanced Example 2: Kueue Integration
 #
 # Queue-based scheduling and quota management with Kueue. The TrainJob is

--- a/examples/yaml/04-volcano-integration.yaml
+++ b/examples/yaml/04-volcano-integration.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Advanced Example 3: Volcano Gang Scheduling
 #
 # Gang scheduling guarantees that all training pods start together (or none

--- a/examples/yaml/05-multi-step.yaml
+++ b/examples/yaml/05-multi-step.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Advanced Example 4: Multi-Step Training with Dataset Initialization
 #
 # Runs a dataset-initializer Job that downloads a HuggingFace dataset, then

--- a/hack/.custom-gcl.yaml
+++ b/hack/.custom-gcl.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: v2.12.1
 name: golangci-lint-kube-api-linter
 destination: ./bin

--- a/hack/boilerplate/boilerplate.helm.txt
+++ b/hack/boilerplate/boilerplate.helm.txt
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2025 The Kubeflow Authors.
+Copyright The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,13 +13,3 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */ -}}
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kubeflow-trainer-public
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "trainer.manager.labels" . | nindent 4 }}
-data:
-  kubeflow_trainer_version: {{ include "trainer.version" . | quote }}

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -33,14 +33,18 @@ from typing import Dict, List, Optional, Tuple
 
 # Maps file extension (or special basename) to the boilerplate template
 # stem on disk (boilerplate.<stem>.txt). One template is reused across
-# all hash-comment languages.
+# all hash-comment languages (sh, bash, py, Dockerfile, yaml, yml).
 EXTENSION_TEMPLATES = {
     "go": "go",
+    "helm": "helm",
+    "gotmpl": "helm",
     "rs": "rs",
     "sh": "sh",
     "bash": "sh",
     "py": "sh",
     "Dockerfile": "sh",
+    "yaml": "sh",
+    "yml": "sh",
 }
 
 # Template used for code-generated Go files (DO NOT EDIT). Loaded from
@@ -52,6 +56,7 @@ _RE_ANY_YEAR = re.compile(r"Copyright \d{4} ")
 _RE_GO_BUILD_CONSTRAINTS = re.compile(r"^(//(go:build| \+build).*\n)+\n", re.MULTILINE)
 _RE_SHEBANG = re.compile(r"^(#!.*\n)\n*")
 _RE_GENERATED = re.compile(r"DO NOT EDIT", re.MULTILINE)
+_RE_HELM_TEMPLATE = re.compile(r"(?:^|/)charts/[^/]+/templates/.*\.(?:ya?ml|tpl)$")
 
 
 def find_root_dir() -> str:
@@ -80,6 +85,9 @@ def load_templates(boilerplate_dir: str) -> Dict[str, List[str]]:
 
 def template_stem_for(filename: str) -> Optional[str]:
     """Return the template stem for filename, or None to skip."""
+    normalized = filename.replace(os.sep, "/")
+    if _RE_HELM_TEMPLATE.search(normalized):
+        return "helm"
     basename = os.path.basename(filename)
     if basename == "Dockerfile" or basename.startswith("Dockerfile."):
         return EXTENSION_TEMPLATES.get("Dockerfile")

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -16,9 +16,18 @@
 
 """Verify boilerplate copyright headers in source files.
 
-Policy:
-  - Files that already contain a copyright year are accepted.
-  - Files without a year must match the year-less boilerplate template.
+Two checks are applied:
+
+  1. All files: the header must match the boilerplate template once any
+     copyright year is normalized out, so a year-bearing header and a
+     year-less header both validate against the single year-less template.
+  2. New files (added relative to the base branch): the header must
+     additionally be year-less; a hardcoded copyright year is rejected.
+
+New-file detection compares against the base branch (--base-ref, default
+$TARGET_BRANCH or master), resolved as origin/<ref> then <ref>. If the base
+cannot be resolved, or files cannot be listed, the run fails rather than
+passing vacuously.
 
 Reference: https://github.com/kubernetes/steering/issues/299
 """
@@ -29,11 +38,13 @@ import os
 import re
 import subprocess
 import sys
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 # Maps file extension (or special basename) to the boilerplate template
-# stem on disk (boilerplate.<stem>.txt). One template is reused across
-# all hash-comment languages (sh, bash, py, Dockerfile, yaml, yml).
+# stem on disk (boilerplate.<stem>.txt). The "sh" stem is reused for every
+# hash-comment language (bash, py, Dockerfile, yaml, yml). "helm" (also used
+# for gotmpl) maps to boilerplate.helm.txt for Go-template comments, and
+# go / rs have their own templates.
 EXTENSION_TEMPLATES = {
     "go": "go",
     "helm": "helm",
@@ -52,7 +63,8 @@ EXTENSION_TEMPLATES = {
 GENERATED_GO_TEMPLATE = "generatego"
 
 # Regex patterns
-_RE_ANY_YEAR = re.compile(r"Copyright \d{4} ")
+_RE_ANY_YEAR = re.compile(r"Copyright \d{4}")
+_RE_YEAR_STRIP = re.compile(r"(Copyright )\d{4}(?:-\d{4})? ")
 _RE_GO_BUILD_CONSTRAINTS = re.compile(r"^(//(go:build| \+build).*\n)+\n", re.MULTILINE)
 _RE_SHEBANG = re.compile(r"^(#!.*\n)\n*")
 _RE_GENERATED = re.compile(r"DO NOT EDIT", re.MULTILINE)
@@ -71,6 +83,32 @@ def find_root_dir() -> str:
         return result.stdout.strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
         return os.getcwd()
+
+
+def base_tree_files(base_ref: str, rootdir: str) -> Optional[Set[str]]:
+    """Repo-relative paths at the merge-base of the base branch and HEAD.
+
+    Tries origin/<base_ref> then <base_ref>. Returns None if neither
+    resolves, so the caller can fail rather than skip the new-file check.
+    """
+    for ref in (f"origin/{base_ref}", base_ref):
+        try:
+            base = subprocess.run(
+                ["git", "-C", rootdir, "merge-base", ref, "HEAD"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+            tree = subprocess.run(
+                ["git", "-C", rootdir, "ls-tree", "-r", "--name-only", base],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            continue
+        return {line for line in tree.stdout.splitlines() if line}
+    return None
 
 
 def load_templates(boilerplate_dir: str) -> Dict[str, List[str]]:
@@ -95,11 +133,13 @@ def template_stem_for(filename: str) -> Optional[str]:
     return EXTENSION_TEMPLATES.get(ext)
 
 
-def list_git_files(rootdir: str) -> List[str]:
+def list_git_files(rootdir: str) -> Optional[List[str]]:
     """List files git considers part of the working tree.
 
     Includes tracked files plus untracked-not-ignored files, so newly
     added files are checked but build artifacts and __pycache__ are not.
+    Returns None if git fails, so the caller can fail rather than treat a
+    broken listing as "no files".
     """
     try:
         result = subprocess.run(
@@ -116,13 +156,14 @@ def list_git_files(rootdir: str) -> List[str]:
             text=True,
             check=True,
         )
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return []
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        print(f"ERROR: 'git ls-files' failed: {e}", file=sys.stderr)
+        return None
     return [os.path.join(rootdir, line) for line in result.stdout.splitlines() if line]
 
 
-def collect_files(rootdir: str, filenames: Optional[List[str]]) -> List[str]:
-    """Return the files to check."""
+def collect_files(rootdir: str, filenames: Optional[List[str]]) -> Optional[List[str]]:
+    """Return the files to check, or None if the git listing failed."""
     if filenames:
         candidates: List[str] = []
         for f in filenames:
@@ -132,17 +173,25 @@ def collect_files(rootdir: str, filenames: Optional[List[str]]) -> List[str]:
                 for root, _, names in os.walk(f):
                     for name in names:
                         candidates.append(os.path.join(root, name))
-    else:
-        candidates = list_git_files(rootdir)
+        return sorted(candidates)
 
-    return sorted(candidates)
+    files = list_git_files(rootdir)
+    if files is None:
+        return None
+    return sorted(files)
 
 
 def file_passes(
     filename: str,
     templates: Dict[str, List[str]],
+    new_file: bool = False,
 ) -> Tuple[bool, Optional[str]]:
-    """Check that filename starts with the expected boilerplate header."""
+    """Verify filename's boilerplate header.
+
+    Check 1 (all files): the header must equal the template after any
+      copyright year is normalized out.
+    Check 2 (new files): the header must be year-less.
+    """
     stem = template_stem_for(filename)
     if stem is None or stem not in templates:
         return True, None
@@ -170,20 +219,22 @@ def file_passes(
     lines = data.splitlines()
     header_lines = lines[: len(ref)]
 
-    # Policy: any file whose header already contains "Copyright YYYY"
-    # is accepted as-is. Those headers were reviewed when the file
-    # landed; re-validating them on every CI run adds little. Trade-off:
-    # a copy-paste with a different holder (e.g. "Copyright 2025 ACME")
-    # would slip through. New files must use the year-less template.
-    for line in header_lines:
-        if _RE_ANY_YEAR.search(line):
-            return True, None
-
     if len(lines) < len(ref):
         return False, "File is shorter than the expected boilerplate header"
 
-    if header_lines != ref:
+    # Check 1: the header must match the template once the copyright year is
+    # normalized out, so year-bearing and year-less headers both validate.
+    normalized = [_RE_YEAR_STRIP.sub(r"\1", line) for line in header_lines]
+    if normalized != ref:
         return False, "Header does not match the boilerplate template"
+
+    # Check 2: files added on this branch must not hardcode a copyright year.
+    if new_file and any(_RE_ANY_YEAR.search(line) for line in header_lines):
+        return (
+            False,
+            "New file must use the year-less header "
+            "(remove the hardcoded copyright year)",
+        )
 
     return True, None
 
@@ -227,6 +278,14 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Root directory to scan (default: auto-detect via git)",
     )
+    parser.add_argument(
+        "--base-ref",
+        default=os.environ.get("TARGET_BRANCH", "master"),
+        help=(
+            "Base branch for new-file detection (default: $TARGET_BRANCH or "
+            "master). Resolved as origin/<ref> then <ref>."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -243,10 +302,27 @@ def main() -> int:
         )
         return 1
 
+    files = collect_files(rootdir, args.filenames or None)
+    if files is None:
+        print("ERROR: could not list repository files via git.", file=sys.stderr)
+        return 1
+
+    base = base_tree_files(args.base_ref, rootdir)
+    if base is None:
+        print(
+            "ERROR: could not resolve a base ref for new-file detection "
+            f"(tried origin/{args.base_ref}, {args.base_ref}). Ensure the base "
+            "branch is fetched (actions/checkout fetch-depth: 0) or pass "
+            "--base-ref.",
+            file=sys.stderr,
+        )
+        return 1
+
     failed: List[Tuple[str, Optional[str]]] = []
-    for filepath in collect_files(rootdir, args.filenames or None):
+    for filepath in files:
         relpath = os.path.relpath(filepath, rootdir).replace(os.sep, "/")
-        passes, error = file_passes(filepath, templates)
+        new_file = relpath not in base
+        passes, error = file_passes(filepath, templates, new_file=new_file)
         if not passes:
             failed.append((relpath, error))
             print(relpath)  # stdout stays parseable

--- a/hack/gpu-time-slicing.yml
+++ b/hack/gpu-time-slicing.yml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # With GPU A10-2, the runner were queued for long time due to host capacity limit of CNCF Runner
 # Check for dicussion: https://cloud-native.slack.com/archives/C08P4HUFQ6M/p1773430783406709
 

--- a/manifests/base/crds/kustomization.yaml
+++ b/manifests/base/crds/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/manifests/base/manager/controller_manager_config.yaml
+++ b/manifests/base/manager/controller_manager_config.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: config.trainer.kubeflow.org/v1alpha1
 kind: Configuration
 # Health configuration

--- a/manifests/base/manager/kustomization.yaml
+++ b/manifests/base/manager/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 resources:
   - manager.yaml
 

--- a/manifests/base/manager/manager.yaml
+++ b/manifests/base/manager/manager.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/base/manager/manager_config_patch.yaml
+++ b/manifests/base/manager/manager_config_patch.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/base/rbac/kustomization.yaml
+++ b/manifests/base/rbac/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 resources:
   - role.yaml
   - role_binding.yaml

--- a/manifests/base/rbac/public_configmap_role.yaml
+++ b/manifests/base/rbac/public_configmap_role.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/manifests/base/rbac/public_configmap_role_binding.yaml
+++ b/manifests/base/rbac/public_configmap_role_binding.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/manifests/base/rbac/role.yaml
+++ b/manifests/base/rbac/role.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/base/rbac/role_binding.yaml
+++ b/manifests/base/rbac/role_binding.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/base/rbac/service_account.yaml
+++ b/manifests/base/rbac/service_account.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/manifests/base/runtimes/data-cache/kustomization.yaml
+++ b/manifests/base/runtimes/data-cache/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/manifests/base/runtimes/data-cache/torch_distributed_with_cache.yaml
+++ b/manifests/base/runtimes/data-cache/torch_distributed_with_cache.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:

--- a/manifests/base/runtimes/deepspeed_distributed.yaml
+++ b/manifests/base/runtimes/deepspeed_distributed.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:

--- a/manifests/base/runtimes/jax_distributed.yaml
+++ b/manifests/base/runtimes/jax_distributed.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:

--- a/manifests/base/runtimes/kustomization.yaml
+++ b/manifests/base/runtimes/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/manifests/base/runtimes/mlx_distributed.yaml
+++ b/manifests/base/runtimes/mlx_distributed.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:

--- a/manifests/base/runtimes/torch_distributed.yaml
+++ b/manifests/base/runtimes/torch_distributed.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:

--- a/manifests/base/runtimes/torchtune/kustomization.yaml
+++ b/manifests/base/runtimes/torchtune/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:

--- a/manifests/base/runtimes/torchtune/qwen2_5/qwen2_5_1.5B.yaml
+++ b/manifests/base/runtimes/torchtune/qwen2_5/qwen2_5_1.5B.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:

--- a/manifests/base/runtimes/xgboost_distributed.yaml
+++ b/manifests/base/runtimes/xgboost_distributed.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:

--- a/manifests/base/webhook/kustomization.yaml
+++ b/manifests/base/webhook/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/manifests/base/webhook/kustomizeconfig.yaml
+++ b/manifests/base/webhook/kustomizeconfig.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # the following config is for teaching kustomize where to look at when substituting vars.
 # It requires kustomize v2.1.0 or newer to work properly.
 namespace:

--- a/manifests/base/webhook/manifests.yaml
+++ b/manifests/base/webhook/manifests.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/manifests/base/webhook/patch_mutating.yaml
+++ b/manifests/base/webhook/patch_mutating.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 - op: replace
   path: /webhooks/0/clientConfig/service/name
   value: kubeflow-trainer-controller-manager

--- a/manifests/base/webhook/patch_validating.yaml
+++ b/manifests/base/webhook/patch_validating.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 - op: replace
   path: /webhooks/0/clientConfig/service/name
   value: kubeflow-trainer-controller-manager

--- a/manifests/overlays/data-cache/cluster_role.yaml
+++ b/manifests/overlays/data-cache/cluster_role.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/overlays/data-cache/kustomization.yaml
+++ b/manifests/overlays/data-cache/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/manifests/overlays/data-cache/namespace-rbac/kustomization.yaml
+++ b/manifests/overlays/data-cache/namespace-rbac/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/manifests/overlays/data-cache/namespace-rbac/role_binding.yaml
+++ b/manifests/overlays/data-cache/namespace-rbac/role_binding.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/manifests/overlays/data-cache/namespace-rbac/service_account.yaml
+++ b/manifests/overlays/data-cache/namespace-rbac/service_account.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/manifests/overlays/kubeflow-platform/kubeflow-trainer-roles.yaml
+++ b/manifests/overlays/kubeflow-platform/kubeflow-trainer-roles.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/manifests/overlays/kubeflow-platform/kustomization.yaml
+++ b/manifests/overlays/kubeflow-platform/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow

--- a/manifests/overlays/kubeflow-platform/patches/jobset-controller-manager-istio.yaml
+++ b/manifests/overlays/kubeflow-platform/patches/jobset-controller-manager-istio.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/overlays/kubeflow-platform/patches/remove-namespace.yaml
+++ b/manifests/overlays/kubeflow-platform/patches/remove-namespace.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 $patch: delete
 apiVersion: v1

--- a/manifests/overlays/kubeflow-platform/patches/trainer-manager-istio-and-selectors.yaml
+++ b/manifests/overlays/kubeflow-platform/patches/trainer-manager-istio-and-selectors.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/overlays/manager/kustomization.yaml
+++ b/manifests/overlays/manager/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/manifests/overlays/manager/namespace.yaml
+++ b/manifests/overlays/manager/namespace.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/manifests/overlays/runtimes/kustomization.yaml
+++ b/manifests/overlays/runtimes/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/manifests/third-party/jobset/kustomization.yaml
+++ b/manifests/third-party/jobset/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/manifests/third-party/jobset/patches/jobset_remove_namespace.yaml
+++ b/manifests/third-party/jobset/patches/jobset_remove_namespace.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 $patch: delete
 apiVersion: v1

--- a/manifests/third-party/leaderworkerset/kustomization.yaml
+++ b/manifests/third-party/leaderworkerset/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/manifests/third-party/leaderworkerset/patches/leaderworkerset_remove_namespace.yaml
+++ b/manifests/third-party/leaderworkerset/patches/leaderworkerset_remove_namespace.yaml
@@ -1,3 +1,17 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 $patch: delete
 apiVersion: v1


### PR DESCRIPTION
**What this PR does / why we need it**:

The boilerplate verifier mapped only Go, Rust, shell, Python and Dockerfiles to a template. This PR extends boilerplate support for YAML and YML. The file types supported include Helm templates and controller-gen generated manifests.

In addition this PR updates the decision logic for copyright enforcement. The following is the proposed decision logic. This enforcement only applies for changed/staged/committed files in working branch:
- not in master → enforce full check (year-less required)
- in master, no header → enforce full check
- in master, has header → enforce header still present
- deleted / relocated-with-header → skip

**Update:**

The decision logic for copyright enforcement has been refined as follows:
- For all files (old or new) we strip the year from the copyright header and match the normalized header against the boilerplate template. This check we already currently enforce in the CI.
- For new files specifically we enforce an additional check to enforce year-less copyright header - this second check requires a diff against master. This is the new enforcement in the code.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
