### PR TITLE
feat(initializer): validate initializer Pod uses correct volume name

### DIFF
--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -98,22 +97,14 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 	// TODO (andreyvelich): Refactor this test to verify the ancestor label in PodTemplate.
 	rJobContainerNames := make(map[string]sets.Set[string])
 	for _, rJob := range jobSetSpec.ReplicatedJobs {
-		if rJob.Name == nil {
-			continue
-		}
-		rJobName := *rJob.Name
-		rJobContainerNames[rJobName] = sets.New[string]()
+		rJobContainerNames[*rJob.Name] = sets.New[string]()
 
 		// Names of initContainer and containers are unique.
 		for _, c := range rJob.Template.Spec.Template.Spec.InitContainers {
-			if c.Name != nil {
-				rJobContainerNames[rJobName].Insert(*c.Name)
-			}
+			rJobContainerNames[*rJob.Name].Insert(*c.Name)
 		}
 		for _, c := range rJob.Template.Spec.Template.Spec.Containers {
-			if c.Name != nil {
-				rJobContainerNames[rJobName].Insert(*c.Name)
-			}
+			rJobContainerNames[*rJob.Name].Insert(*c.Name)
 		}
 	}
 
@@ -123,8 +114,27 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have %s job when trainJob is configured with input datasetConfig", constants.DatasetInitializer)))
 		} else if !containers.Has(constants.DatasetInitializer) {
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have container with name - %s in the %s job", constants.DatasetInitializer, constants.DatasetInitializer)))
-		} else if !initializerContainerHasVolumeMount(jobSetSpec, constants.DatasetInitializer, constants.DatasetInitializer) {
-			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volumeMount with name - %s in container %s of the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer, constants.DatasetInitializer)))
+		} else {
+			hasVolumeMount := false
+			for _, rJob := range jobSetSpec.ReplicatedJobs {
+				if *rJob.Name != constants.DatasetInitializer {
+					continue
+				}
+				for _, c := range rJob.Template.Spec.Template.Spec.Containers {
+					if *c.Name != constants.DatasetInitializer {
+						continue
+					}
+					for _, vm := range c.VolumeMounts {
+						if *vm.Name == jobsetplgconsts.VolumeNameInitializer {
+							hasVolumeMount = true
+							break
+						}
+					}
+				}
+			}
+			if !hasVolumeMount {
+				allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volumeMount with name - %s in container %s of the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer, constants.DatasetInitializer)))
+			}
 		}
 	}
 
@@ -134,8 +144,27 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have %s job when trainJob is configured with input modelConfig", constants.ModelInitializer)))
 		} else if !containers.Has(constants.ModelInitializer) {
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have container with name - %s in the %s job", constants.ModelInitializer, constants.ModelInitializer)))
-		} else if !initializerContainerHasVolumeMount(jobSetSpec, constants.ModelInitializer, constants.ModelInitializer) {
-			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volumeMount with name - %s in container %s of the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer, constants.ModelInitializer)))
+		} else {
+			hasVolumeMount := false
+			for _, rJob := range jobSetSpec.ReplicatedJobs {
+				if *rJob.Name != constants.ModelInitializer {
+					continue
+				}
+				for _, c := range rJob.Template.Spec.Template.Spec.Containers {
+					if *c.Name != constants.ModelInitializer {
+						continue
+					}
+					for _, vm := range c.VolumeMounts {
+						if *vm.Name == jobsetplgconsts.VolumeNameInitializer {
+							hasVolumeMount = true
+							break
+						}
+					}
+				}
+			}
+			if !hasVolumeMount {
+				allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volumeMount with name - %s in container %s of the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer, constants.ModelInitializer)))
+			}
 		}
 	}
 
@@ -179,43 +208,6 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 	}
 
 	return nil, allErrs
-}
-
-// initializerContainerHasVolumeMount reports whether the container named containerName in the
-// ReplicatedJob named rJobName mounts a volume named jobsetplgconsts.VolumeNameInitializer.
-// The volume itself is supplied by the runtime via JobSet volumeClaimPolicies and injected by
-// the JobSet controller, so only the VolumeMount can be validated at admission time.
-func initializerContainerHasVolumeMount(spec *jobsetv1alpha2ac.JobSetSpecApplyConfiguration, rJobName, containerName string) bool {
-	hasMount := func(c corev1ac.ContainerApplyConfiguration) bool {
-		if c.Name == nil || *c.Name != containerName {
-			return false
-		}
-		for _, vm := range c.VolumeMounts {
-			if vm.Name != nil && *vm.Name == jobsetplgconsts.VolumeNameInitializer {
-				return true
-			}
-		}
-		return false
-	}
-
-	for _, rJob := range spec.ReplicatedJobs {
-		if rJob.Name == nil || *rJob.Name != rJobName {
-			continue
-		}
-		podSpec := rJob.Template.Spec.Template.Spec
-		for _, c := range podSpec.InitContainers {
-			if hasMount(c) {
-				return true
-			}
-		}
-		for _, c := range podSpec.Containers {
-			if hasMount(c) {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 func (j *JobSet) checkRuntimePatchesImmutability(ctx context.Context, oldObj, newObj *trainer.TrainJob) field.ErrorList {

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -96,45 +96,76 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 
 	// TODO (andreyvelich): Refactor this test to verify the ancestor label in PodTemplate.
 	rJobContainerNames := make(map[string]sets.Set[string])
-	rJobVolumeNames := make(map[string]sets.Set[string])
+	rJobContainerVolumeMountNames := make(map[string]map[string]sets.Set[string])
+
 	for _, rJob := range jobSetSpec.ReplicatedJobs {
-		rJobContainerNames[*rJob.Name] = sets.New[string]()
+		if rJob.Name == nil {
+			continue
+		}
+		rJobName := *rJob.Name
+
+		rJobContainerNames[rJobName] = sets.New[string]()
+		rJobContainerVolumeMountNames[rJobName] = make(map[string]sets.Set[string])
+
 		// Names of initContainer and containers are unique.
 		for _, c := range rJob.Template.Spec.Template.Spec.InitContainers {
-			rJobContainerNames[*rJob.Name].Insert(*c.Name)
+			if c.Name == nil {
+				continue
+			}
+			containerName := *c.Name
+			rJobContainerNames[rJobName].Insert(containerName)
+			rJobContainerVolumeMountNames[rJobName][containerName] = sets.New[string]()
+
+			for _, vm := range c.VolumeMounts {
+				if vm.Name == nil {
+					continue
+				}
+				rJobContainerVolumeMountNames[rJobName][containerName].Insert(*vm.Name)
+			}
 		}
+
 		for _, c := range rJob.Template.Spec.Template.Spec.Containers {
-			rJobContainerNames[*rJob.Name].Insert(*c.Name)
-		}
-		rJobVolumeNames[*rJob.Name] = sets.New[string]()
-		for _, v := range rJob.Template.Spec.Template.Spec.Volumes {
-			if v.Name == nil {
- 				continue
- 			}
-			rJobVolumeNames[*rJob.Name].Insert(*v.Name)
+			if c.Name == nil {
+				continue
+			}
+			containerName := *c.Name
+			rJobContainerNames[rJobName].Insert(containerName)
+			rJobContainerVolumeMountNames[rJobName][containerName] = sets.New[string]()
+
+			for _, vm := range c.VolumeMounts {
+				if vm.Name == nil {
+					continue
+				}
+				rJobContainerVolumeMountNames[rJobName][containerName].Insert(*vm.Name)
+			}
 		}
 	}
+
 	if newObj.Spec.Initializer != nil && newObj.Spec.Initializer.Dataset != nil {
-		if containers, ok := rJobContainerNames[constants.DatasetInitializer]; !ok {
+		containers, ok := rJobContainerNames[constants.DatasetInitializer]
+		if !ok {
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have %s job when trainJob is configured with input datasetConfig", constants.DatasetInitializer)))
+		} else if !containers.Has(constants.DatasetInitializer) {
+			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have container with name - %s in the %s job", constants.DatasetInitializer, constants.DatasetInitializer)))
 		} else {
- 			if !containers.Has(constants.DatasetInitializer) {
- 				allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have container with name - %s in the %s job", constants.DatasetInitializer, constants.DatasetInitializer)))
- 			}
- 			if volumes := rJobVolumeNames[constants.DatasetInitializer]; !volumes.Has(jobsetplgconsts.VolumeNameInitializer) {
- 				allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer)))
- 			}
+			if volumeMounts := rJobContainerVolumeMountNames[constants.DatasetInitializer][constants.DatasetInitializer]; !volumeMounts.Has(jobsetplgconsts.VolumeNameInitializer) {
+				allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volumeMount with name - %s in container %s of the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer, constants.DatasetInitializer)))
+			}
+		}
 	}
+
 	if newObj.Spec.Initializer != nil && newObj.Spec.Initializer.Model != nil {
-		if containers, ok := rJobContainerNames[constants.ModelInitializer]; !ok {
+		containers, ok := rJobContainerNames[constants.ModelInitializer]
+		if !ok {
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have %s job when trainJob is configured with input modelConfig", constants.ModelInitializer)))
+		} else if !containers.Has(constants.ModelInitializer) {
+			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have container with name - %s in the %s job", constants.ModelInitializer, constants.ModelInitializer)))
 		} else {
- 			if !containers.Has(constants.ModelInitializer) {
- 				allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have container with name - %s in the %s job", constants.ModelInitializer, constants.ModelInitializer)))
- 			}
- 			if volumes := rJobVolumeNames[constants.ModelInitializer]; !volumes.Has(jobsetplgconsts.VolumeNameInitializer) {
- 				allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer)))
- 			}
+			if volumeMounts := rJobContainerVolumeMountNames[constants.ModelInitializer][constants.ModelInitializer]; !volumeMounts.Has(jobsetplgconsts.VolumeNameInitializer) {
+				allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volumeMount with name - %s in container %s of the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer, constants.ModelInitializer)))
+			}
+		}
+	}
 
 	allErrs = append(allErrs, j.checkRuntimePatchesImmutability(ctx, oldObj, newObj)...)
 

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -48,6 +48,7 @@ import (
 	"github.com/kubeflow/trainer/v2/pkg/constants"
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework"
+	jobsetplgconsts "github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/jobset/constants"
 	"github.com/kubeflow/trainer/v2/pkg/util/trainjob"
 )
 
@@ -94,7 +95,9 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 	}
 
 	// TODO (andreyvelich): Refactor this test to verify the ancestor label in PodTemplate.
+	// TODO (andreyvelich): Refactor this test to verify the ancestor label in PodTemplate.
 	rJobContainerNames := make(map[string]sets.Set[string])
+	rJobVolumeNames := make(map[string]sets.Set[string])
 	for _, rJob := range jobSetSpec.ReplicatedJobs {
 		rJobContainerNames[*rJob.Name] = sets.New[string]()
 		// Names of initContainer and containers are unique.
@@ -104,21 +107,29 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 		for _, c := range rJob.Template.Spec.Template.Spec.Containers {
 			rJobContainerNames[*rJob.Name].Insert(*c.Name)
 		}
+		rJobVolumeNames[*rJob.Name] = sets.New[string]()
+		for _, v := range rJob.Template.Spec.Template.Spec.Volumes {
+			rJobVolumeNames[*rJob.Name].Insert(*v.Name)
+		}
 	}
-
 	if newObj.Spec.Initializer != nil && newObj.Spec.Initializer.Dataset != nil {
 		if containers, ok := rJobContainerNames[constants.DatasetInitializer]; !ok {
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have %s job when trainJob is configured with input datasetConfig", constants.DatasetInitializer)))
 		} else if !containers.Has(constants.DatasetInitializer) {
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have container with name - %s in the %s job", constants.DatasetInitializer, constants.DatasetInitializer)))
 		}
+		if volumes, ok := rJobVolumeNames[constants.DatasetInitializer]; !ok || !volumes.Has(jobsetplgconsts.VolumeNameInitializer) {
+			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer)))
+		}
 	}
-
 	if newObj.Spec.Initializer != nil && newObj.Spec.Initializer.Model != nil {
 		if containers, ok := rJobContainerNames[constants.ModelInitializer]; !ok {
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have %s job when trainJob is configured with input modelConfig", constants.ModelInitializer)))
 		} else if !containers.Has(constants.ModelInitializer) {
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have container with name - %s in the %s job", constants.ModelInitializer, constants.ModelInitializer)))
+		}
+		if volumes, ok := rJobVolumeNames[constants.ModelInitializer]; !ok || !volumes.Has(jobsetplgconsts.VolumeNameInitializer) {
+			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer)))
 		}
 	}
 

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -95,7 +95,6 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 	}
 
 	// TODO (andreyvelich): Refactor this test to verify the ancestor label in PodTemplate.
-	// TODO (andreyvelich): Refactor this test to verify the ancestor label in PodTemplate.
 	rJobContainerNames := make(map[string]sets.Set[string])
 	rJobVolumeNames := make(map[string]sets.Set[string])
 	for _, rJob := range jobSetSpec.ReplicatedJobs {

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -96,47 +97,22 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 
 	// TODO (andreyvelich): Refactor this test to verify the ancestor label in PodTemplate.
 	rJobContainerNames := make(map[string]sets.Set[string])
-	rJobContainerVolumeMountNames := make(map[string]map[string]sets.Set[string])
-
 	for _, rJob := range jobSetSpec.ReplicatedJobs {
 		if rJob.Name == nil {
 			continue
 		}
 		rJobName := *rJob.Name
-
 		rJobContainerNames[rJobName] = sets.New[string]()
-		rJobContainerVolumeMountNames[rJobName] = make(map[string]sets.Set[string])
 
 		// Names of initContainer and containers are unique.
 		for _, c := range rJob.Template.Spec.Template.Spec.InitContainers {
-			if c.Name == nil {
-				continue
-			}
-			containerName := *c.Name
-			rJobContainerNames[rJobName].Insert(containerName)
-			rJobContainerVolumeMountNames[rJobName][containerName] = sets.New[string]()
-
-			for _, vm := range c.VolumeMounts {
-				if vm.Name == nil {
-					continue
-				}
-				rJobContainerVolumeMountNames[rJobName][containerName].Insert(*vm.Name)
+			if c.Name != nil {
+				rJobContainerNames[rJobName].Insert(*c.Name)
 			}
 		}
-
 		for _, c := range rJob.Template.Spec.Template.Spec.Containers {
-			if c.Name == nil {
-				continue
-			}
-			containerName := *c.Name
-			rJobContainerNames[rJobName].Insert(containerName)
-			rJobContainerVolumeMountNames[rJobName][containerName] = sets.New[string]()
-
-			for _, vm := range c.VolumeMounts {
-				if vm.Name == nil {
-					continue
-				}
-				rJobContainerVolumeMountNames[rJobName][containerName].Insert(*vm.Name)
+			if c.Name != nil {
+				rJobContainerNames[rJobName].Insert(*c.Name)
 			}
 		}
 	}
@@ -147,10 +123,8 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have %s job when trainJob is configured with input datasetConfig", constants.DatasetInitializer)))
 		} else if !containers.Has(constants.DatasetInitializer) {
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have container with name - %s in the %s job", constants.DatasetInitializer, constants.DatasetInitializer)))
-		} else {
-			if volumeMounts := rJobContainerVolumeMountNames[constants.DatasetInitializer][constants.DatasetInitializer]; !volumeMounts.Has(jobsetplgconsts.VolumeNameInitializer) {
-				allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volumeMount with name - %s in container %s of the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer, constants.DatasetInitializer)))
-			}
+		} else if !initializerContainerHasVolumeMount(jobSetSpec, constants.DatasetInitializer, constants.DatasetInitializer) {
+			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volumeMount with name - %s in container %s of the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer, constants.DatasetInitializer)))
 		}
 	}
 
@@ -160,10 +134,8 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have %s job when trainJob is configured with input modelConfig", constants.ModelInitializer)))
 		} else if !containers.Has(constants.ModelInitializer) {
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have container with name - %s in the %s job", constants.ModelInitializer, constants.ModelInitializer)))
-		} else {
-			if volumeMounts := rJobContainerVolumeMountNames[constants.ModelInitializer][constants.ModelInitializer]; !volumeMounts.Has(jobsetplgconsts.VolumeNameInitializer) {
-				allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volumeMount with name - %s in container %s of the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer, constants.ModelInitializer)))
-			}
+		} else if !initializerContainerHasVolumeMount(jobSetSpec, constants.ModelInitializer, constants.ModelInitializer) {
+			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volumeMount with name - %s in container %s of the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer, constants.ModelInitializer)))
 		}
 	}
 
@@ -207,6 +179,43 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 	}
 
 	return nil, allErrs
+}
+
+// initializerContainerHasVolumeMount reports whether the container named containerName in the
+// ReplicatedJob named rJobName mounts a volume named jobsetplgconsts.VolumeNameInitializer.
+// The volume itself is supplied by the runtime via JobSet volumeClaimPolicies and injected by
+// the JobSet controller, so only the VolumeMount can be validated at admission time.
+func initializerContainerHasVolumeMount(spec *jobsetv1alpha2ac.JobSetSpecApplyConfiguration, rJobName, containerName string) bool {
+	hasMount := func(c corev1ac.ContainerApplyConfiguration) bool {
+		if c.Name == nil || *c.Name != containerName {
+			return false
+		}
+		for _, vm := range c.VolumeMounts {
+			if vm.Name != nil && *vm.Name == jobsetplgconsts.VolumeNameInitializer {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, rJob := range spec.ReplicatedJobs {
+		if rJob.Name == nil || *rJob.Name != rJobName {
+			continue
+		}
+		podSpec := rJob.Template.Spec.Template.Spec
+		for _, c := range podSpec.InitContainers {
+			if hasMount(c) {
+				return true
+			}
+		}
+		for _, c := range podSpec.Containers {
+			if hasMount(c) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (j *JobSet) checkRuntimePatchesImmutability(ctx context.Context, oldObj, newObj *trainer.TrainJob) field.ErrorList {

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -108,29 +108,33 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 		}
 		rJobVolumeNames[*rJob.Name] = sets.New[string]()
 		for _, v := range rJob.Template.Spec.Template.Spec.Volumes {
+			if v.Name == nil {
+ 				continue
+ 			}
 			rJobVolumeNames[*rJob.Name].Insert(*v.Name)
 		}
 	}
 	if newObj.Spec.Initializer != nil && newObj.Spec.Initializer.Dataset != nil {
 		if containers, ok := rJobContainerNames[constants.DatasetInitializer]; !ok {
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have %s job when trainJob is configured with input datasetConfig", constants.DatasetInitializer)))
-		} else if !containers.Has(constants.DatasetInitializer) {
-			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have container with name - %s in the %s job", constants.DatasetInitializer, constants.DatasetInitializer)))
-		}
-		if volumes, ok := rJobVolumeNames[constants.DatasetInitializer]; !ok || !volumes.Has(jobsetplgconsts.VolumeNameInitializer) {
-			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer)))
-		}
+		} else {
+ 			if !containers.Has(constants.DatasetInitializer) {
+ 				allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have container with name - %s in the %s job", constants.DatasetInitializer, constants.DatasetInitializer)))
+ 			}
+ 			if volumes := rJobVolumeNames[constants.DatasetInitializer]; !volumes.Has(jobsetplgconsts.VolumeNameInitializer) {
+ 				allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer)))
+ 			}
 	}
 	if newObj.Spec.Initializer != nil && newObj.Spec.Initializer.Model != nil {
 		if containers, ok := rJobContainerNames[constants.ModelInitializer]; !ok {
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have %s job when trainJob is configured with input modelConfig", constants.ModelInitializer)))
-		} else if !containers.Has(constants.ModelInitializer) {
-			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have container with name - %s in the %s job", constants.ModelInitializer, constants.ModelInitializer)))
-		}
-		if volumes, ok := rJobVolumeNames[constants.ModelInitializer]; !ok || !volumes.Has(jobsetplgconsts.VolumeNameInitializer) {
-			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer)))
-		}
-	}
+		} else {
+ 			if !containers.Has(constants.ModelInitializer) {
+ 				allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have container with name - %s in the %s job", constants.ModelInitializer, constants.ModelInitializer)))
+ 			}
+ 			if volumes := rJobVolumeNames[constants.ModelInitializer]; !volumes.Has(jobsetplgconsts.VolumeNameInitializer) {
+ 				allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer)))
+ 			}
 
 	allErrs = append(allErrs, j.checkRuntimePatchesImmutability(ctx, oldObj, newObj)...)
 

--- a/pkg/runtime/framework/plugins/jobset/jobset_test.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kubeflow/trainer/v2/pkg/constants"
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework"
+	jobsetplgconsts "github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/jobset/constants"
 	utiltesting "github.com/kubeflow/trainer/v2/pkg/util/testing"
 )
 
@@ -394,6 +395,9 @@ func TestValidate(t *testing.T) {
 				field.Invalid(runtimeRefPath,
 					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
 					fmt.Sprintf("must have %s job when trainJob is configured with input datasetConfig", constants.DatasetInitializer)),
+				field.Invalid(runtimeRefPath,
+					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
+					fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer)),
 			},
 		},
 		"must have container with name - dataset initializer in the dataset initializer job": {
@@ -425,6 +429,9 @@ func TestValidate(t *testing.T) {
 				field.Invalid(runtimeRefPath,
 					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
 					fmt.Sprintf("must have container with name - %s in the %s job", constants.DatasetInitializer, constants.DatasetInitializer)),
+				field.Invalid(runtimeRefPath,
+					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
+					fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer)),
 			},
 		},
 		"no model initializer job": {
@@ -489,6 +496,9 @@ func TestValidate(t *testing.T) {
 				field.Invalid(runtimeRefPath,
 					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
 					fmt.Sprintf("must have %s job when trainJob is configured with input modelConfig", constants.ModelInitializer)),
+				field.Invalid(runtimeRefPath,
+					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
+					fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer)),
 			},
 		},
 		"must have container with name - model initializer in the model initializer job": {
@@ -520,6 +530,79 @@ func TestValidate(t *testing.T) {
 				field.Invalid(runtimeRefPath,
 					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
 					fmt.Sprintf("must have container with name - %s in the %s job", constants.ModelInitializer, constants.ModelInitializer)),
+				field.Invalid(runtimeRefPath,
+					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
+					fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer)),
+			},
+		},
+		"must have volume with name - initializer in the dataset initializer job": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
+						ReplicatedJobs: []jobsetv1alpha2ac.ReplicatedJobApplyConfiguration{
+							{
+								Name: ptr.To(constants.DatasetInitializer),
+								Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+									Spec: &batchv1ac.JobSpecApplyConfiguration{
+										Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+											Spec: &corev1ac.PodSpecApplyConfiguration{
+												Containers: []corev1ac.ContainerApplyConfiguration{
+													{
+														Name: ptr.To(constants.DatasetInitializer),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newObj: utiltesting.MakeTrainJobWrapper("default", "test").
+				Initializer(&trainer.Initializer{
+					Dataset: &trainer.DatasetInitializer{},
+				}).Obj(),
+			wantError: field.ErrorList{
+				field.Invalid(runtimeRefPath,
+					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
+					fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer)),
+			},
+		},
+		"must have volume with name - initializer in the model initializer job": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
+						ReplicatedJobs: []jobsetv1alpha2ac.ReplicatedJobApplyConfiguration{
+							{
+								Name: ptr.To(constants.ModelInitializer),
+								Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+									Spec: &batchv1ac.JobSpecApplyConfiguration{
+										Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+											Spec: &corev1ac.PodSpecApplyConfiguration{
+												Containers: []corev1ac.ContainerApplyConfiguration{
+													{
+														Name: ptr.To(constants.ModelInitializer),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newObj: utiltesting.MakeTrainJobWrapper("default", "test").
+				Initializer(&trainer.Initializer{
+					Model: &trainer.ModelInitializer{},
+				}).Obj(),
+			wantError: field.ErrorList{
+				field.Invalid(runtimeRefPath,
+					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
+					fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer)),
 			},
 		},
 		"runtimePatches contain invalid replicated job": {

--- a/pkg/runtime/framework/plugins/jobset/jobset_test.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset_test.go
@@ -395,9 +395,6 @@ func TestValidate(t *testing.T) {
 				field.Invalid(runtimeRefPath,
 					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
 					fmt.Sprintf("must have %s job when trainJob is configured with input datasetConfig", constants.DatasetInitializer)),
-				field.Invalid(runtimeRefPath,
-					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
-					fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer)),
 			},
 		},
 		"must have container with name - dataset initializer in the dataset initializer job": {
@@ -429,9 +426,6 @@ func TestValidate(t *testing.T) {
 				field.Invalid(runtimeRefPath,
 					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
 					fmt.Sprintf("must have container with name - %s in the %s job", constants.DatasetInitializer, constants.DatasetInitializer)),
-				field.Invalid(runtimeRefPath,
-					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
-					fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer)),
 			},
 		},
 		"no model initializer job": {
@@ -496,9 +490,6 @@ func TestValidate(t *testing.T) {
 				field.Invalid(runtimeRefPath,
 					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
 					fmt.Sprintf("must have %s job when trainJob is configured with input modelConfig", constants.ModelInitializer)),
-				field.Invalid(runtimeRefPath,
-					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
-					fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer)),
 			},
 		},
 		"must have container with name - model initializer in the model initializer job": {
@@ -530,12 +521,153 @@ func TestValidate(t *testing.T) {
 				field.Invalid(runtimeRefPath,
 					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
 					fmt.Sprintf("must have container with name - %s in the %s job", constants.ModelInitializer, constants.ModelInitializer)),
-				field.Invalid(runtimeRefPath,
-					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
-					fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer)),
 			},
 		},
-		"must have volume with name - initializer in the dataset initializer job": {
+		"valid dataset initializer with volumeClaimPolicies and volumeMount passes": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
+						VolumeClaimPolicies: []jobsetv1alpha2ac.VolumeClaimPolicyApplyConfiguration{
+							{
+								Templates: []corev1.PersistentVolumeClaim{
+									{
+										ObjectMeta: metav1.ObjectMeta{
+											Name: jobsetplgconsts.VolumeNameInitializer,
+										},
+									},
+								},
+							},
+						},
+						ReplicatedJobs: []jobsetv1alpha2ac.ReplicatedJobApplyConfiguration{
+							{
+								Name: ptr.To(constants.DatasetInitializer),
+								Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+									Spec: &batchv1ac.JobSpecApplyConfiguration{
+										Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+											Spec: &corev1ac.PodSpecApplyConfiguration{
+												Containers: []corev1ac.ContainerApplyConfiguration{
+													*corev1ac.Container().
+														WithName(constants.DatasetInitializer).
+														WithVolumeMounts(corev1ac.VolumeMount().
+															WithName(jobsetplgconsts.VolumeNameInitializer)),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newObj: utiltesting.MakeTrainJobWrapper("default", "test").
+				Initializer(&trainer.Initializer{
+					Dataset: &trainer.DatasetInitializer{},
+				}).Obj(),
+		},
+		"valid model initializer with volumeClaimPolicies and volumeMount passes": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
+						VolumeClaimPolicies: []jobsetv1alpha2ac.VolumeClaimPolicyApplyConfiguration{
+							{
+								Templates: []corev1.PersistentVolumeClaim{
+									{
+										ObjectMeta: metav1.ObjectMeta{
+											Name: jobsetplgconsts.VolumeNameInitializer,
+										},
+									},
+								},
+							},
+						},
+						ReplicatedJobs: []jobsetv1alpha2ac.ReplicatedJobApplyConfiguration{
+							{
+								Name: ptr.To(constants.ModelInitializer),
+								Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+									Spec: &batchv1ac.JobSpecApplyConfiguration{
+										Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+											Spec: &corev1ac.PodSpecApplyConfiguration{
+												Containers: []corev1ac.ContainerApplyConfiguration{
+													*corev1ac.Container().
+														WithName(constants.ModelInitializer).
+														WithVolumeMounts(corev1ac.VolumeMount().
+															WithName(jobsetplgconsts.VolumeNameInitializer)),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newObj: utiltesting.MakeTrainJobWrapper("default", "test").
+				Initializer(&trainer.Initializer{
+					Model: &trainer.ModelInitializer{},
+				}).Obj(),
+		},
+		"valid dataset and model initializers together pass": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
+						VolumeClaimPolicies: []jobsetv1alpha2ac.VolumeClaimPolicyApplyConfiguration{
+							{
+								Templates: []corev1.PersistentVolumeClaim{
+									{
+										ObjectMeta: metav1.ObjectMeta{
+											Name: jobsetplgconsts.VolumeNameInitializer,
+										},
+									},
+								},
+							},
+						},
+						ReplicatedJobs: []jobsetv1alpha2ac.ReplicatedJobApplyConfiguration{
+							{
+								Name: ptr.To(constants.DatasetInitializer),
+								Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+									Spec: &batchv1ac.JobSpecApplyConfiguration{
+										Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+											Spec: &corev1ac.PodSpecApplyConfiguration{
+												Containers: []corev1ac.ContainerApplyConfiguration{
+													*corev1ac.Container().
+														WithName(constants.DatasetInitializer).
+														WithVolumeMounts(corev1ac.VolumeMount().
+															WithName(jobsetplgconsts.VolumeNameInitializer)),
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: ptr.To(constants.ModelInitializer),
+								Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+									Spec: &batchv1ac.JobSpecApplyConfiguration{
+										Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+											Spec: &corev1ac.PodSpecApplyConfiguration{
+												Containers: []corev1ac.ContainerApplyConfiguration{
+													*corev1ac.Container().
+														WithName(constants.ModelInitializer).
+														WithVolumeMounts(corev1ac.VolumeMount().
+															WithName(jobsetplgconsts.VolumeNameInitializer)),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newObj: utiltesting.MakeTrainJobWrapper("default", "test").
+				Initializer(&trainer.Initializer{
+					Dataset: &trainer.DatasetInitializer{},
+					Model:   &trainer.ModelInitializer{},
+				}).Obj(),
+		},
+		"must have volumeMount with name - initializer in the dataset initializer container": {
 			info: &runtime.Info{
 				TemplateSpec: runtime.TemplateSpec{
 					ObjApply: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
@@ -567,10 +699,10 @@ func TestValidate(t *testing.T) {
 			wantError: field.ErrorList{
 				field.Invalid(runtimeRefPath,
 					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
-					fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer)),
+					fmt.Sprintf("must have volumeMount with name - %s in container %s of the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer, constants.DatasetInitializer)),
 			},
 		},
-		"must have volume with name - initializer in the model initializer job": {
+		"must have volumeMount with name - initializer in the model initializer container": {
 			info: &runtime.Info{
 				TemplateSpec: runtime.TemplateSpec{
 					ObjApply: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
@@ -602,7 +734,7 @@ func TestValidate(t *testing.T) {
 			wantError: field.ErrorList{
 				field.Invalid(runtimeRefPath,
 					utiltesting.MakeTrainJobWrapper("default", "test").Obj().Spec.RuntimeRef,
-					fmt.Sprintf("must have volume with name - %s in the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer)),
+					fmt.Sprintf("must have volumeMount with name - %s in container %s of the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer, constants.ModelInitializer)),
 			},
 		},
 		"runtimePatches contain invalid replicated job": {


### PR DESCRIPTION
**What this PR does / why we need it ?**:

Adds validation in the JobSet plugin's `Validate()` function to ensure the
dataset/model initializer `ReplicatedJob` has a Volume named
`jobsetplgconsts.VolumeNameInitializer`.

Previously `VolumeNameInitializer` was only a string constant with no
enforcement — a misconfigured runtime template could silently reference
the wrong volume name and only fail later at Pod scheduling/mount time,
instead of at admission time with a clear error.

This follows the same pattern already used in this function for validating
container names (`rJobContainerNames`), extended to also track volume
names (`rJobVolumeNames`) per ReplicatedJob.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #3710

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing (not user facing — internal validation logic only, no API/docs change needed)