### PR TITLE
fix(docs): update Trainer documentation links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -16,7 +16,7 @@ blank_issues_enabled: true
 
 contact_links:
   - name: Kubeflow Trainer Documentation
-    url: https://www.kubeflow.org/docs/components/trainer/
+    url: https://trainer.kubeflow.org/en/latest/
     about: Much help can be found in the docs
   - name: Kubeflow Trainer Slack Channel
     url: https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,4 @@ Fixes #
 
 **Checklist:**
 
-- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
+- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Before writing code, agents should:
 - Review CRD schemas in `pkg/apis/` before changing API structures
 - Call out for any breaking changes introduced and follow the deprecation policy
 
-For additional context see [the Kubeflow Trainer docs](https://www.kubeflow.org/docs/components/trainer/overview/).
+For additional context see [the Kubeflow Trainer docs](https://trainer.kubeflow.org/en/latest/overview/index.html).
 
 ## Repository Map
 

--- a/CHANGELOG/CHANGELOG-2.0.md
+++ b/CHANGELOG/CHANGELOG-2.0.md
@@ -25,7 +25,7 @@ For more information, please see the
 
 - [Blog post announcement](https://blog.kubeflow.org/trainer/intro/)
 
-- [Migration guide from the Training Operator v1](https://www.kubeflow.org/docs/components/trainer/operator-guides/migration/)
+- [Migration guide from the Training Operator v1](https://trainer.kubeflow.org/en/latest/operator-guides/migration.html)
 
 ## Breaking Changes
 

--- a/CHANGELOG/CHANGELOG-2.1.md
+++ b/CHANGELOG/CHANGELOG-2.1.md
@@ -13,7 +13,7 @@ You can now install controller manager with Helm charts 🚀
 helm install kubeflow-trainer oci://ghcr.io/kubeflow/charts/kubeflow-trainer --version 2.1.0
 ```
 
-For more information, please see [the Kubeflow Trainer docs](https://www.kubeflow.org/docs/components/trainer/overview/)
+For more information, please see [the Kubeflow Trainer docs](https://trainer.kubeflow.org/en/latest/overview/index.html)
 
 ## Breaking Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Developer Guide
 
 This guide explains how to contribute to the Kubeflow Trainer V2 project.
-For the Kubeflow Trainer documentation, please check [the official Kubeflow documentation](https://www.kubeflow.org/docs/components/trainer/overview/).
+For the Kubeflow Trainer documentation, please check [the official Kubeflow documentation](https://trainer.kubeflow.org/en/latest/overview/index.html).
 
 ## AI Assistant Tooling
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Latest News 🔥
   and Flux Framework integration for HPC and MPI workloads. Check out
   [the blog post announcement](https://blog.kubeflow.org/kubeflow-trainer-v2.2-release/).
 - [2025/11] Kubeflow Trainer v2.1 is officially released with support of
-  [Distributed Data Cache](https://www.kubeflow.org/docs/components/trainer/user-guides/data-cache/),
+  [Distributed Data Cache](https://trainer.kubeflow.org/en/latest/user-guides/data-cache.html),
   topology aware scheduling with Kueue and Volcano, and LLM post-training enhancements. Check out
   [the GitHub release notes](https://github.com/kubeflow/trainer/releases/tag/v2.1.0).
 - [2025/09] Kubeflow SDK v0.1 is officially released with support for CustomTrainer,
@@ -80,7 +80,7 @@ Additional talks:
 
 ## Getting Started
 
-Please check [the official Kubeflow Trainer documentation](https://www.kubeflow.org/docs/components/trainer/getting-started)
+Please check [the official Kubeflow Trainer documentation](https://trainer.kubeflow.org/en/latest/getting-started/index.html)
 to install and get started with Kubeflow Trainer.
 
 ## Community
@@ -102,12 +102,12 @@ Please refer to the [CHANGELOG](CHANGELOG/) directory.
 ## Kubeflow Training Operator V1
 
 Kubeflow Trainer project is currently in <strong>alpha</strong> status, and APIs may change.
-If you are using Kubeflow Training Operator V1, please refer [to this migration document](https://www.kubeflow.org/docs/components/trainer/operator-guides/migration/).
+If you are using Kubeflow Training Operator V1, please refer [to this migration document](https://trainer.kubeflow.org/en/latest/operator-guides/migration.html).
 
 Kubeflow Community will maintain the Training Operator V1 source code at
 [the `release-1.9` branch](https://github.com/kubeflow/trainer/tree/release-1.9).
 
-You can find the documentation for Kubeflow Training Operator V1 in [these guides](https://www.kubeflow.org/docs/components/trainer/legacy-v1).
+You can find the documentation for Kubeflow Training Operator V1 in [these guides](https://trainer.kubeflow.org/en/latest/legacy-v1/index.html).
 
 ## Acknowledgement
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,4 +2,4 @@
 
 Welcome to Kubeflow Trainer!
 
-The Kubeflow Trainer documentation is available on [kubeflow.org](https://www.kubeflow.org/docs/components/trainer/).
+The Kubeflow Trainer documentation is available on [trainer.kubeflow.org](https://trainer.kubeflow.org/en/latest/).

--- a/examples/README.md
+++ b/examples/README.md
@@ -75,9 +75,9 @@ kubectl apply -f yaml/02-runtime-patches.yaml
 
 ## Documentation
 
-- [Kubeflow Trainer Documentation](https://www.kubeflow.org/docs/components/trainer/)
-- [Getting Started Guide](https://www.kubeflow.org/docs/components/trainer/getting-started/)
-- [Runtime Guide](https://www.kubeflow.org/docs/components/trainer/operator-guides/runtime/)
+- [Kubeflow Trainer Documentation](https://trainer.kubeflow.org/en/latest/)
+- [Getting Started Guide](https://trainer.kubeflow.org/en/latest/getting-started/index.html)
+- [Runtime Guide](https://trainer.kubeflow.org/en/latest/operator-guides/runtime.html)
 - [Kubeflow SDK Documentation](https://sdk.kubeflow.org/en/latest/)
 
 ## Contributing

--- a/examples/yaml/01-multi-node.yaml
+++ b/examples/yaml/01-multi-node.yaml
@@ -20,7 +20,7 @@
 # (PET_NNODES, PET_NPROC_PER_NODE, PET_NODE_RANK, PET_MASTER_ADDR,
 # PET_MASTER_PORT) and exposes WORLD_SIZE / RANK / LOCAL_RANK to each worker.
 #
-# See https://www.kubeflow.org/docs/components/trainer/user-guides/pytorch/#pytorch-distributed-environment
+# See https://trainer.kubeflow.org/en/latest/user-guides/pytorch.html#pytorch-distributed-environment
 #
 # Apply: kubectl apply -f 01-multi-node.yaml
 # Check: kubectl get trainjob multi-node-example

--- a/examples/yaml/04-volcano-integration.yaml
+++ b/examples/yaml/04-volcano-integration.yaml
@@ -32,7 +32,7 @@
 # Clean: kubectl delete trainjob volcano-example && \
 #        kubectl delete clustertrainingruntime torch-distributed-volcano
 #
-# Reference: https://www.kubeflow.org/docs/components/trainer/operator-guides/job-scheduling/volcano/
+# Reference: https://trainer.kubeflow.org/en/latest/operator-guides/job-scheduling/volcano.html
 
 apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime

--- a/examples/yaml/README.md
+++ b/examples/yaml/README.md
@@ -1,6 +1,6 @@
 # Kubeflow Trainer YAML Examples
 
-Standalone manifests that can be applied directly with `kubectl`. For an end-to-end conceptual walkthrough, see the [Kubeflow Trainer documentation](https://www.kubeflow.org/docs/components/trainer/).
+Standalone manifests that can be applied directly with `kubectl`. For an end-to-end conceptual walkthrough, see the [Kubeflow Trainer documentation](https://trainer.kubeflow.org/en/latest/).
 
 ## Prerequisites
 
@@ -34,6 +34,6 @@ kubectl delete trainjob multi-node-example
 
 ## See also
 
-- [Runtime guide](https://www.kubeflow.org/docs/components/trainer/operator-guides/runtime/)
-- [Job scheduling guide](https://www.kubeflow.org/docs/components/trainer/operator-guides/job-scheduling/)
+- [Runtime guide](https://trainer.kubeflow.org/en/latest/operator-guides/runtime.html)
+- [Job scheduling guide](https://trainer.kubeflow.org/en/latest/operator-guides/job-scheduling/overview.html)
 - [Python SDK examples](../pytorch/)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -47,7 +47,7 @@ const (
 	SupportDeprecated string = "deprecated"
 
 	// RuntimeDeprecationPolicyURL is the URL to the runtime deprecation policy documentation.
-	RuntimeDeprecationPolicyURL string = "https://www.kubeflow.org/docs/components/trainer/operator-guides/runtime/#runtime-deprecation-policy"
+	RuntimeDeprecationPolicyURL string = "https://trainer.kubeflow.org/en/latest/operator-guides/runtime.html#runtime-deprecation-policy"
 
 	// DatasetInitializer is the name of the Job, volume mount, container, and label value for the dataset initializer.
 	DatasetInitializer string = "dataset-initializer"

--- a/proposals/2432-gpu-testing-on-llm-blueprints/README.md
+++ b/proposals/2432-gpu-testing-on-llm-blueprints/README.md
@@ -166,7 +166,7 @@ I will be using OKE to deploy after production. To make sure there is no unneces
 
 Oracle Docs[ https://oracle.github.io/fmw-kubernetes/wccontent-domains/oracle-cloud/prepare-oke-environment/ https://github.com/oracle/weblogic-kubernetes-operator/blob/main/kubernetes/hands-on-lab/tutorials/setup.oke.ocishell.md](https://oracle.github.io/fmw-kubernetes/wccontent-domains/oracle-cloud/prepare-oke-environment/)
 
-KubeFlow Docs[ https://www.kubeflow.org/docs/components/trainer/getting-started/ https://www.kubeflow.org/docs/started/architecture/](https://www.kubeflow.org/docs/components/trainer/getting-started/)
+KubeFlow Docs[ https://trainer.kubeflow.org/en/latest/getting-started/index.html https://www.kubeflow.org/docs/started/architecture/](https://trainer.kubeflow.org/en/latest/getting-started/index.html)
 
 GitHub ACR Docs[ https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/about-actions-runner-controller](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/about-actions-runner-controller)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates all remaining old Trainer documentation URLs (`kubeflow.org/docs/components/trainer`) to the new docs site (`trainer.kubeflow.org`).

This PR inherits the work from #3700 by @iacker, who contributed the most of the changes (updating links in `.github/PULL_REQUEST_TEMPLATE.md` and `.github/ISSUE_TEMPLATE/config.yml`). Thank you @iacker for identifying the affected files and preparing the initial update!

My contribution adds the missing README link updates requested in the [review](https://github.com/kubeflow/trainer/pull/3700#pullrequestreview-4637662616), fixes the DCO sign-off, and drops the empty trigger commit so the PR can be merged.

**Which issue(s) this PR fixes**:
Fixes #3676

**Checklist:**

- [x] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing