### PR TITLE
fix(api): increase the length limit on train job commands and args

### DIFF
--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
@@ -5610,7 +5610,7 @@ spec:
                   args:
                     description: args for the entrypoint for the training container.
                     items:
-                      maxLength: 65536
+                      maxLength: 4194304
                       type: string
                     maxItems: 128
                     type: array
@@ -5618,7 +5618,7 @@ spec:
                   command:
                     description: command for the entrypoint of the training container.
                     items:
-                      maxLength: 65536
+                      maxLength: 4194304
                       type: string
                     maxItems: 128
                     type: array

--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
@@ -5610,7 +5610,7 @@ spec:
                   args:
                     description: args for the entrypoint for the training container.
                     items:
-                      maxLength: 4194304
+                      maxLength: 1048576
                       type: string
                     maxItems: 128
                     type: array
@@ -5618,7 +5618,7 @@ spec:
                   command:
                     description: command for the entrypoint of the training container.
                     items:
-                      maxLength: 4194304
+                      maxLength: 1048576
                       type: string
                     maxItems: 128
                     type: array

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -5607,7 +5607,7 @@ spec:
                   args:
                     description: args for the entrypoint for the training container.
                     items:
-                      maxLength: 65536
+                      maxLength: 4194304
                       type: string
                     maxItems: 128
                     type: array
@@ -5615,7 +5615,7 @@ spec:
                   command:
                     description: command for the entrypoint of the training container.
                     items:
-                      maxLength: 65536
+                      maxLength: 4194304
                       type: string
                     maxItems: 128
                     type: array

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -5607,7 +5607,7 @@ spec:
                   args:
                     description: args for the entrypoint for the training container.
                     items:
-                      maxLength: 4194304
+                      maxLength: 1048576
                       type: string
                     maxItems: 128
                     type: array
@@ -5615,7 +5615,7 @@ spec:
                   command:
                     description: command for the entrypoint of the training container.
                     items:
-                      maxLength: 4194304
+                      maxLength: 1048576
                       type: string
                     maxItems: 128
                     type: array

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -253,14 +253,14 @@ type Trainer struct {
 	// command for the entrypoint of the training container.
 	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=128
-	// +kubebuilder:validation:items:MaxLength=65536
+	// +kubebuilder:validation:items:MaxLength=4194304
 	// +optional
 	Command []string `json:"command,omitempty"`
 
 	// args for the entrypoint for the training container.
 	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=128
-	// +kubebuilder:validation:items:MaxLength=65536
+	// +kubebuilder:validation:items:MaxLength=4194304
 	// +optional
 	Args []string `json:"args,omitempty"`
 

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -253,14 +253,14 @@ type Trainer struct {
 	// command for the entrypoint of the training container.
 	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=128
-	// +kubebuilder:validation:items:MaxLength=4194304
+	// +kubebuilder:validation:items:MaxLength=1048576
 	// +optional
 	Command []string `json:"command,omitempty"`
 
 	// args for the entrypoint for the training container.
 	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=128
-	// +kubebuilder:validation:items:MaxLength=4194304
+	// +kubebuilder:validation:items:MaxLength=1048576
 	// +optional
 	Args []string `json:"args,omitempty"`
 

--- a/test/integration/webhooks/trainjob_test.go
+++ b/test/integration/webhooks/trainjob_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package webhooks
 
 import (
+	"strings"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -342,6 +344,50 @@ var _ = ginkgo.Describe("TrainJob Webhook", ginkgo.Ordered, func() {
 						Obj()
 				},
 				gomega.Succeed(),
+			),
+			ginkgo.Entry("Should succeed to create TrainJob with trainer command item at the max length",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), runtimeName).
+						Trainer(&trainer.Trainer{
+							Command: []string{strings.Repeat("a", 1048576)},
+						}).
+						Obj()
+				},
+				gomega.Succeed(),
+			),
+			ginkgo.Entry("Should fail to create TrainJob with trainer command item exceeding the max length",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), runtimeName).
+						Trainer(&trainer.Trainer{
+							Command: []string{strings.Repeat("a", 1048576+1)},
+						}).
+						Obj()
+				},
+				testingutil.BeInvalidError(),
+			),
+			ginkgo.Entry("Should succeed to create TrainJob with trainer args item at the max length",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), runtimeName).
+						Trainer(&trainer.Trainer{
+							Args: []string{strings.Repeat("a", 1048576)},
+						}).
+						Obj()
+				},
+				gomega.Succeed(),
+			),
+			ginkgo.Entry("Should fail to create TrainJob with trainer args item exceeding the max length",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), runtimeName).
+						Trainer(&trainer.Trainer{
+							Args: []string{strings.Repeat("a", 1048576+1)},
+						}).
+						Obj()
+				},
+				testingutil.BeInvalidError(),
 			),
 		)
 		ginkgo.DescribeTable("RFC1035-compliant TrainJob name validation", func(trainJob func() *trainer.TrainJob, errorMatcher gomega.OmegaMatcher) {


### PR DESCRIPTION
 This PR increases the maximum length for `TrainJob` `Command` and `Args` items from 65,536 to 4,194,304 characters (4MB).

The current 65k character limit is too restrictive for the SDK's custom training job feature, which inlines training scripts directly into the `command` / `args` fields. While 65k characters (~2k lines of Python) covers many use cases, it's an arbitrary constraint that can block legitimate use cases.

Rather than remove the limit, I've increased the max size to 4MB so it's effectively infinite because afaict KAL doesn't let me suppress just a single linting rule. I'd have to suppress all the linting checks for these fields which is not ideal.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #3688

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
