### PR TITLE
feat(runtimes): BREAKING CHANGE: Remove Runtime Finalizers

### DIFF
--- a/pkg/controller/clustertrainingruntime_controller.go
+++ b/pkg/controller/clustertrainingruntime_controller.go
@@ -39,7 +39,6 @@ import (
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
-	idxer "github.com/kubeflow/trainer/v2/pkg/runtime/indexer"
 	"github.com/kubeflow/trainer/v2/pkg/util/trainjob"
 )
 
@@ -74,21 +73,13 @@ func (r *ClusterTrainingRuntimeReconciler) Reconcile(ctx context.Context, reques
 	ctrl.LoggerInto(ctx, log)
 	log.V(2).Info("Reconciling ClusterTrainingRuntime")
 
-	trainJobs := &trainer.TrainJobList{}
-	if err := r.client.List(ctx, trainJobs, client.MatchingFields{
-		idxer.TrainJobClusterRuntimeRefKey: clRuntime.Name,
-	}); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	prevClRuntime := clRuntime.DeepCopy()
-	if !ctrlutil.ContainsFinalizer(&clRuntime, constants.ResourceInUseFinalizer) && len(trainJobs.Items) != 0 {
-		ctrlutil.AddFinalizer(&clRuntime, constants.ResourceInUseFinalizer)
-		return ctrl.Result{}, r.client.Patch(ctx, &clRuntime, client.MergeFrom(prevClRuntime))
-	} else if !clRuntime.DeletionTimestamp.IsZero() && len(trainJobs.Items) == 0 {
+
+	if ctrlutil.ContainsFinalizer(&clRuntime, constants.ResourceInUseFinalizer) {
 		ctrlutil.RemoveFinalizer(&clRuntime, constants.ResourceInUseFinalizer)
 		return ctrl.Result{}, r.client.Patch(ctx, &clRuntime, client.MergeFrom(prevClRuntime))
 	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/controller/clustertrainingruntime_controller.go
+++ b/pkg/controller/clustertrainingruntime_controller.go
@@ -18,46 +18,36 @@ package controller
 
 import (
 	"context"
-	"iter"
-	"slices"
-	"time"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
-	"github.com/kubeflow/trainer/v2/pkg/util/trainjob"
 )
 
 type ClusterTrainingRuntimeReconciler struct {
-	log                        logr.Logger
-	client                     client.Client
-	recorder                   events.EventRecorder
-	nonClRuntimeObjectUpdateCh chan event.TypedGenericEvent[iter.Seq[types.NamespacedName]]
+	log      logr.Logger
+	client   client.Client
+	recorder events.EventRecorder
 }
 
 var _ reconcile.Reconciler = (*ClusterTrainingRuntimeReconciler)(nil)
-var _ TrainJobWatcher = (*ClusterTrainingRuntimeReconciler)(nil)
 
 func NewClusterTrainingRuntimeReconciler(cli client.Client, recorder events.EventRecorder) *ClusterTrainingRuntimeReconciler {
 	return &ClusterTrainingRuntimeReconciler{
-		log:                        ctrl.Log.WithName("clustertrainingruntime-controller"),
-		client:                     cli,
-		recorder:                   recorder,
-		nonClRuntimeObjectUpdateCh: make(chan event.TypedGenericEvent[iter.Seq[types.NamespacedName]], updateChBuffer),
+		log:      ctrl.Log.WithName("clustertrainingruntime-controller"),
+		client:   cli,
+		recorder: recorder,
 	}
 }
 
@@ -83,48 +73,6 @@ func (r *ClusterTrainingRuntimeReconciler) Reconcile(ctx context.Context, reques
 	return ctrl.Result{}, nil
 }
 
-func (r *ClusterTrainingRuntimeReconciler) NotifyTrainJobUpdate(oldJob, newJob *trainer.TrainJob) {
-	var clRuntimeNSName *types.NamespacedName
-	switch {
-	case oldJob != nil && newJob != nil:
-		// UPDATE Event.
-		if trainjob.RuntimeRefIsClusterTrainingRuntime(newJob.Spec.RuntimeRef) {
-			clRuntimeNSName = &types.NamespacedName{Name: newJob.Spec.RuntimeRef.Name}
-		}
-	case oldJob == nil:
-		// CREATE Event.
-		if trainjob.RuntimeRefIsClusterTrainingRuntime(newJob.Spec.RuntimeRef) {
-			clRuntimeNSName = &types.NamespacedName{Name: newJob.Spec.RuntimeRef.Name}
-		}
-	default:
-		// DELETE Event.
-		if trainjob.RuntimeRefIsClusterTrainingRuntime(oldJob.Spec.RuntimeRef) {
-			clRuntimeNSName = &types.NamespacedName{Name: oldJob.Spec.RuntimeRef.Name}
-		}
-	}
-	if clRuntimeNSName != nil {
-		r.nonClRuntimeObjectUpdateCh <- event.TypedGenericEvent[iter.Seq[types.NamespacedName]]{
-			Object: slices.Values([]types.NamespacedName{*clRuntimeNSName}),
-		}
-	}
-}
-
-type nonClRuntimeObjectHandler struct{}
-
-var _ handler.TypedEventHandler[iter.Seq[types.NamespacedName], reconcile.Request] = (*nonClRuntimeObjectHandler)(nil)
-
-func (h *nonClRuntimeObjectHandler) Create(context.Context, event.TypedCreateEvent[iter.Seq[types.NamespacedName]], workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-}
-func (h *nonClRuntimeObjectHandler) Update(context.Context, event.TypedUpdateEvent[iter.Seq[types.NamespacedName]], workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-}
-func (h *nonClRuntimeObjectHandler) Delete(context.Context, event.TypedDeleteEvent[iter.Seq[types.NamespacedName]], workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-}
-func (h *nonClRuntimeObjectHandler) Generic(_ context.Context, e event.TypedGenericEvent[iter.Seq[types.NamespacedName]], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	for nsName := range e.Object {
-		q.AddAfter(reconcile.Request{NamespacedName: nsName}, time.Second)
-	}
-}
-
 func (r *ClusterTrainingRuntimeReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
 	return builder.TypedControllerManagedBy[reconcile.Request](mgr).
 		Named("clustertrainingruntime_controller").
@@ -134,6 +82,5 @@ func (r *ClusterTrainingRuntimeReconciler) SetupWithManager(mgr ctrl.Manager, op
 			&trainer.ClusterTrainingRuntime{},
 			&handler.TypedEnqueueRequestForObject[*trainer.ClusterTrainingRuntime]{},
 		)).
-		WatchesRawSource(source.Channel(r.nonClRuntimeObjectUpdateCh, &nonClRuntimeObjectHandler{})).
 		Complete(r)
 }

--- a/pkg/controller/clustertrainingruntime_controller_test.go
+++ b/pkg/controller/clustertrainingruntime_controller_test.go
@@ -18,17 +18,13 @@ package controller
 
 import (
 	"context"
-	"iter"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/ktesting"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
@@ -80,92 +76,6 @@ func TestReconcile_ClusterTrainingRuntimeReconciler(t *testing.T) {
 				cmpopts.IgnoreFields(metav1.TypeMeta{}, "Kind", "APIVersion"),
 			); len(diff) != 0 {
 				t.Errorf("Unexpected ClusterTrainingRuntime: (-want, +got): \n%s", diff)
-			}
-		})
-	}
-}
-
-func TestNotifyTrainJobUpdate_ClusterTrainingRuntimeReconciler(t *testing.T) {
-	t.Parallel()
-	cases := map[string]struct {
-		oldJob    *trainer.TrainJob
-		newJob    *trainer.TrainJob
-		wantEvent event.TypedGenericEvent[iter.Seq[types.NamespacedName]]
-	}{
-		"UPDATE Event: runtimeRef is ClusterTrainingRuntime": {
-			oldJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
-				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
-				Obj(),
-			newJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
-				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
-				RuntimePatches([]trainer.RuntimePatch{{Manager: "test"}}).
-				Obj(),
-			wantEvent: event.TypedGenericEvent[iter.Seq[types.NamespacedName]]{
-				Object: func(yield func(types.NamespacedName) bool) {
-					yield(types.NamespacedName{Name: "test-runtime"})
-				},
-			},
-		},
-		"UPDATE Event: runtimeRef is not ClusterTrainingRuntime": {
-			oldJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
-				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
-				Obj(),
-			newJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
-				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
-				RuntimePatches([]trainer.RuntimePatch{{Manager: "test"}}).
-				Obj(),
-		},
-		"CREATE Event: runtimeRef is ClusterTrainingRuntime": {
-			newJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
-				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
-				Obj(),
-			wantEvent: event.TypedGenericEvent[iter.Seq[types.NamespacedName]]{
-				Object: func(yield func(types.NamespacedName) bool) {
-					yield(types.NamespacedName{Name: "test-runtime"})
-				},
-			},
-		},
-		"CREATE Event: runtimeRef is not ClusterTrainingRuntime": {
-			newJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
-				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
-				Obj(),
-		},
-		"DELETE Event: runtimeRef is ClusterTrainingRuntime": {
-			oldJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
-				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
-				Obj(),
-			wantEvent: event.TypedGenericEvent[iter.Seq[types.NamespacedName]]{
-				Object: func(yield func(types.NamespacedName) bool) {
-					yield(types.NamespacedName{Name: "test-runtime"})
-				},
-			},
-		},
-		"DELETE Event: runtimeRef is not ClusterTrainingRuntime": {
-			oldJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
-				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
-				Obj(),
-		},
-	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			logger, _ := ktesting.NewTestContext(t)
-			updateCh := make(chan event.TypedGenericEvent[iter.Seq[types.NamespacedName]], 1)
-			t.Cleanup(func() {
-				close(updateCh)
-			})
-			r := &ClusterTrainingRuntimeReconciler{
-				log:                        logger,
-				nonClRuntimeObjectUpdateCh: updateCh,
-			}
-			r.NotifyTrainJobUpdate(tc.oldJob, tc.newJob)
-			var got event.TypedGenericEvent[iter.Seq[types.NamespacedName]]
-			select {
-			case got = <-updateCh:
-			case <-time.After(time.Second):
-			}
-			if diff := cmp.Diff(tc.wantEvent, got, utiltesting.TrainJobUpdateReconcileRequestCmpOpts); len(diff) != 0 {
-				t.Errorf("Unexpected GenericEvent (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/clustertrainingruntime_controller_test.go
+++ b/pkg/controller/clustertrainingruntime_controller_test.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"iter"
 	"testing"
 	"time"
@@ -29,70 +28,30 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/ktesting"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
-	idxer "github.com/kubeflow/trainer/v2/pkg/runtime/indexer"
 	utiltesting "github.com/kubeflow/trainer/v2/pkg/util/testing"
 )
 
 func TestReconcile_ClusterTrainingRuntimeReconciler(t *testing.T) {
-	errorFailedGetClusterTrainingRuntime := errors.New("TEST: failed to get ClusterTrainingRuntime")
 	cases := map[string]struct {
-		trainJobs             trainer.TrainJobList
 		clTrainingRuntime     *trainer.ClusterTrainingRuntime
 		wantClTrainingRuntime *trainer.ClusterTrainingRuntime
-		wantError             error
 	}{
-		"no action when clusterTrainingRuntime with finalizer does not being deleted": {
+		"remove existing finalizer during reconciliation": {
 			clTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
 				Finalizers(constants.ResourceInUseFinalizer).
 				Obj(),
 			wantClTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
-				Finalizers(constants.ResourceInUseFinalizer).
 				Obj(),
 		},
-		"remove clusterTrainingRuntime due to removed finalizers when runtime without finalizer is deleting": {
-			clTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
-				Finalizers(constants.ResourceInUseFinalizer).
-				DeletionTimestamp(metav1.Now()).
-				Obj(),
-			wantError:             errorFailedGetClusterTrainingRuntime,
-			wantClTrainingRuntime: &trainer.ClusterTrainingRuntime{},
-		},
-		"add finalizer when clusterTrainingRuntime is used by trainJob": {
+		"no action when runtime has no finalizer": {
 			clTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
 				Obj(),
-			trainJobs: trainer.TrainJobList{
-				Items: []trainer.TrainJob{
-					*utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "trainJob").
-						RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "runtime").
-						Obj(),
-				},
-			},
-			wantClTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
-				Finalizers(constants.ResourceInUseFinalizer).
-				Obj(),
-		},
-		"no action when all TrainJobs use another ClusterTrainingRuntime": {
-			clTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
-				Obj(),
-			trainJobs: trainer.TrainJobList{
-				Items: []trainer.TrainJob{
-					*utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "trainJob").
-						RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "another").
-						Obj(),
-				},
-			},
-			wantClTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
-				Obj(),
-		},
-		"no action when runtime without finalizer is not used by any TrainJob": {
-			clTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
-				Obj(),
+
 			wantClTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
 				Obj(),
 		},
@@ -105,27 +64,16 @@ func TestReconcile_ClusterTrainingRuntimeReconciler(t *testing.T) {
 			t.Cleanup(cancel)
 			cli := utiltesting.NewClientBuilder().
 				WithObjects(tc.clTrainingRuntime).
-				WithLists(&tc.trainJobs).
-				WithIndex(&trainer.TrainJob{}, idxer.TrainJobClusterRuntimeRefKey, idxer.IndexTrainJobClusterTrainingRuntime).
-				WithInterceptorFuncs(interceptor.Funcs{
-					Get: func(ctx context.Context, cli client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-						if _, ok := obj.(*trainer.TrainJob); !ok && errors.Is(tc.wantError, errorFailedGetClusterTrainingRuntime) {
-							return errorFailedGetClusterTrainingRuntime
-						}
-						return cli.Get(ctx, key, obj, opts...)
-					},
-				}).
 				Build()
 			r := NewClusterTrainingRuntimeReconciler(cli, nil)
 			clRuntimeKey := client.ObjectKeyFromObject(tc.clTrainingRuntime)
-			_, gotError := r.Reconcile(ctx, reconcile.Request{NamespacedName: clRuntimeKey})
-			if diff := cmp.Diff(tc.wantError, gotError, cmpopts.EquateErrors()); len(diff) != 0 {
-				t.Errorf("Unexpected Reconcile error (-want, +got): \n%s", diff)
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: clRuntimeKey})
+			if err != nil {
+				t.Fatalf("Reconcile() returned error: %v", err)
 			}
 			var gotClRuntime trainer.ClusterTrainingRuntime
-			gotError = cli.Get(ctx, clRuntimeKey, &gotClRuntime)
-			if diff := cmp.Diff(tc.wantError, gotError, cmpopts.EquateErrors()); len(diff) != 0 {
-				t.Errorf("Unexpected GET error (-want, +got): \n%s", diff)
+			if err := cli.Get(ctx, clRuntimeKey, &gotClRuntime); err != nil {
+				t.Fatalf("Get() returned error: %v", err)
 			}
 			if diff := cmp.Diff(tc.wantClTrainingRuntime, &gotClRuntime,
 				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),

--- a/pkg/controller/setup.go
+++ b/pkg/controller/setup.go
@@ -43,7 +43,6 @@ func SetupControllers(mgr ctrl.Manager, runtimes map[string]runtime.Runtime, opt
 		mgr.GetClient(),
 		mgr.GetEventRecorder("trainer-trainjob-controller"),
 		runtimes,
-		WithWatchers(runtimeRec, clRuntimeRec),
 	).SetupWithManager(mgr, options); err != nil {
 		return trainer.TrainJobKind, err
 	}

--- a/pkg/controller/trainingruntime_controller.go
+++ b/pkg/controller/trainingruntime_controller.go
@@ -18,50 +18,36 @@ package controller
 
 import (
 	"context"
-	"iter"
-	"slices"
-	"time"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
-	"github.com/kubeflow/trainer/v2/pkg/util/trainjob"
-)
-
-const (
-	updateChBuffer = 10
 )
 
 type TrainingRuntimeReconciler struct {
-	log                      logr.Logger
-	client                   client.Client
-	recorder                 events.EventRecorder
-	nonRuntimeObjectUpdateCh chan event.TypedGenericEvent[iter.Seq[types.NamespacedName]]
+	log      logr.Logger
+	client   client.Client
+	recorder events.EventRecorder
 }
 
 var _ reconcile.Reconciler = (*TrainingRuntimeReconciler)(nil)
-var _ TrainJobWatcher = (*TrainingRuntimeReconciler)(nil)
 
 func NewTrainingRuntimeReconciler(cli client.Client, recorder events.EventRecorder) *TrainingRuntimeReconciler {
 	return &TrainingRuntimeReconciler{
-		log:                      ctrl.Log.WithName("trainingruntime-controller"),
-		client:                   cli,
-		recorder:                 recorder,
-		nonRuntimeObjectUpdateCh: make(chan event.TypedGenericEvent[iter.Seq[types.NamespacedName]], updateChBuffer),
+		log:      ctrl.Log.WithName("trainingruntime-controller"),
+		client:   cli,
+		recorder: recorder,
 	}
 }
 
@@ -87,48 +73,6 @@ func (r *TrainingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	return ctrl.Result{}, nil
 }
 
-func (r *TrainingRuntimeReconciler) NotifyTrainJobUpdate(oldJob, newJob *trainer.TrainJob) {
-	var runtimeNSName *types.NamespacedName
-	switch {
-	case oldJob != nil && newJob != nil:
-		// UPDATE Event.
-		if trainjob.RuntimeRefIsTrainingRuntime(newJob.Spec.RuntimeRef) {
-			runtimeNSName = &types.NamespacedName{Namespace: newJob.Namespace, Name: newJob.Spec.RuntimeRef.Name}
-		}
-	case oldJob == nil:
-		// CREATE Event.
-		if trainjob.RuntimeRefIsTrainingRuntime(newJob.Spec.RuntimeRef) {
-			runtimeNSName = &types.NamespacedName{Namespace: newJob.Namespace, Name: newJob.Spec.RuntimeRef.Name}
-		}
-	default:
-		// DELETE Event.
-		if trainjob.RuntimeRefIsTrainingRuntime(oldJob.Spec.RuntimeRef) {
-			runtimeNSName = &types.NamespacedName{Namespace: oldJob.Namespace, Name: oldJob.Spec.RuntimeRef.Name}
-		}
-	}
-	if runtimeNSName != nil {
-		r.nonRuntimeObjectUpdateCh <- event.TypedGenericEvent[iter.Seq[types.NamespacedName]]{
-			Object: slices.Values([]types.NamespacedName{*runtimeNSName}),
-		}
-	}
-}
-
-type nonRuntimeObjectHandler struct{}
-
-var _ handler.TypedEventHandler[iter.Seq[types.NamespacedName], reconcile.Request] = (*nonRuntimeObjectHandler)(nil)
-
-func (h *nonRuntimeObjectHandler) Create(context.Context, event.TypedCreateEvent[iter.Seq[types.NamespacedName]], workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-}
-func (h *nonRuntimeObjectHandler) Update(context.Context, event.TypedUpdateEvent[iter.Seq[types.NamespacedName]], workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-}
-func (h *nonRuntimeObjectHandler) Delete(context.Context, event.TypedDeleteEvent[iter.Seq[types.NamespacedName]], workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-}
-func (h *nonRuntimeObjectHandler) Generic(_ context.Context, e event.TypedGenericEvent[iter.Seq[types.NamespacedName]], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	for nsName := range e.Object {
-		q.AddAfter(reconcile.Request{NamespacedName: nsName}, time.Second)
-	}
-}
-
 func (r *TrainingRuntimeReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
 	return builder.TypedControllerManagedBy[reconcile.Request](mgr).
 		Named("trainingruntime_controller").
@@ -138,6 +82,5 @@ func (r *TrainingRuntimeReconciler) SetupWithManager(mgr ctrl.Manager, options c
 			&trainer.TrainingRuntime{},
 			&handler.TypedEnqueueRequestForObject[*trainer.TrainingRuntime]{},
 		)).
-		WatchesRawSource(source.Channel(r.nonRuntimeObjectUpdateCh, &nonRuntimeObjectHandler{})).
 		Complete(r)
 }

--- a/pkg/controller/trainingruntime_controller.go
+++ b/pkg/controller/trainingruntime_controller.go
@@ -39,7 +39,6 @@ import (
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
-	idxer "github.com/kubeflow/trainer/v2/pkg/runtime/indexer"
 	"github.com/kubeflow/trainer/v2/pkg/util/trainjob"
 )
 
@@ -78,21 +77,13 @@ func (r *TrainingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	ctrl.LoggerInto(ctx, log)
 	log.V(2).Info("Reconciling TrainingRuntime")
 
-	trainJobs := &trainer.TrainJobList{}
-	if err := r.client.List(ctx, trainJobs, client.InNamespace(runtime.Namespace), client.MatchingFields{
-		idxer.TrainJobRuntimeRefKey: runtime.Name,
-	}); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	prevRuntime := runtime.DeepCopy()
-	if !ctrlutil.ContainsFinalizer(&runtime, constants.ResourceInUseFinalizer) && len(trainJobs.Items) != 0 {
-		ctrlutil.AddFinalizer(&runtime, constants.ResourceInUseFinalizer)
-		return ctrl.Result{}, r.client.Patch(ctx, &runtime, client.MergeFrom(prevRuntime))
-	} else if !runtime.DeletionTimestamp.IsZero() && len(trainJobs.Items) == 0 {
+
+	if ctrlutil.ContainsFinalizer(&runtime, constants.ResourceInUseFinalizer) {
 		ctrlutil.RemoveFinalizer(&runtime, constants.ResourceInUseFinalizer)
 		return ctrl.Result{}, r.client.Patch(ctx, &runtime, client.MergeFrom(prevRuntime))
 	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/controller/trainingruntime_controller_test.go
+++ b/pkg/controller/trainingruntime_controller_test.go
@@ -18,17 +18,13 @@ package controller
 
 import (
 	"context"
-	"iter"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/ktesting"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
@@ -86,92 +82,6 @@ func TestReconcile_TrainingRuntimeReconciler(t *testing.T) {
 				cmpopts.IgnoreFields(metav1.TypeMeta{}, "Kind", "APIVersion"),
 			); len(diff) != 0 {
 				t.Errorf("Unexpected TrainingRuntime: (-want, +got): \n%s", diff)
-			}
-		})
-	}
-}
-
-func TestNotifyTrainJobUpdate_TrainingRuntimeReconciler(t *testing.T) {
-	t.Parallel()
-	cases := map[string]struct {
-		oldJob    *trainer.TrainJob
-		newJob    *trainer.TrainJob
-		wantEvent event.TypedGenericEvent[iter.Seq[types.NamespacedName]]
-	}{
-		"UPDATE Event: runtimeRef is TrainingRuntime": {
-			oldJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
-				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
-				Obj(),
-			newJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
-				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
-				RuntimePatches([]trainer.RuntimePatch{{Manager: "test"}}).
-				Obj(),
-			wantEvent: event.TypedGenericEvent[iter.Seq[types.NamespacedName]]{
-				Object: func(yield func(types.NamespacedName) bool) {
-					yield(types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: "test-runtime"})
-				},
-			},
-		},
-		"UPDATE Event: runtimeRef is not TrainingRuntime": {
-			oldJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
-				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
-				Obj(),
-			newJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
-				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
-				RuntimePatches([]trainer.RuntimePatch{{Manager: "test"}}).
-				Obj(),
-		},
-		"CREATE Event: runtimeRef is TrainingRuntime": {
-			newJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
-				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
-				Obj(),
-			wantEvent: event.TypedGenericEvent[iter.Seq[types.NamespacedName]]{
-				Object: func(yield func(types.NamespacedName) bool) {
-					yield(types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: "test-runtime"})
-				},
-			},
-		},
-		"CREATE Event: runtimeRef is not TrainingRuntime": {
-			newJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
-				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
-				Obj(),
-		},
-		"DELETE Event: runtimeRef is TrainingRuntime": {
-			oldJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
-				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
-				Obj(),
-			wantEvent: event.TypedGenericEvent[iter.Seq[types.NamespacedName]]{
-				Object: func(yield func(types.NamespacedName) bool) {
-					yield(types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: "test-runtime"})
-				},
-			},
-		},
-		"DELETE Event: runtimeRef is not TrainingRuntime": {
-			oldJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
-				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
-				Obj(),
-		},
-	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			logger, _ := ktesting.NewTestContext(t)
-			updateCh := make(chan event.TypedGenericEvent[iter.Seq[types.NamespacedName]], 1)
-			t.Cleanup(func() {
-				close(updateCh)
-			})
-			r := &TrainingRuntimeReconciler{
-				log:                      logger,
-				nonRuntimeObjectUpdateCh: updateCh,
-			}
-			r.NotifyTrainJobUpdate(tc.oldJob, tc.newJob)
-			var got event.TypedGenericEvent[iter.Seq[types.NamespacedName]]
-			select {
-			case got = <-updateCh:
-			case <-time.After(time.Second):
-			}
-			if diff := cmp.Diff(tc.wantEvent, got, utiltesting.TrainJobUpdateReconcileRequestCmpOpts); len(diff) != 0 {
-				t.Errorf("Unexpected GenericEvent (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/trainingruntime_controller_test.go
+++ b/pkg/controller/trainingruntime_controller_test.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"iter"
 	"testing"
 	"time"
@@ -29,72 +28,38 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/ktesting"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
-	idxer "github.com/kubeflow/trainer/v2/pkg/runtime/indexer"
 	utiltesting "github.com/kubeflow/trainer/v2/pkg/util/testing"
 )
 
 func TestReconcile_TrainingRuntimeReconciler(t *testing.T) {
-	errorFailedGetTrainingRuntime := errors.New("TEST: failed to get TrainingRuntime")
 	cases := map[string]struct {
-		trainJobs           trainer.TrainJobList
 		trainingRuntime     *trainer.TrainingRuntime
 		wantTrainingRuntime *trainer.TrainingRuntime
-		wantError           error
 	}{
-		"no action when runtime with finalizer does not being deleted": {
+		"remove existing finalizer during reconciliation": {
 			trainingRuntime: utiltesting.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "runtime").
 				Finalizers(constants.ResourceInUseFinalizer).
 				Obj(),
-			wantTrainingRuntime: utiltesting.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "runtime").
-				Finalizers(constants.ResourceInUseFinalizer).
-				Obj(),
+			wantTrainingRuntime: utiltesting.MakeTrainingRuntimeWrapper(
+				metav1.NamespaceDefault,
+				"runtime",
+			).Obj(),
 		},
-		"remove trainingRuntime due to removed finalizers when runtime without finalizer is deleting": {
-			trainingRuntime: utiltesting.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "runtime").
-				Finalizers(constants.ResourceInUseFinalizer).
-				DeletionTimestamp(metav1.Now()).
-				Obj(),
-			wantError:           errorFailedGetTrainingRuntime,
-			wantTrainingRuntime: &trainer.TrainingRuntime{},
-		},
-		"add finalizer when trainingRuntime is used by trainJob": {
-			trainingRuntime: utiltesting.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "runtime").
-				Obj(),
-			trainJobs: trainer.TrainJobList{
-				Items: []trainer.TrainJob{
-					*utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "trainJob").
-						RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "runtime").
-						Obj(),
-				},
-			},
-			wantTrainingRuntime: utiltesting.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "runtime").
-				Finalizers(constants.ResourceInUseFinalizer).
-				Obj(),
-		},
-		"no action when all TrainJobs use another TrainingRuntime": {
-			trainingRuntime: utiltesting.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "runtime").
-				Obj(),
-			trainJobs: trainer.TrainJobList{
-				Items: []trainer.TrainJob{
-					*utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "trainJob").
-						RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "another").
-						Obj(),
-				},
-			},
-			wantTrainingRuntime: utiltesting.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "runtime").
-				Obj(),
-		},
-		"no action when runtime without finalizer is not used by any TrainJob": {
-			trainingRuntime: utiltesting.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "runtime").
-				Obj(),
-			wantTrainingRuntime: utiltesting.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "runtime").
-				Obj(),
+		"no action when runtime has no finalizer": {
+			trainingRuntime: utiltesting.MakeTrainingRuntimeWrapper(
+				metav1.NamespaceDefault,
+				"runtime",
+			).Obj(),
+
+			wantTrainingRuntime: utiltesting.MakeTrainingRuntimeWrapper(
+				metav1.NamespaceDefault,
+				"runtime",
+			).Obj(),
 		},
 	}
 	for name, tc := range cases {
@@ -105,27 +70,16 @@ func TestReconcile_TrainingRuntimeReconciler(t *testing.T) {
 			t.Cleanup(cancel)
 			cli := utiltesting.NewClientBuilder().
 				WithObjects(tc.trainingRuntime).
-				WithIndex(&trainer.TrainJob{}, idxer.TrainJobRuntimeRefKey, idxer.IndexTrainJobTrainingRuntime).
-				WithLists(&tc.trainJobs).
-				WithInterceptorFuncs(interceptor.Funcs{
-					Get: func(ctx context.Context, cli client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-						if _, ok := obj.(*trainer.TrainJob); !ok && errors.Is(tc.wantError, errorFailedGetTrainingRuntime) {
-							return errorFailedGetTrainingRuntime
-						}
-						return cli.Get(ctx, key, obj, opts...)
-					},
-				}).
 				Build()
 			r := NewTrainingRuntimeReconciler(cli, nil)
 			runtimeKey := client.ObjectKeyFromObject(tc.trainingRuntime)
-			_, gotError := r.Reconcile(ctx, reconcile.Request{NamespacedName: runtimeKey})
-			if diff := cmp.Diff(tc.wantError, gotError, cmpopts.EquateErrors()); len(diff) != 0 {
-				t.Errorf("Unexpected Recincile error: (-want, +got): \n%s", diff)
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: runtimeKey})
+			if err != nil {
+				t.Fatalf("Reconcile() returned error: %v", err)
 			}
 			var gotRuntime trainer.TrainingRuntime
-			gotError = cli.Get(ctx, runtimeKey, &gotRuntime)
-			if diff := cmp.Diff(tc.wantError, gotError, cmpopts.EquateErrors()); len(diff) != 0 {
-				t.Errorf("Unexpected GET error: (-want, +got): \n%s", diff)
+			if err := cli.Get(ctx, runtimeKey, &gotRuntime); err != nil {
+				t.Fatalf("Get() returned error: %v", err)
 			}
 			if diff := cmp.Diff(tc.wantTrainingRuntime, &gotRuntime,
 				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),

--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"iter"
-	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -49,44 +47,26 @@ import (
 	"github.com/kubeflow/trainer/v2/pkg/util/trainjob"
 )
 
-type TrainJobWatcher interface {
-	NotifyTrainJobUpdate(oldJob, newJob *trainer.TrainJob)
-}
-
 type TrainJobReconciler struct {
 	log      logr.Logger
 	client   client.Client
 	recorder events.EventRecorder
 	runtimes map[string]jobruntimes.Runtime
-	watchers iter.Seq[TrainJobWatcher]
-}
-
-type TrainJobReconcilerOptions struct {
-	Watchers iter.Seq[TrainJobWatcher]
-}
-
-type TrainJobReconcilerOption func(*TrainJobReconcilerOptions)
-
-func WithWatchers(watchers ...TrainJobWatcher) TrainJobReconcilerOption {
-	return func(o *TrainJobReconcilerOptions) {
-		o.Watchers = slices.Values(watchers)
-	}
 }
 
 var _ reconcile.Reconciler = (*TrainJobReconciler)(nil)
 var _ predicate.TypedPredicate[*trainer.TrainJob] = (*TrainJobReconciler)(nil)
 
-func NewTrainJobReconciler(client client.Client, recorder events.EventRecorder, runtimes map[string]jobruntimes.Runtime, opts ...TrainJobReconcilerOption) *TrainJobReconciler {
-	options := &TrainJobReconcilerOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+func NewTrainJobReconciler(
+	client client.Client,
+	recorder events.EventRecorder,
+	runtimes map[string]jobruntimes.Runtime,
+) *TrainJobReconciler {
 	return &TrainJobReconciler{
 		log:      ctrl.Log.WithName("trainjob-controller"),
 		client:   client,
 		recorder: recorder,
 		runtimes: runtimes,
-		watchers: options.Watchers,
 	}
 }
 
@@ -213,31 +193,22 @@ func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *tr
 
 func (r *TrainJobReconciler) Create(e event.TypedCreateEvent[*trainer.TrainJob]) bool {
 	r.log.WithValues("trainJob", klog.KObj(e.Object)).Info("TrainJob create event")
-	defer r.notifyWatchers(nil, e.Object)
 	return true
 }
 
 func (r *TrainJobReconciler) Delete(e event.TypedDeleteEvent[*trainer.TrainJob]) bool {
 	r.log.WithValues("trainJob", klog.KObj(e.Object)).Info("TrainJob delete event")
-	defer r.notifyWatchers(e.Object, nil)
 	return true
 }
 
 func (r *TrainJobReconciler) Update(e event.TypedUpdateEvent[*trainer.TrainJob]) bool {
 	r.log.WithValues("trainJob", klog.KObj(e.ObjectNew)).Info("TrainJob update event")
-	defer r.notifyWatchers(e.ObjectOld, e.ObjectNew)
 	return true
 }
 
 func (r *TrainJobReconciler) Generic(e event.TypedGenericEvent[*trainer.TrainJob]) bool {
 	r.log.WithValues("trainJob", klog.KObj(e.Object)).Info("TrainJob generic event")
 	return true
-}
-
-func (r *TrainJobReconciler) notifyWatchers(oldJob, newJob *trainer.TrainJob) {
-	for w := range r.watchers {
-		w.NotifyTrainJobUpdate(oldJob, newJob)
-	}
 }
 
 func setSuspendedCondition(trainJob *trainer.TrainJob) {

--- a/proposals/2599-mutable-runtimes/README.md
+++ b/proposals/2599-mutable-runtimes/README.md
@@ -35,7 +35,7 @@ Decoupling TrainJob behavior from runtime objects would also enable removing the
 
 * **Mutable TrainJobs**: we are not proposing any changes to the existing immutable fields of TrainJobs. These fields will remain immutable.
 * **Remove the existing implementation-level protections**: e.g. like not updating JobSets once they are created.
-* **Remove finalizer on runtimes**: removing the finalizer from `TrainingRuntimes` and `ClusterTrainingRuntimes` is out of scope for this KEP. However, this KEP creates the foundation to enable finalizer removal in future work.
+* Runtime finalizers have now been removed because runtime snapshots decouple TrainJobs from runtime lifecycle.
 
 ## Proposal
 

--- a/test/integration/controller/clustertrainingruntime_controller_test.go
+++ b/test/integration/controller/clustertrainingruntime_controller_test.go
@@ -81,26 +81,6 @@ var _ = ginkgo.Describe("ClusterTrainingRuntime controller", ginkgo.Ordered, fun
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("ClusterTrainingRuntime does not obtain finalizer when TrainJob with ClusterTrainingRuntime is created", func() {
-			ginkgo.By("Creating a ClusterTrainingRuntime")
-			gomega.Expect(k8sClient.Create(ctx, clTrainingRuntime)).Should(gomega.Succeed())
-
-			ginkgo.By("Checking that the ClusterTrainingRuntime never obtains finalizers")
-			gomega.Consistently(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, clTrainingRuntimeKey, clTrainingRuntime)).Should(gomega.Succeed())
-				g.Expect(clTrainingRuntime.Finalizers).Should(gomega.BeEmpty())
-			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
-
-			ginkgo.By("Creating a TrainJob")
-			gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
-
-			ginkgo.By("Checking that the ClusterTrainingRuntime still has no finalizers")
-			gomega.Consistently(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, clTrainingRuntimeKey, clTrainingRuntime)).Should(gomega.Succeed())
-				g.Expect(clTrainingRuntime.Finalizers).Should(gomega.BeEmpty())
-			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
-		})
-
 		ginkgo.It("ClusterTrainingRuntime can be deleted while referenced by a TrainJob", func() {
 			ginkgo.By("Creating a ClusterTrainingRuntime and TrainJob")
 			gomega.Expect(k8sClient.Create(ctx, clTrainingRuntime)).Should(gomega.Succeed())

--- a/test/integration/controller/clustertrainingruntime_controller_test.go
+++ b/test/integration/controller/clustertrainingruntime_controller_test.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
-	"github.com/kubeflow/trainer/v2/pkg/constants"
 	utiltesting "github.com/kubeflow/trainer/v2/pkg/util/testing"
 	"github.com/kubeflow/trainer/v2/test/integration/framework"
 	"github.com/kubeflow/trainer/v2/test/util"
@@ -82,57 +81,33 @@ var _ = ginkgo.Describe("ClusterTrainingRuntime controller", ginkgo.Ordered, fun
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("ClusterTrainingRuntime obtains finalizer when TrainJob with ClusterTrainingRuntime is created", func() {
+		ginkgo.It("ClusterTrainingRuntime does not obtain finalizer when TrainJob with ClusterTrainingRuntime is created", func() {
 			ginkgo.By("Creating a ClusterTrainingRuntime")
 			gomega.Expect(k8sClient.Create(ctx, clTrainingRuntime)).Should(gomega.Succeed())
 
-			ginkgo.By("Checking if the ClusterTrainingRuntime does not keep obtaining finalizers")
+			ginkgo.By("Checking that the ClusterTrainingRuntime never obtains finalizers")
 			gomega.Consistently(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, clTrainingRuntimeKey, clTrainingRuntime)).Should(gomega.Succeed())
-				g.Expect(clTrainingRuntime.ObjectMeta.Finalizers).Should(gomega.HaveLen(0))
+				g.Expect(clTrainingRuntime.Finalizers).Should(gomega.BeEmpty())
 			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Creating a TrainJob")
 			gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
 
-			ginkgo.By("Checking if the ClusterTrainingRuntime obtains finalizers")
-			gomega.Eventually(func(g gomega.Gomega) {
+			ginkgo.By("Checking that the ClusterTrainingRuntime still has no finalizers")
+			gomega.Consistently(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, clTrainingRuntimeKey, clTrainingRuntime)).Should(gomega.Succeed())
-				g.Expect(clTrainingRuntime.ObjectMeta.Finalizers).Should(gomega.BeComparableTo(
-					[]string{constants.ResourceInUseFinalizer},
-				))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				g.Expect(clTrainingRuntime.Finalizers).Should(gomega.BeEmpty())
+			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("ClusterTrainingRuntime can be deleted once referenced TrainJob is deleted", func() {
+		ginkgo.It("ClusterTrainingRuntime can be deleted while referenced by a TrainJob", func() {
 			ginkgo.By("Creating a ClusterTrainingRuntime and TrainJob")
 			gomega.Expect(k8sClient.Create(ctx, clTrainingRuntime)).Should(gomega.Succeed())
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clTrainingRuntime), clTrainingRuntime)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
-
-			ginkgo.By("Checking if the ClusterTrainingRuntime obtains finalizers")
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, clTrainingRuntimeKey, clTrainingRuntime)).Should(gomega.Succeed())
-				g.Expect(clTrainingRuntime.ObjectMeta.Finalizers).Should(gomega.BeComparableTo(
-					[]string{constants.ResourceInUseFinalizer},
-				))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			ginkgo.By("Delete a TrainJob")
-			gomega.Expect(k8sClient.Delete(ctx, trainJob)).Should(gomega.Succeed())
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainJob), trainJob)).Should(utiltesting.BeNotFoundError())
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			ginkgo.By("Checking if the ClusterTrainingRuntime keeps having finalizers")
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, clTrainingRuntimeKey, clTrainingRuntime)).Should(gomega.Succeed())
-				g.Expect(clTrainingRuntime.ObjectMeta.Finalizers).Should(gomega.BeComparableTo(
-					[]string{constants.ResourceInUseFinalizer},
-				))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Checking if the ClusterTrainingRuntime can be deleted")
 			gomega.Expect(k8sClient.Delete(ctx, clTrainingRuntime)).Should(gomega.Succeed())

--- a/test/integration/controller/trainingruntime_controller_test.go
+++ b/test/integration/controller/trainingruntime_controller_test.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
-	"github.com/kubeflow/trainer/v2/pkg/constants"
 	utiltesting "github.com/kubeflow/trainer/v2/pkg/util/testing"
 	"github.com/kubeflow/trainer/v2/test/integration/framework"
 	"github.com/kubeflow/trainer/v2/test/util"
@@ -74,7 +73,7 @@ var _ = ginkgo.Describe("TrainingRuntime controller", ginkgo.Ordered, func() {
 			gomega.Expect(k8sClient.DeleteAllOf(ctx, &trainer.TrainingRuntime{}, client.InNamespace(ns.Name))).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("TrainingRuntime obtains finalizer when TrainJob with TrainingRuntime is created", func() {
+		ginkgo.It("TrainingRuntime does not obtain finalizer when TrainJob with TrainingRuntime is created", func() {
 			ginkgo.By("Creating a TrainingRuntime")
 			gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
 
@@ -87,44 +86,20 @@ var _ = ginkgo.Describe("TrainingRuntime controller", ginkgo.Ordered, func() {
 			ginkgo.By("Creating a TrainJob")
 			gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
 
-			ginkgo.By("Checking if the TrainingRuntime obtains finalizers")
-			gomega.Eventually(func(g gomega.Gomega) {
+			ginkgo.By("Checking that the TrainingRuntime never obtains finalizers")
+			gomega.Consistently(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, trainingRuntimeKey, trainingRuntime)).Should(gomega.Succeed())
-				g.Expect(trainingRuntime.ObjectMeta.Finalizers).Should(gomega.BeComparableTo(
-					[]string{constants.ResourceInUseFinalizer},
-				))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				g.Expect(trainingRuntime.ObjectMeta.Finalizers).Should(gomega.HaveLen(0))
+			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("TrainingRuntime can be deleted once referenced TrainJob is deleted", func() {
+		ginkgo.It("TrainingRuntime can be deleted while referenced by a TrainJob", func() {
 			ginkgo.By("Creating a TrainingRuntime and TrainJob")
 			gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), trainingRuntime)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
-
-			ginkgo.By("Checking if the TrainingRuntime obtains finalizers")
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, trainingRuntimeKey, trainingRuntime)).Should(gomega.Succeed())
-				g.Expect(trainingRuntime.ObjectMeta.Finalizers).Should(gomega.BeComparableTo(
-					[]string{constants.ResourceInUseFinalizer},
-				))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			ginkgo.By("Delete a TrainJob")
-			gomega.Expect(k8sClient.Delete(ctx, trainJob)).Should(gomega.Succeed())
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainJob), trainJob)).Should(utiltesting.BeNotFoundError())
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			ginkgo.By("Checking if the TrainingRuntime keep having finalizers")
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, trainingRuntimeKey, trainingRuntime)).Should(gomega.Succeed())
-				g.Expect(trainingRuntime.ObjectMeta.Finalizers).Should(gomega.BeComparableTo(
-					[]string{constants.ResourceInUseFinalizer},
-				))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Checking if the TrainingRuntime can be deleted")
 			gomega.Expect(k8sClient.Delete(ctx, trainingRuntime)).Should(gomega.Succeed())

--- a/test/integration/controller/trainingruntime_controller_test.go
+++ b/test/integration/controller/trainingruntime_controller_test.go
@@ -73,26 +73,6 @@ var _ = ginkgo.Describe("TrainingRuntime controller", ginkgo.Ordered, func() {
 			gomega.Expect(k8sClient.DeleteAllOf(ctx, &trainer.TrainingRuntime{}, client.InNamespace(ns.Name))).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("TrainingRuntime does not obtain finalizer when TrainJob with TrainingRuntime is created", func() {
-			ginkgo.By("Creating a TrainingRuntime")
-			gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
-
-			ginkgo.By("Checking if the TrainingRuntime does not keep obtaining finalizers")
-			gomega.Consistently(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, trainingRuntimeKey, trainingRuntime)).Should(gomega.Succeed())
-				g.Expect(trainingRuntime.ObjectMeta.Finalizers).Should(gomega.HaveLen(0))
-			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
-
-			ginkgo.By("Creating a TrainJob")
-			gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
-
-			ginkgo.By("Checking that the TrainingRuntime never obtains finalizers")
-			gomega.Consistently(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, trainingRuntimeKey, trainingRuntime)).Should(gomega.Succeed())
-				g.Expect(trainingRuntime.ObjectMeta.Finalizers).Should(gomega.HaveLen(0))
-			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
-		})
-
 		ginkgo.It("TrainingRuntime can be deleted while referenced by a TrainJob", func() {
 			ginkgo.By("Creating a TrainingRuntime and TrainJob")
 			gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:
- Remove logic that adds runtime finalizers.
- Automatically remove existing runtime finalizers during reconciliation to provide a safe upgrade path.
- Update unit tests, integration tests, and the runtime snapshot KEP accordingly.

Fixes #3715
