### PR TITLE
fix(manifests): enforce Pod Security Admission baseline on the Trainer namespace

### DIFF
--- a/charts/kubeflow-trainer/README.md
+++ b/charts/kubeflow-trainer/README.md
@@ -99,6 +99,9 @@ manager:
 |-----|------|---------|-------------|
 | nameOverride | string | `""` | String to partially override release name. |
 | fullnameOverride | string | `""` | String to fully override release name. |
+| namespace.create | bool | `true` | Whether the chart creates the release namespace. Set to `false` if the namespace is created out of band (for example with `helm install --create-namespace`) and labelled separately. |
+| namespace.labels | object | `{"pod-security.kubernetes.io/enforce":"baseline"}` | Labels to set on the release namespace. The Pod Security Admission level is applied here so a default install enforces it on the namespace where TrainJobs run. |
+| namespace.annotations | object | `{}` | Annotations to set on the release namespace. |
 | crds.enabled | bool | `true` | Whether to install the Trainer CRDs (TrainJob, TrainingRuntime, ClusterTrainingRuntime) with the chart. Set to `false` if you manage the CRDs outside of the chart (for example, applying them separately). This replaces Helm's built-in `--skip-crds` flag, which no longer applies now that the CRDs are chart templates. |
 | jobset.install | bool | `true` | Whether to install jobset as a dependency managed by trainer. This must be set to `false` if jobset controller/webhook has already been installed into the cluster. |
 | jobset.fullnameOverride | string | `"jobset"` | String to fully override jobset release name. |

--- a/charts/kubeflow-trainer/templates/namespace.yaml
+++ b/charts/kubeflow-trainer/templates/namespace.yaml
@@ -1,0 +1,30 @@
+{{- /*
+Copyright The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  {{- with .Values.namespace.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.namespace.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/kubeflow-trainer/tests/namespace_test.yaml
+++ b/charts/kubeflow-trainer/tests/namespace_test.yaml
@@ -1,0 +1,56 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+suite: Test release Namespace
+
+templates:
+  - namespace.yaml
+
+release:
+  name: kubeflow-trainer
+  namespace: kubeflow-system
+
+tests:
+  - it: Should create the release namespace with the default Pod Security Admission label
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Namespace
+          name: kubeflow-system
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/enforce"]
+          value: baseline
+
+  - it: Should honour custom labels and annotations
+    set:
+      namespace:
+        labels:
+          team: ml
+        annotations:
+          owner: platform
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: ml
+      - equal:
+          path: metadata.annotations.owner
+          value: platform
+
+  - it: Should not render the namespace when create is false
+    set:
+      namespace:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/kubeflow-trainer/values.yaml
+++ b/charts/kubeflow-trainer/values.yaml
@@ -22,6 +22,18 @@ nameOverride: ""
 # -- String to fully override release name.
 fullnameOverride: ""
 
+namespace:
+  # -- Whether the chart creates the release namespace. Set to `false` if the
+  # namespace is created out of band (for example with `helm install --create-namespace`)
+  # and labelled separately.
+  create: true
+  # -- Labels to set on the release namespace. The Pod Security Admission level is
+  # applied here so a default install enforces it on the namespace where TrainJobs run.
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+  # -- Annotations to set on the release namespace.
+  annotations: {}
+
 crds:
   # -- Whether to install the Trainer CRDs (TrainJob, TrainingRuntime, ClusterTrainingRuntime) with the chart.
   # Set to `false` if you manage the CRDs outside of the chart (for example, applying them separately).

--- a/manifests/overlays/manager/namespace.yaml
+++ b/manifests/overlays/manager/namespace.yaml
@@ -16,3 +16,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kubeflow-system
+  labels:
+    pod-security.kubernetes.io/enforce: baseline


### PR DESCRIPTION
**What this PR does / why we need it**:

The default Trainer install does not label its namespace with a Pod Security Admission (PSA) level, so nothing at the admission layer prevents a workload scheduled into that namespace from running with `privileged: true`, `hostPath` volumes, or other node-level escape primitives.

This PR labels the release namespace with `pod-security.kubernetes.io/enforce: baseline` in both install paths:

- **Kustomize overlay** (`manifests/overlays/manager/namespace.yaml`) gets the label directly.
- **Helm chart**: the chart deployed every resource into `.Release.Namespace` but never created the namespace itself, so unlike the kustomize overlay it had no Namespace object to carry PSA labels. This adds a `namespace.yaml` template, gated by `namespace.create` (default `true`), that creates the release namespace from a configurable `labels`/`annotations` map. The default labels carry `pod-security.kubernetes.io/enforce: baseline`, matching the kustomize overlay, so a default install enforces PSA on the namespace where TrainJobs run. Operators who create the namespace out of band can set `namespace.create=false` and label it themselves.

The `baseline` profile rejects the most common privilege-escalation vectors (privileged containers, host namespaces, `hostPath` volumes, adding dangerous capabilities) while staying permissive enough for normal training workloads.

Relates to GHSA-2v88-3c5j-xcjq.

**Which issue(s) this PR fixes**:
N/A

**Checklist:**

- [x] helm-unittest coverage added (`charts/kubeflow-trainer/tests/namespace_test.yaml`) for the default label, custom labels/annotations, and the `create=false` case
- [ ] Docs included if any changes are user facing
