### PR TITLE
fix(docs): update Trainer documentation links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -16,7 +16,7 @@ blank_issues_enabled: true
 
 contact_links:
   - name: Kubeflow Trainer Documentation
-    url: https://www.kubeflow.org/docs/components/trainer/
+    url: https://trainer.kubeflow.org/en/latest/
     about: Much help can be found in the docs
   - name: Kubeflow Trainer Slack Channel
     url: https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,4 @@ Fixes #
 
 **Checklist:**
 
-- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
+- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the remaining repository contribution templates that still point to the old Kubeflow Trainer docs URL. The Trainer docs now live at `trainer.kubeflow.org`, and these links were listed in #3676 as known affected locations.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #3676

**Checklist:**

- [x] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing

Validation:
- Parsed `.github/ISSUE_TEMPLATE/config.yml` with Python `yaml.safe_load`
- Confirmed the old Trainer docs URL no longer appears in the two touched template files

AI assistance disclosure:
- I used AI assistance to identify the affected files and prepare this small documentation link update.
