### PR TITLE
feat(docs): add theme toggle to top navbar

### DIFF
--- a/docs/_ext/kubeflow_topnav/topnav.html
+++ b/docs/_ext/kubeflow_topnav/topnav.html
@@ -37,4 +37,10 @@ GitHub</a>
 <a href='https://kubeflow.slack.com'>Slack</a>
 <a href='https://blog.kubeflow.org/trainer/intro/'>
 Blog</a>
+<button type='button' class='theme-toggle top-nav-theme-toggle' aria-label='Toggle Light / Dark / Auto color theme' title='Toggle Light / Dark / Auto color theme'>
+<svg class='theme-icon-when-auto-light'><use href='#svg-sun-with-moon'></use></svg>
+<svg class='theme-icon-when-auto-dark'><use href='#svg-moon-with-sun'></use></svg>
+<svg class='theme-icon-when-dark'><use href='#svg-moon'></use></svg>
+<svg class='theme-icon-when-light'><use href='#svg-sun'></use></svg>
+</button>
 </div></nav>

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -630,11 +630,49 @@ body:has(.landing-page) .sidebar-toggle {
     display: none !important;
 }
 
+body:has(.landing-page) footer:not(.landing-footer),
+body.is-landing footer:not(.landing-footer) {
+    border-top: none !important;
+    margin-top: 0 !important;
+    padding: 0 !important;
+    background-color: #0c1b33 !important;
+}
+
+/* Remove border-top divider from ethical ads and ReadTheDocs addons on the landing page */
+body:has(.landing-page) .ethical-ads-footer,
+body:has(.landing-page) #ethical-ad-placement,
+body:has(.landing-page) readthedocs-addons,
+body:has(.landing-page) .rst-versions,
+body.is-landing .ethical-ads-footer,
+body.is-landing #ethical-ad-placement,
+body.is-landing readthedocs-addons,
+body.is-landing .rst-versions {
+    border-top: none !important;
+}
+
+/* Make ethical ads background transparent */
+body:has(.landing-page) .ethical-ads-footer,
+body:has(.landing-page) .ethical-ads-footer *,
+body:has(.landing-page) #ethical-ad-placement,
+body:has(.landing-page) #ethical-ad-placement *,
+body.is-landing .ethical-ads-footer,
+body.is-landing .ethical-ads-footer *,
+body.is-landing #ethical-ad-placement,
+body.is-landing #ethical-ad-placement * {
+    background: transparent !important;
+    background-color: transparent !important;
+}
+
 body:has(.landing-page) .article-container {
     max-width: 100% !important;
     width: 100% !important;
     padding: 0 !important;
     margin: 0 !important;
+}
+
+.landing-page ~ .image-reference,
+.landing-page ~ .toctree-wrapper {
+    display: none !important;
 }
 
 /* Font import — DM Sans for headings, Source Sans 3 for body */

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -147,10 +147,10 @@ body {
 
 @media (max-width: 768px) {
     .top-nav-links {
-        display: none;
+        display: flex;
     }
-    .top-nav {
-        justify-content: center;
+    .top-nav-links a {
+        display: none !important;
     }
 }
 

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -88,6 +88,7 @@ body {
 
 .top-nav-links {
     display: flex;
+    align-items: center;
     gap: 0.5rem;
 }
 
@@ -103,6 +104,45 @@ body {
 .top-nav-links a:hover {
     color: var(--color-brand-primary, #4299e1) !important;
     background: var(--color-background-hover, rgba(0, 0, 0, 0.04));
+}
+
+/* Light/dark/auto mode toggle button */
+.top-nav-theme-toggle {
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    margin-left: 0.5rem;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--color-foreground-secondary, #2d3748) !important;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.top-nav-theme-toggle:hover {
+    color: var(--color-brand-primary, #4299e1) !important;
+    background: var(--color-background-hover, rgba(0, 0, 0, 0.04));
+}
+
+.top-nav-theme-toggle svg {
+    color: var(--color-foreground-secondary, #2d3748) !important;
+    width: 16px !important;
+    height: 16px !important;
+}
+
+/* Hide Furo's built-in theme toggle since we have the top-nav theme toggle */
+.theme-toggle-container,
+.theme-toggle-content,
+.theme-toggle:not(.top-nav-theme-toggle) {
+    display: none !important;
+}
+
+.top-nav-theme-toggle:hover svg {
+    color: var(--color-brand-primary, #4299e1) !important;
 }
 
 @media (max-width: 768px) {
@@ -584,9 +624,6 @@ body:has(.landing-page) .bottom-of-page {
 }
 
 body:has(.landing-page) .content-icon-container,
-body:has(.landing-page) .theme-toggle-container,
-body:has(.landing-page) .theme-toggle-content,
-body:has(.landing-page) .theme-toggle,
 body:has(.landing-page) .related-pages,
 body:has(.landing-page) .nav-overlay-icon,
 body:has(.landing-page) .sidebar-toggle {
@@ -619,6 +656,35 @@ body:has(.landing-page) .article-container {
     color: var(--lp-text);
     line-height: 1.6;
     background: #1a1c24;
+}
+
+/* Light Mode */
+body[data-theme="light"] .landing-page {
+    --lp-blue: #3182ce;
+    --lp-blue-deep: #1a3a6b;
+    --lp-blue-glow: #4299e1;
+    --lp-navy: #0c1b33;
+    --lp-surface: #ffffff;
+    --lp-surface-alt: #f7fafc;
+    --lp-text: #1a202c;
+    --lp-text-muted: #4a5568;
+    --lp-border: #e2e8f0;
+    background: #ffffff;
+}
+
+@media not (prefers-color-scheme: dark) {
+    body:not([data-theme="dark"]) .landing-page {
+        --lp-blue: #3182ce;
+        --lp-blue-deep: #1a3a6b;
+        --lp-blue-glow: #4299e1;
+        --lp-navy: #0c1b33;
+        --lp-surface: #ffffff;
+        --lp-surface-alt: #f7fafc;
+        --lp-text: #1a202c;
+        --lp-text-muted: #4a5568;
+        --lp-border: #e2e8f0;
+        background: #ffffff;
+    }
 }
 
 .landing-page .section-title {
@@ -1219,9 +1285,6 @@ body.is-landing .bottom-of-page {
 }
 
 body.is-landing .content-icon-container,
-body.is-landing .theme-toggle-container,
-body.is-landing .theme-toggle-content,
-body.is-landing .theme-toggle,
 body.is-landing .related-pages,
 body.is-landing .nav-overlay-icon,
 body.is-landing .sidebar-toggle {


### PR DESCRIPTION
## Summary

Adds a light/dark/auto theme toggle to the documentation landing page by placing it in the top navigation bar, providing immediate access to theme switching and aligning the landing page with the rest of the documentation.

Fixes #3680.

## Changes

- Added a light/dark/auto theme toggle to the top navigation bar.
- Hides Furo's default inline theme toggle to avoid duplicate controls.
- Added light theme support for the landing page.

## Screenshots
### Landing page

**Dark theme:** Theme toggle added to the top navigation bar.

| Before | After |
|---|---|
| <img width="1920" alt="Before Dark" src="https://github.com/user-attachments/assets/2c7b91d7-446e-48a8-900d-958aeeff8c83" /> | <img width="1920" alt="After Dark" src="https://github.com/user-attachments/assets/fad8c7f2-68da-4b6a-a0d3-4bc4804dce69" /> |

**Light theme:** Landing page now follows the selected theme.

| Before | After |
|---|---|
| <img width="1920" alt="Before Light" src="https://github.com/user-attachments/assets/c69798e5-9c53-4517-a62d-ddd39a57c19e" /> | <img width="1920" alt="After Light" src="https://github.com/user-attachments/assets/829f14c2-57e1-4a8f-a38c-cff425c4dbe2" /> |

### Documentation pages

**Getting Started:** Theme toggle moved to the top navigation bar.

| Before | After |
|---|---|
| <img width="1920" alt="Before Getting Started" src="https://github.com/user-attachments/assets/92f1b5a7-5c14-4e78-b0c7-1a6b7bf7c98a" /> | <img width="1920" alt="After Getting Started" src="https://github.com/user-attachments/assets/a4335615-50ce-422b-84d7-b86446f909ed" /> |

## Testing

- Ran `make html` successfully.
- Verified theme switching (light/dark/auto) on the landing page and documentation pages.
- Ran `pre-commit` hooks successfully.