### PR TITLE
feat(operator): add component-level context rules and depguard boundary enforcement

### DIFF
--- a/.claude/rules/pkg-apis.md
+++ b/.claude/rules/pkg-apis.md
@@ -1,0 +1,13 @@
+---
+paths:
+  - "pkg/apis/**"
+---
+
+# API type conventions
+
+- Pure data types only - no business logic, no imports from `pkg/controller/`, `pkg/webhooks/`, or `pkg/runtime/`
+- Use CEL validation (`+kubebuilder:validation:XValidation`) over webhook validation when possible
+- Mark optional fields with `+optional` and pointer types with `omitempty` json tag
+- Add `+kubebuilder:object:root=true` and `+k8s:deepcopy-gen:interfaces=...` markers on root types
+- Register new types in `groupversion_info.go` `addKnownTypes()`
+- Run `make generate` after any change - generated files (`zz_generated.*.go`) must never be edited manually

--- a/.claude/rules/pkg-controller.md
+++ b/.claude/rules/pkg-controller.md
@@ -1,0 +1,13 @@
+---
+paths:
+  - "pkg/controller/**"
+---
+
+# Controller conventions
+
+- Reconcilers implement `reconcile.Reconciler` - register in `setup.go` via `SetupControllers()`
+- Use `ctrl.LoggerFrom(ctx)` for structured logging - never create loggers manually
+- Use `mgr.GetEventRecorder()` for events - record both success and failure
+- Use server-side apply (SSA) for child resources via `pkg/apply/` - never `client.Create()` or `client.Update()`
+- Use finalizers via `ctrlutil.AddFinalizer` / `ctrlutil.RemoveFinalizer` for deletion cleanup
+- Tests use table-driven `map[string]struct` pattern with `utiltesting.NewClientBuilder()`

--- a/.claude/rules/pkg-runtime.md
+++ b/.claude/rules/pkg-runtime.md
@@ -1,0 +1,14 @@
+---
+paths:
+  - "pkg/runtime/**"
+---
+
+# Runtime and plugin conventions
+
+- Plugins follow factory pattern: `const Name` + `func New(ctx, client, indexer, cfg) (Plugin, error)`
+- Use compile-time interface assertions: `var _ framework.XPlugin = (*PluginName)(nil)`
+- Register in `plugins/registry.go` `NewRegistry()` - feature-gated plugins use `features.Enabled()`
+- Only one `TrainJobStatusPlugin` allowed - framework errors at startup if multiple registered
+- Plugin execution order within same interface type is non-deterministic - do not depend on ordering
+- Use Info object methods (`FindPodSetByAncestor`, `FindContainerByPodSetName`) - not manual traversal
+- Runtime registry (`core/registry.go`) has dependency resolution - declare dependencies in `RuntimeRegistrar`

--- a/.claude/rules/pkg-webhooks.md
+++ b/.claude/rules/pkg-webhooks.md
@@ -1,0 +1,13 @@
+---
+paths:
+  - "pkg/webhooks/**"
+---
+
+# Webhook conventions
+
+- Defaulters implement `admission.CustomDefaulter` - only set defaults, never validate
+- Validators implement `admission.CustomValidator` - delegate to runtime plugins via `Runtime.ValidateObjects()`
+- Do not put validation logic in webhook files - implement `CustomValidationPlugin` in the relevant plugin
+- Register in `setup.go` via private `setupWebhookFor*()` functions
+- Use `field.NewPath()` and `field.ErrorList` for structured errors
+- Use `clock.PassiveClock` for time-dependent logic to keep webhooks testable

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 bin/
 manifests/external-crds/
 .specify/
-.claude/
+.claude/*
+!.claude/rules/
+!.claude/settings.json
 specs/
 # IDEs
 .vscode/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,6 +6,57 @@ version: "2"
 run:
   allow-parallel-runners: true
 
+linters:
+  enable:
+    - depguard
+  settings:
+    depguard:
+      rules:
+        apis-boundary:
+          list-mode: lax
+          files:
+            - "pkg/apis/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/kubeflow/trainer/v2/pkg/controller
+              desc: "pkg/apis/ must not import pkg/controller/ - API types are pure data, no business logic"
+            - pkg: github.com/kubeflow/trainer/v2/pkg/webhooks
+              desc: "pkg/apis/ must not import pkg/webhooks/ - API types are pure data, no business logic"
+            - pkg: github.com/kubeflow/trainer/v2/pkg/runtime
+              desc: "pkg/apis/ must not import pkg/runtime/ - API types are pure data, no business logic"
+        controller-boundary:
+          list-mode: lax
+          files:
+            - "pkg/controller/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/kubeflow/trainer/v2/test
+              desc: "pkg/controller/ must not import test/ packages"
+            - pkg: github.com/kubeflow/trainer/v2/pkg/webhooks
+              desc: "pkg/controller/ must not import pkg/webhooks/ - controllers and webhooks are separate concerns"
+        webhooks-boundary:
+          list-mode: lax
+          files:
+            - "pkg/webhooks/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/kubeflow/trainer/v2/test
+              desc: "pkg/webhooks/ must not import test/ packages"
+            - pkg: github.com/kubeflow/trainer/v2/pkg/controller
+              desc: "pkg/webhooks/ must not import pkg/controller/ - webhooks delegate to runtime, not controller"
+        runtime-boundary:
+          list-mode: lax
+          files:
+            - "pkg/runtime/**"
+            - "!$test"
+          deny:
+            - pkg: github.com/kubeflow/trainer/v2/test
+              desc: "pkg/runtime/ must not import test/ packages"
+            - pkg: github.com/kubeflow/trainer/v2/pkg/controller
+              desc: "pkg/runtime/ must not import pkg/controller/ - runtime is consumed by controller, not the other way"
+            - pkg: github.com/kubeflow/trainer/v2/pkg/webhooks
+              desc: "pkg/runtime/ must not import pkg/webhooks/ - runtime is consumed by webhooks, not the other way"
+
 issues:
   max-same-issues: 0
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Tier 3 AI scaffolding for the trainer repo, continuing the work from #3652:

- **Component-level context files** (`.claude/rules/`): path-scoped rules for `pkg/controller/`, `pkg/apis/`, `pkg/webhooks/`, and `pkg/runtime/` with component-specific conventions that load only when editing matching files
- **Architectural boundary lint rules**: depguard rules in `.golangci.yaml` enforcing one-way import boundaries between core packages (e.g., `pkg/apis/` cannot import `pkg/controller/`, `pkg/runtime/` cannot import `pkg/webhooks/`)
- Updated `.gitignore` to track `.claude/rules/` while keeping session-local data excluded

**Which issue(s) this PR fixes**:
Fixes #3677

**Checklist:**

- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing