### PR TITLE
fix(operator): preserve terminal TrainJob failures

### DIFF
--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -115,34 +115,35 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Keep track of the origin TrainJob status
 	prevTrainJob := trainJob.DeepCopy()
 
-	// Let's clear the failed condition that could have been set previously.
-	// An external change to the TrainJob spec may transition it out of the Failed state.
-	removeFailedCondition(&trainJob)
-
 	runtimeRefGK := jobruntimes.RuntimeRefToRuntimeRegistryKey(trainJob.Spec.RuntimeRef)
 	runtime, ok := r.runtimes[runtimeRefGK]
 	if !ok {
 		err = fmt.Errorf("unsupported runtime: %s", runtimeRefGK)
-		setFailedCondition(&trainJob, fmt.Sprintf("unsupported runtime: %s", runtimeRefGK), trainer.TrainJobRuntimeNotSupportedReason)
-	} else if !trainjob.IsTrainJobFinished(&trainJob) {
-		err = r.reconcileObjects(ctx, runtime, &trainJob)
-		if err != nil {
-			// TODO (astefanutti): the error should be surfaced in the TrainJob status to indicate
-			//  the creation of the runtime resources failed and the TrainJob is backed off until
-			//  the next retry attempt.
-			// The event message is truncated to stay within the maximum length limit (1024 chars).
-			message := fmt.Sprintf("TrainJob resources reconciliation failed: %.950v", err.Error())
-			if len(err.Error()) > 950 {
-				message = fmt.Sprintf("%s ...", message)
+		setRuntimeNotSupportedFailedCondition(&trainJob, fmt.Sprintf("unsupported runtime: %s", runtimeRefGK))
+	} else {
+		removeTransientFailedCondition(&trainJob)
+		if !trainjob.IsTrainJobFinished(&trainJob) {
+			err = r.reconcileObjects(ctx, runtime, &trainJob)
+			if err != nil {
+				// TODO (astefanutti): the error should be surfaced in the TrainJob status to indicate
+				//  the creation of the runtime resources failed and the TrainJob is backed off until
+				//  the next retry attempt.
+				// The event message is truncated to stay within the maximum length limit (1024 chars).
+				message := fmt.Sprintf("TrainJob resources reconciliation failed: %.950v", err.Error())
+				if len(err.Error()) > 950 {
+					message = fmt.Sprintf("%s ...", message)
+				}
+				r.recorder.Eventf(&trainJob, nil, corev1.EventTypeWarning, "TrainJobResourcesCreationFailed", "Reconciling", message)
 			}
-			r.recorder.Eventf(&trainJob, nil, corev1.EventTypeWarning, "TrainJobResourcesCreationFailed", "Reconciling", message)
 		}
 	}
 
 	setSuspendedCondition(&trainJob)
 
-	if statusErr := setTrainJobStatus(ctx, runtime, &trainJob); statusErr != nil {
-		err = errors.Join(err, statusErr)
+	if ok {
+		if statusErr := setTrainJobStatus(ctx, runtime, &trainJob); statusErr != nil {
+			err = errors.Join(err, statusErr)
+		}
 	}
 
 	if deadlineResult, deadlineErr := r.reconcileDeadline(ctx, &trainJob); deadlineErr != nil || deadlineResult.RequeueAfter > 0 {
@@ -273,12 +274,19 @@ func setFailedCondition(trainJob *trainer.TrainJob, message, reason string) {
 	meta.SetStatusCondition(&trainJob.Status.Conditions, newCond)
 }
 
-func removeFailedCondition(trainJob *trainer.TrainJob) {
+func setRuntimeNotSupportedFailedCondition(trainJob *trainer.TrainJob, message string) {
 	cond := meta.FindStatusCondition(trainJob.Status.Conditions, trainer.TrainJobFailed)
-	if cond != nil && cond.Reason == trainer.TrainJobDeadlineExceededReason {
+	if cond != nil && cond.Status == metav1.ConditionTrue && cond.Reason != trainer.TrainJobRuntimeNotSupportedReason {
 		return
 	}
-	meta.RemoveStatusCondition(&trainJob.Status.Conditions, trainer.TrainJobFailed)
+	setFailedCondition(trainJob, message, trainer.TrainJobRuntimeNotSupportedReason)
+}
+
+func removeTransientFailedCondition(trainJob *trainer.TrainJob) {
+	cond := meta.FindStatusCondition(trainJob.Status.Conditions, trainer.TrainJobFailed)
+	if cond != nil && cond.Reason == trainer.TrainJobRuntimeNotSupportedReason {
+		meta.RemoveStatusCondition(&trainJob.Status.Conditions, trainer.TrainJobFailed)
+	}
 }
 
 func setTrainJobStatus(ctx context.Context, runtime jobruntimes.Runtime, trainJob *trainer.TrainJob) error {

--- a/pkg/controller/trainjob_controller_test.go
+++ b/pkg/controller/trainjob_controller_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2026 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	jobsetconsts "sigs.k8s.io/jobset/pkg/constants"
+
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+)
+
+func TestReconcileUnsupportedRuntime(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := trainer.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+	trainJob := &trainer.TrainJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: trainer.TrainJobSpec{
+			RuntimeRef: trainer.RuntimeRef{
+				Name:     "unsupported",
+				APIGroup: ptr.To(trainer.GroupVersion.Group),
+				Kind:     ptr.To("UnsupportedRuntime"),
+			},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&trainer.TrainJob{}).
+		WithObjects(trainJob).
+		Build()
+	reconciler := NewTrainJobReconciler(k8sClient, nil, nil)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(trainJob)})
+	if err == nil || !strings.Contains(err.Error(), "unsupported runtime") {
+		t.Fatalf("Reconcile() error = %v, want unsupported runtime error", err)
+	}
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(trainJob), trainJob); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	failedCond := meta.FindStatusCondition(trainJob.Status.Conditions, trainer.TrainJobFailed)
+	if failedCond == nil || failedCond.Status != metav1.ConditionTrue || failedCond.Reason != trainer.TrainJobRuntimeNotSupportedReason {
+		t.Errorf("Failed condition = %#v, want True with reason %q", failedCond, trainer.TrainJobRuntimeNotSupportedReason)
+	}
+}
+
+func TestRemoveTransientFailedCondition(t *testing.T) {
+	cases := map[string]struct {
+		failedCondition *metav1.Condition
+		wantFailed      bool
+	}{
+		"no Failed condition": {},
+		"TrainingRuntimeNotSupported is transient": {
+			failedCondition: &metav1.Condition{
+				Type:   trainer.TrainJobFailed,
+				Status: metav1.ConditionTrue,
+				Reason: trainer.TrainJobRuntimeNotSupportedReason,
+			},
+		},
+		"DeadlineExceeded is terminal": {
+			failedCondition: &metav1.Condition{
+				Type:   trainer.TrainJobFailed,
+				Status: metav1.ConditionTrue,
+				Reason: trainer.TrainJobDeadlineExceededReason,
+			},
+			wantFailed: true,
+		},
+		"FailedJobs is terminal": {
+			failedCondition: &metav1.Condition{
+				Type:   trainer.TrainJobFailed,
+				Status: metav1.ConditionTrue,
+				Reason: jobsetconsts.FailedJobsReason,
+			},
+			wantFailed: true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			trainJob := &trainer.TrainJob{}
+			if tc.failedCondition != nil {
+				trainJob.Status.Conditions = []metav1.Condition{*tc.failedCondition}
+			}
+
+			removeTransientFailedCondition(trainJob)
+
+			gotFailed := len(trainJob.Status.Conditions) != 0
+			if gotFailed != tc.wantFailed {
+				t.Errorf("Failed condition presence = %t, want %t", gotFailed, tc.wantFailed)
+			}
+		})
+	}
+}
+
+func TestSetRuntimeNotSupportedFailedCondition(t *testing.T) {
+	cases := map[string]struct {
+		failedCondition *metav1.Condition
+		wantReason      string
+	}{
+		"no Failed condition": {
+			wantReason: trainer.TrainJobRuntimeNotSupportedReason,
+		},
+		"TrainingRuntimeNotSupported remains transient": {
+			failedCondition: &metav1.Condition{
+				Type:   trainer.TrainJobFailed,
+				Status: metav1.ConditionTrue,
+				Reason: trainer.TrainJobRuntimeNotSupportedReason,
+			},
+			wantReason: trainer.TrainJobRuntimeNotSupportedReason,
+		},
+		"DeadlineExceeded is preserved": {
+			failedCondition: &metav1.Condition{
+				Type:   trainer.TrainJobFailed,
+				Status: metav1.ConditionTrue,
+				Reason: trainer.TrainJobDeadlineExceededReason,
+			},
+			wantReason: trainer.TrainJobDeadlineExceededReason,
+		},
+		"FailedJobs is preserved": {
+			failedCondition: &metav1.Condition{
+				Type:   trainer.TrainJobFailed,
+				Status: metav1.ConditionTrue,
+				Reason: jobsetconsts.FailedJobsReason,
+			},
+			wantReason: jobsetconsts.FailedJobsReason,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			trainJob := &trainer.TrainJob{}
+			if tc.failedCondition != nil {
+				trainJob.Status.Conditions = []metav1.Condition{*tc.failedCondition}
+			}
+
+			setRuntimeNotSupportedFailedCondition(trainJob, "unsupported runtime")
+
+			if gotReason := trainJob.Status.Conditions[0].Reason; gotReason != tc.wantReason {
+				t.Errorf("Failed condition reason = %q, want %q", gotReason, tc.wantReason)
+			}
+		})
+	}
+}

--- a/test/integration/controller/trainjob_controller_test.go
+++ b/test/integration/controller/trainjob_controller_test.go
@@ -730,6 +730,26 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 						},
 					}))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Deleting the failed JobSet")
+				gomega.Expect(k8sClient.Delete(ctx, &jobsetv1alpha2.JobSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: trainJobKey.Namespace,
+						Name:      trainJobKey.Name,
+					},
+				})).Should(gomega.Succeed())
+
+				ginkgo.By("Checking that the JobSet stays deleted and the TrainJob remains failed")
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, trainJobKey, &jobsetv1alpha2.JobSet{})).Should(testingutil.BeNotFoundError())
+					gotTrainJob := &trainer.TrainJob{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, gotTrainJob)).Should(gomega.Succeed())
+					g.Expect(gotTrainJob.Status.Conditions).Should(gomega.ContainElement(gomega.And(
+						gomega.HaveField("Type", trainer.TrainJobFailed),
+						gomega.HaveField("Status", metav1.ConditionTrue),
+						gomega.HaveField("Reason", jobsetconsts.FailedJobsReason),
+					)))
+				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.It("Should synchronize JobsStatus from JobSet ReplicatedJobsStatus", func() {


### PR DESCRIPTION
## What this PR does
﻿
Fixes an issue where a failed TrainJob could be restarted after its JobSet was deleted manually or removed by TTL cleanup.
﻿
Previously, the TrainJob controller cleared most `Failed` conditions during reconciliation. When the failed JobSet no longer existed, the TrainJob was no longer considered finished and the controller recreated the runtime resources, causing the failed workload to run again.
﻿
This PR changes the controller to:
﻿
- Clear only the transient `TrainingRuntimeNotSupported` failure after the referenced runtime becomes available.
- Preserve terminal JobSet failure conditions.
- Preserve `DeadlineExceeded` failures.
- Avoid replacing an existing terminal failure when runtime lookup fails.
- Add unit and integration regression coverage for the JobSet deletion scenario.
﻿
## Why
﻿
Only `TrainingRuntimeNotSupported` depends on a mutable TrainJob runtime reference and should be reevaluated during reconciliation. JobSet failures and deadline expiration represent terminal execution results and must remain in the TrainJob status after the underlying workload is deleted.
﻿
Preserving these conditions keeps `IsTrainJobFinished` true and prevents the controller from recreating and rerunning a failed workload.
﻿
Fixes #3737.
﻿
﻿