### PR TITLE
fix(api): Add missing update validation to Training Runtime webhook

### DIFF
--- a/pkg/webhooks/trainingruntime_webhook.go
+++ b/pkg/webhooks/trainingruntime_webhook.go
@@ -105,7 +105,9 @@ func validateReplicatedJobs(rJobs []jobsetv1alpha2.ReplicatedJob) field.ErrorLis
 }
 
 func (w *TrainingRuntimeValidator) ValidateUpdate(ctx context.Context, oldObj, newObj *trainer.TrainingRuntime) (admission.Warnings, error) {
-	return nil, nil
+	log := ctrl.LoggerFrom(ctx).WithName("trainingruntime-webhook")
+	log.V(5).Info("Validating update", "trainingRuntime", klog.KObj(newObj))
+	return nil, validateReplicatedJobs(newObj.Spec.Template.Spec.ReplicatedJobs).ToAggregate()
 }
 
 func (w *TrainingRuntimeValidator) ValidateDelete(ctx context.Context, obj *trainer.TrainingRuntime) (admission.Warnings, error) {

--- a/test/integration/webhooks/trainjob_test.go
+++ b/test/integration/webhooks/trainjob_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
@@ -102,7 +103,7 @@ var _ = ginkgo.Describe("TrainJob Webhook", ginkgo.Ordered, func() {
 						Obj()
 				},
 				testingutil.BeForbiddenError()),
-			ginkgo.Entry("Should succeed in creating trainJob with namespace scoped trainingRuntime",
+			ginkgo.Entry("Should succeed in creating trainJob with cluster scoped ClusterTrainingRuntime",
 				func() *trainer.TrainJob {
 					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
 						RuntimeRef(trainer.GroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), runtimeName).
@@ -111,16 +112,18 @@ var _ = ginkgo.Describe("TrainJob Webhook", ginkgo.Ordered, func() {
 				gomega.Succeed()),
 			ginkgo.Entry("Should fail in creating trainJob with pre-trained model config when referencing a trainingRuntime without an initializer",
 				func() *trainer.TrainJob {
-					newContainers := []corev1.Container{}
-					// TODO (andreyvelich): Refactor this test to check ancestor label.
-					job := &trainingRuntime.Spec.Template.Spec.ReplicatedJobs[1]
-					for _, container := range job.Template.Spec.Template.Spec.Containers {
-						if container.Name != constants.ModelInitializer {
-							newContainers = append(newContainers, container)
+					// remove model initializer from runtime
+					var replicatedJobs []jobsetv1alpha2.ReplicatedJob
+					for _, rj := range trainingRuntime.Spec.Template.Spec.ReplicatedJobs {
+						labels := rj.Template.Labels
+						if v := labels[constants.LabelTrainJobAncestor]; v != constants.ModelInitializer {
+							replicatedJobs = append(replicatedJobs, rj)
 						}
 					}
-					job.Template.Spec.Template.Spec.Containers = newContainers
+					gomega.Expect(replicatedJobs).To(gomega.HaveLen(len(trainingRuntime.Spec.Template.Spec.ReplicatedJobs) - 1))
+					trainingRuntime.Spec.Template.Spec.ReplicatedJobs = replicatedJobs
 					gomega.Expect(k8sClient.Update(ctx, trainingRuntime)).To(gomega.Succeed())
+
 					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
 						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
 						Initializer(
@@ -137,15 +140,18 @@ var _ = ginkgo.Describe("TrainJob Webhook", ginkgo.Ordered, func() {
 				testingutil.BeForbiddenError()),
 			ginkgo.Entry("Should fail in creating trainJob with dataset initializer when referencing a trainingRuntime without an initializer",
 				func() *trainer.TrainJob {
-					newContainers := []corev1.Container{}
-					job := &trainingRuntime.Spec.Template.Spec.ReplicatedJobs[0]
-					for _, container := range job.Template.Spec.Template.Spec.Containers {
-						if container.Name != constants.DatasetInitializer {
-							newContainers = append(newContainers, container)
+					// remove dataset initializer from runtime
+					var replicatedJobs []jobsetv1alpha2.ReplicatedJob
+					for _, rj := range trainingRuntime.Spec.Template.Spec.ReplicatedJobs {
+						labels := rj.Template.Labels
+						if v := labels[constants.LabelTrainJobAncestor]; v != constants.DatasetInitializer {
+							replicatedJobs = append(replicatedJobs, rj)
 						}
 					}
-					job.Template.Spec.Template.Spec.Containers = newContainers
+					gomega.Expect(replicatedJobs).To(gomega.HaveLen(len(trainingRuntime.Spec.Template.Spec.ReplicatedJobs) - 1))
+					trainingRuntime.Spec.Template.Spec.ReplicatedJobs = replicatedJobs
 					gomega.Expect(k8sClient.Update(ctx, trainingRuntime)).To(gomega.Succeed())
+
 					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
 						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
 						Initializer(


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR adds the missing validation to the namespaced `TrainingRuntime` webhook.

Previously, validation was only being done on creation, not on update. This PR adds the validation to the ValidateUpdate() method to match the existing validation in the `ClusterTrainingRuntime` webhook.

As part of this, I've had to update two of the tests which were previously updating the the TrainingRuntime in a way that should have failed validation..

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #3686

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
