### PR TITLE
fix(operator): honor managedBy field in TrainJob reconciler

### DIFF
--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -106,6 +106,11 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(2).Info("Reconciling TrainJob")
 
+	if trainjob.IsManagedByExternalController(&trainJob) {
+		log.V(2).Info("Skipping TrainJob managed by a custom controller", "managedBy", ptr.Deref(trainJob.Spec.ManagedBy, ""))
+		return ctrl.Result{}, nil
+	}
+
 	var err error
 	// Keep track of the origin TrainJob status
 	prevTrainJob := trainJob.DeepCopy()

--- a/pkg/util/trainjob/trainjob.go
+++ b/pkg/util/trainjob/trainjob.go
@@ -23,9 +23,21 @@ import (
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 )
 
+const (
+	// TrainJobControllerName is the reserved value for the TrainJob managedBy field,
+	// indicating that the TrainJob is reconciled by the built-in TrainJob controller.
+	TrainJobControllerName string = "trainer.kubeflow.org/trainjob-controller"
+)
+
 func IsTrainJobFinished(trainJob *trainer.TrainJob) bool {
 	return meta.IsStatusConditionTrue(trainJob.Status.Conditions, trainer.TrainJobComplete) ||
 		meta.IsStatusConditionTrue(trainJob.Status.Conditions, trainer.TrainJobFailed)
+}
+
+// IsManagedByExternalController returns true when the TrainJob is managed by an external
+// controller, i.e. it is not reconciled by the built-in TrainJob controller.
+func IsManagedByExternalController(trainJob *trainer.TrainJob) bool {
+	return ptr.Deref(trainJob.Spec.ManagedBy, TrainJobControllerName) != TrainJobControllerName
 }
 
 func RuntimeRefIsTrainingRuntime(ref trainer.RuntimeRef) bool {

--- a/pkg/util/trainjob/trainjob_test.go
+++ b/pkg/util/trainjob/trainjob_test.go
@@ -135,6 +135,50 @@ func TestRuntimeRefIsClusterTrainingRuntime(t *testing.T) {
 	}
 }
 
+func TestIsManagedByExternalController(t *testing.T) {
+	cases := map[string]struct {
+		trainJob *trainer.TrainJob
+		want     bool
+	}{
+		"managedBy is unset": {
+			trainJob: &trainer.TrainJob{},
+			want:     false,
+		},
+		"managedBy is the built-in TrainJob controller": {
+			trainJob: &trainer.TrainJob{
+				Spec: trainer.TrainJobSpec{
+					ManagedBy: ptr.To(TrainJobControllerName),
+				},
+			},
+			want: false,
+		},
+		"managedBy is MultiKueue": {
+			trainJob: &trainer.TrainJob{
+				Spec: trainer.TrainJobSpec{
+					ManagedBy: ptr.To("kueue.x-k8s.io/multikueue"),
+				},
+			},
+			want: true,
+		},
+		"managedBy is an unrecognized controller": {
+			trainJob: &trainer.TrainJob{
+				Spec: trainer.TrainJobSpec{
+					ManagedBy: ptr.To("foo"),
+				},
+			},
+			want: true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := IsManagedByExternalController(tc.trainJob)
+			if got != tc.want {
+				t.Errorf("IsManagedByExternalController(%v) = %v, want %v", tc.trainJob, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIsTrainJobFinished(t *testing.T) {
 	cases := map[string]struct {
 		trainJob *trainer.TrainJob

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -507,6 +507,29 @@ var _ = ginkgo.Describe("TrainJob e2e", func() {
 		})
 	})
 
+	ginkgo.When("Creating a TrainJob managed by an external controller", func() {
+		ginkgo.It("should not be reconciled by the built-in controller", func() {
+			trainJob := testingutil.MakeTrainJobWrapper(ns.Name, "e2e-test-managed-by").
+				ManagedBy("kueue.x-k8s.io/multikueue").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), torchRuntime).
+				Obj()
+			trainJobKey := client.ObjectKeyFromObject(trainJob)
+
+			ginkgo.By("Create a TrainJob managed by MultiKueue", func() {
+				gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Ensuring the built-in controller neither creates a JobSet nor sets any status", func() {
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, trainJobKey, &jobsetv1alpha2.JobSet{})).Should(testingutil.BeNotFoundError())
+					gotTrainJob := &trainer.TrainJob{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, gotTrainJob)).Should(gomega.Succeed())
+					g.Expect(gotTrainJob.Status.Conditions).Should(gomega.BeEmpty())
+				}, 15*time.Second, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
+
 	ginkgo.When("Creating a TrainJob with Resource Timeouts", func() {
 		ginkgo.It("should fail the TrainJob with DeadlineExceeded when active timeout expires", func() {
 			deadline := int64(10)

--- a/test/integration/controller/trainjob_controller_test.go
+++ b/test/integration/controller/trainjob_controller_test.go
@@ -194,6 +194,23 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
+			ginkgo.It("Should not reconcile TrainJob managed by an external controller", func() {
+				ginkgo.By("Creating TrainingRuntime and a TrainJob managed by MultiKueue")
+				gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), trainingRuntime)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				trainJob.Spec.ManagedBy = ptr.To("kueue.x-k8s.io/multikueue")
+				gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+
+				ginkgo.By("Checking that the built-in controller does not create a JobSet nor set any status")
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, trainJobKey, &jobsetv1alpha2.JobSet{})).Should(testingutil.BeNotFoundError())
+					g.Expect(k8sClient.Get(ctx, trainJobKey, trainJob)).Should(gomega.Succeed())
+					g.Expect(trainJob.Status.Conditions).Should(gomega.BeEmpty())
+				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+			})
+
 			ginkgo.It("Should succeeded to update JobSet when TrainJob is suspended", func() {
 				ginkgo.By("Creating TrainingRuntime and suspended TrainJob")
 				gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
The TrainJob Reconciler does not honor `spec.managedBy`. It reconciles every TrainJob regardless of the field valueand conflicting with any external manager (e.g. MultiKueue) that is supposed to own the TrainJob.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #3632 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
