### PR TITLE
chore(ci): skip image builds and E2E tests for docs-only changes

### DIFF
--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -22,6 +22,8 @@ on:
     tags:
       - "v*"
   pull_request:
+    paths-ignore:
+      - 'docs/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -24,6 +24,7 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'proposals/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -18,6 +18,7 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'proposals/**'
 
 permissions:
   contents: read

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -16,6 +16,8 @@ name: E2E Tests
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `paths-ignore: docs/**` to `build-and-push-images.yaml` and `test-e2e.yaml` so docs-only PRs/changes skip image builds and E2E tests. 

- What still runs: Unit tests, linting, and DCO checks will still run on all PRs. Push triggers remain unchanged.

- Reference: https://github.com/kubeflow/trainer/pull/3682#issuecomment-4879301048

**Which issue(s) this PR fixes**:
N/A

**Checklist:**
- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing