### PR TITLE
fix(runtimes): implement JAX reserved environment variable validation in Validate()

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -276,6 +276,18 @@ const (
 
 	// XGBoostEnvNumWorker is the env name for the total number of workers.
 	XGBoostEnvNumWorker string = "DMLC_NUM_WORKER"
+
+	// Distributed envs for JAX.
+	// Ref: https://jax.readthedocs.io/en/latest/multi_process.html
+
+	// JAXEnvNumProcesses is the env name for the total number of JAX processes.
+	JAXEnvNumProcesses string = "JAX_NUM_PROCESSES"
+
+	// JAXEnvProcessID is the env name for the JAX process ID (rank).
+	JAXEnvProcessID string = "JAX_PROCESS_ID"
+
+	// JAXEnvCoordinatorAddress is the env name for the coordinator address.
+	JAXEnvCoordinatorAddress string = "JAX_COORDINATOR_ADDRESS"
 )
 
 const (
@@ -304,6 +316,9 @@ var (
 
 	// MPIReservedEnvNames is MPI reserved env names that users must not set manually.
 	MPIReservedEnvNames = sets.New(OpenMPIEnvHostFileLocation, OpenMPIEnvKeyRSHArgs, OpenMPIEnvKeepFQDNHostNames, OpenMPIEnvDefaultSlots)
+
+	// JAXReservedEnvNames is JAX reserved env names that should not be set by users.
+	JAXReservedEnvNames = sets.New(JAXEnvNumProcesses, JAXEnvProcessID, JAXEnvCoordinatorAddress)
 
 	// ResourceInUseFinalizer is a finalizer for managed resources which is used by other resources.
 	ResourceInUseFinalizer = fmt.Sprintf("%s/resource-in-use", trainer.GroupVersion.Group)

--- a/pkg/runtime/framework/plugins/jax/jax.go
+++ b/pkg/runtime/framework/plugins/jax/jax.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/utils/ptr"
@@ -50,7 +51,30 @@ func (j *Jax) Name() string {
 }
 
 func (j *Jax) Validate(_ context.Context, runtimeInfo *runtime.Info, _, newObj *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
-	return nil, nil
+	var allErrs field.ErrorList
+
+	if runtimeInfo == nil || runtimeInfo.RuntimePolicy.MLPolicySource == nil || runtimeInfo.RuntimePolicy.MLPolicySource.JAX == nil {
+		return nil, allErrs
+	}
+
+	if newObj.Spec.Trainer != nil {
+		jaxEnvs := sets.New[string]()
+		for _, env := range newObj.Spec.Trainer.Env {
+			if constants.JAXReservedEnvNames.Has(env.Name) {
+				jaxEnvs.Insert(env.Name)
+			}
+		}
+
+		if jaxEnvs.Len() > 0 {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("spec", "trainer", "env"),
+				newObj.Spec.Trainer.Env,
+				fmt.Sprintf("must not have reserved envs, invalid envs configured: %v", sets.List(jaxEnvs)),
+			))
+		}
+	}
+
+	return nil, allErrs
 }
 
 func (j *Jax) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) error {

--- a/pkg/runtime/framework/plugins/jax/jax_test.go
+++ b/pkg/runtime/framework/plugins/jax/jax_test.go
@@ -26,6 +26,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
@@ -383,6 +385,208 @@ func TestJAXEnforceMLPolicy(t *testing.T) {
 				cmpopts.SortMaps(func(a, b string) bool { return a < b }),
 			); len(diff) != 0 {
 				t.Errorf("Unexpected RuntimeInfo (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestJAXValidate(t *testing.T) {
+	cases := map[string]struct {
+		runtimeInfo *runtime.Info
+		trainJob    *trainer.TrainJob
+		wantErrs    field.ErrorList
+	}{
+		"no action when info is nil": {
+			runtimeInfo: nil,
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				Obj(),
+		},
+		"no action when mlPolicySource is nil": {
+			runtimeInfo: runtime.NewInfo(
+				runtime.WithMLPolicySource(
+					utiltesting.MakeMLPolicyWrapper().Obj(),
+				),
+			),
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				Obj(),
+		},
+		"no action when JAX policy is nil": {
+			runtimeInfo: runtime.NewInfo(
+				runtime.WithMLPolicySource(
+					utiltesting.MakeMLPolicyWrapper().
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().Obj()).
+						Obj(),
+				),
+			),
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				Obj(),
+		},
+		"no action when trainer is nil": {
+			runtimeInfo: runtime.NewInfo(
+				runtime.WithMLPolicySource(
+					utiltesting.MakeMLPolicyWrapper().
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							JAXPolicy().
+							Obj(),
+						).
+						Obj(),
+				),
+			),
+			trainJob: &trainer.TrainJob{},
+		},
+		"pass when no envs configured": {
+			runtimeInfo: runtime.NewInfo(
+				runtime.WithMLPolicySource(
+					utiltesting.MakeMLPolicyWrapper().
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							JAXPolicy().
+							Obj(),
+						).
+						Obj(),
+				),
+			),
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				Obj(),
+		},
+		"pass when non reserved envs configured": {
+			runtimeInfo: runtime.NewInfo(
+				runtime.WithMLPolicySource(
+					utiltesting.MakeMLPolicyWrapper().
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							JAXPolicy().
+							Obj(),
+						).
+						Obj(),
+				),
+			),
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				Trainer(
+					utiltesting.MakeTrainJobTrainerWrapper().
+						Env(
+							[]corev1.EnvVar{
+								{Name: "USER_ENV", Value: "123"},
+							}...,
+						).
+						Obj(),
+				).
+				Obj(),
+		},
+		"reject when reserved envs configured": {
+			runtimeInfo: runtime.NewInfo(
+				runtime.WithMLPolicySource(
+					utiltesting.MakeMLPolicyWrapper().
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							JAXPolicy().
+							Obj(),
+						).
+						Obj(),
+				),
+			),
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				Trainer(
+					utiltesting.MakeTrainJobTrainerWrapper().
+						Env(
+							[]corev1.EnvVar{
+								{Name: "JAX_NUM_PROCESSES", Value: "2"},
+							}...,
+						).
+						Obj(),
+				).
+				Obj(),
+			wantErrs: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec", "trainer", "env"),
+					[]corev1.EnvVar{
+						{Name: "JAX_NUM_PROCESSES", Value: "2"},
+					},
+					fmt.Sprintf("must not have reserved envs, invalid envs configured: %v", sets.List(sets.New[string](constants.JAXEnvNumProcesses))),
+				),
+			},
+		},
+		"reject when all reserved envs configured": {
+			runtimeInfo: runtime.NewInfo(
+				runtime.WithMLPolicySource(
+					utiltesting.MakeMLPolicyWrapper().
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							JAXPolicy().
+							Obj(),
+						).
+						Obj(),
+				),
+			),
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				Trainer(
+					utiltesting.MakeTrainJobTrainerWrapper().
+						Env(
+							[]corev1.EnvVar{
+								{Name: "JAX_NUM_PROCESSES", Value: "4"},
+								{Name: "JAX_PROCESS_ID", Value: "0"},
+								{Name: "JAX_COORDINATOR_ADDRESS", Value: "coord:29500"},
+							}...,
+						).
+						Obj(),
+				).
+				Obj(),
+			wantErrs: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec", "trainer", "env"),
+					[]corev1.EnvVar{
+						{Name: "JAX_NUM_PROCESSES", Value: "4"},
+						{Name: "JAX_PROCESS_ID", Value: "0"},
+						{Name: "JAX_COORDINATOR_ADDRESS", Value: "coord:29500"},
+					},
+					fmt.Sprintf("must not have reserved envs, invalid envs configured: %v", sets.List(sets.New[string](constants.JAXEnvNumProcesses, constants.JAXEnvProcessID, constants.JAXEnvCoordinatorAddress))),
+				),
+			},
+		},
+		"reject mixed reserved and non reserved envs": {
+			runtimeInfo: runtime.NewInfo(
+				runtime.WithMLPolicySource(
+					utiltesting.MakeMLPolicyWrapper().
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							JAXPolicy().
+							Obj(),
+						).
+						Obj(),
+				),
+			),
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				Trainer(
+					utiltesting.MakeTrainJobTrainerWrapper().
+						Env(
+							[]corev1.EnvVar{
+								{Name: "JAX_NUM_PROCESSES", Value: "2"},
+								{Name: "MY_VAR", Value: "foo"},
+							}...,
+						).
+						Obj(),
+				).
+				Obj(),
+			wantErrs: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec", "trainer", "env"),
+					[]corev1.EnvVar{
+						{Name: "JAX_NUM_PROCESSES", Value: "2"},
+						{Name: "MY_VAR", Value: "foo"},
+					},
+					fmt.Sprintf("must not have reserved envs, invalid envs configured: %v", sets.List(sets.New[string](constants.JAXEnvNumProcesses))),
+				),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			cliBuilder := utiltesting.NewClientBuilder()
+			p, err := New(ctx, cliBuilder.Build(), nil, nil)
+			if err != nil {
+				t.Fatalf("Failed to create JAX plugin: %v", err)
+			}
+
+			_, errs := p.(framework.CustomValidationPlugin).Validate(ctx, tc.runtimeInfo, nil, tc.trainJob)
+			if diff := cmp.Diff(tc.wantErrs, errs); len(diff) != 0 {
+				t.Errorf("Unexpected errors (-want,+got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The JAX plugin`s `Validate()` method at `pkg/runtime/framework/plugins/jax/jax.go:52-54` was previously a no-op (`return nil, nil`). This allowed users to manually set `JAX_NUM_PROCESSES`, `JAX_PROCESS_ID`, or `JAX_COORDINATOR_ADDRESS` in their TrainJob`s `trainer.env`. When the controller runs `EnforceMLPolicy`, it silently overwrites these user-provided values via `apply.UpsertEnvVars`, leading to hard-to-debug training failures.

All other ML policy plugins (Torch, MPI, XGBoost) validate and reject TrainJobs that set reserved environment variables. This PR brings JAX to the same standard by:

1. Adding `JAXEnvNumProcesses`, `JAXEnvProcessID`, and `JAXEnvCoordinatorAddress` constants and a `JAXReservedEnvNames` set in `pkg/constants/constants.go`
2. Implementing real validation in the JAX plugin`s `Validate()` method that checks for reserved envs and returns `field.Invalid` errors, following the exact pattern used by the Torch plugin
3. Adding comprehensive test coverage with 9 test cases covering guard clauses, non-reserved envs, and reserved env rejection

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #3669

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing