### PR TITLE
fix(initializer): validate HuggingFace storage URI

### DIFF
--- a/pkg/initializers/dataset/huggingface.py
+++ b/pkg/initializers/dataset/huggingface.py
@@ -27,6 +27,30 @@ logging.basicConfig(
 )
 
 
+def parse_huggingface_storage_uri(storage_uri: str) -> str:
+    """Parse HuggingFace dataset storage URI.
+
+    Expected format: hf://<USER_NAME>/<DATASET_NAME>
+    """
+    prefix = "hf://"
+    if not storage_uri.startswith(prefix):
+        raise ValueError(
+            f"Invalid HuggingFace storage URI {storage_uri!r}: "
+            "expected format hf://<USER_NAME>/<DATASET_NAME>"
+        )
+
+    storage_uri_parsed = urlparse(storage_uri)
+    path_parts = storage_uri_parsed.path.strip("/").split("/")
+
+    if not storage_uri_parsed.netloc or len(path_parts) != 1 or not path_parts[0]:
+        raise ValueError(
+            f"Invalid HuggingFace storage URI {storage_uri!r}: "
+            "expected format hf://<USER_NAME>/<DATASET_NAME>"
+        )
+
+    return f"{storage_uri_parsed.netloc}/{path_parts[0]}"
+
+
 class HuggingFace(utils.DatasetProvider):
 
     def load_config(self):
@@ -34,10 +58,7 @@ class HuggingFace(utils.DatasetProvider):
         self.config = types.HuggingFaceDatasetInitializer(**config_dict)
 
     def download_dataset(self):
-        storage_uri_parsed = urlparse(self.config.storage_uri)
-        dataset_uri = (
-            storage_uri_parsed.netloc + "/" + storage_uri_parsed.path.split("/")[1]
-        )
+        dataset_uri = parse_huggingface_storage_uri(self.config.storage_uri)
 
         logging.info(f"Downloading dataset: {dataset_uri}")
         logging.info("-" * 40)
@@ -53,3 +74,4 @@ class HuggingFace(utils.DatasetProvider):
         )
 
         logging.info("Dataset has been downloaded")
+        

--- a/pkg/initializers/dataset/huggingface.py
+++ b/pkg/initializers/dataset/huggingface.py
@@ -40,9 +40,16 @@ def parse_huggingface_storage_uri(storage_uri: str) -> str:
         )
 
     storage_uri_parsed = urlparse(storage_uri)
-    path_parts = storage_uri_parsed.path.strip("/").split("/")
+    path_parts = storage_uri_parsed.path.split("/")
 
-    if not storage_uri_parsed.netloc or len(path_parts) != 1 or not path_parts[0]:
+    if (
+        not storage_uri_parsed.netloc
+        or len(path_parts) != 2
+        or path_parts[0]
+        or not path_parts[1]
+        or storage_uri_parsed.query
+        or storage_uri_parsed.fragment
+    ):
         raise ValueError(
             f"Invalid HuggingFace storage URI {storage_uri!r}: "
             "expected format hf://<USER_NAME>/<DATASET_NAME>"

--- a/pkg/initializers/dataset/huggingface.py
+++ b/pkg/initializers/dataset/huggingface.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-from urllib.parse import urlparse
 
 import huggingface_hub
 
@@ -30,32 +29,35 @@ logging.basicConfig(
 def parse_huggingface_storage_uri(storage_uri: str) -> str:
     """Parse HuggingFace dataset storage URI.
 
-    Expected format: hf://<USER_NAME>/<DATASET_NAME>
+    Expected formats:
+    - hf://<DATASET_NAME>
+    - hf://<USER_OR_ORG>/<DATASET_NAME>
     """
     prefix = "hf://"
     if not storage_uri.startswith(prefix):
         raise ValueError(
             f"Invalid HuggingFace storage URI {storage_uri!r}: "
-            "expected format hf://<USER_NAME>/<DATASET_NAME>"
+            "expected format hf://<DATASET_NAME> or "
+            "hf://<USER_OR_ORG>/<DATASET_NAME>"
         )
 
-    storage_uri_parsed = urlparse(storage_uri)
-    path_parts = storage_uri_parsed.path.split("/")
+    dataset_uri = storage_uri[len(prefix) :]
+    parts = dataset_uri.split("/")
 
     if (
-        not storage_uri_parsed.netloc
-        or len(path_parts) != 2
-        or path_parts[0]
-        or not path_parts[1]
-        or storage_uri_parsed.query
-        or storage_uri_parsed.fragment
+        not dataset_uri
+        or dataset_uri.startswith("/")
+        or dataset_uri.endswith("/")
+        or any(not part for part in parts)
+        or len(parts) > 2
     ):
         raise ValueError(
             f"Invalid HuggingFace storage URI {storage_uri!r}: "
-            "expected format hf://<USER_NAME>/<DATASET_NAME>"
+            "expected format hf://<DATASET_NAME> or "
+            "hf://<USER_OR_ORG>/<DATASET_NAME>"
         )
 
-    return f"{storage_uri_parsed.netloc}/{path_parts[0]}"
+    return dataset_uri
 
 
 class HuggingFace(utils.DatasetProvider):
@@ -81,4 +83,3 @@ class HuggingFace(utils.DatasetProvider):
         )
 
         logging.info("Dataset has been downloaded")
-        

--- a/pkg/initializers/dataset/huggingface_test.py
+++ b/pkg/initializers/dataset/huggingface_test.py
@@ -26,11 +26,12 @@ from pkg.initializers.dataset.huggingface import (
 @pytest.mark.parametrize(
     "storage_uri, expected",
     [
+        ("hf://cnn_dailymail", "cnn_dailymail"),
         ("hf://username/dataset-name", "username/dataset-name"),
         ("hf://org/dataset-v1", "org/dataset-v1"),
     ],
 )
-def test_parse_huggingface_storage_uri_valid(storage_uri, expected):
+def test_parse_huggingface_storage_uri(storage_uri, expected):
     assert parse_huggingface_storage_uri(storage_uri) == expected
 
 
@@ -38,10 +39,10 @@ def test_parse_huggingface_storage_uri_valid(storage_uri, expected):
     "storage_uri",
     [
         "hf://",
-        "hf://username",
         "hf:///dataset",
         "hf://username/",
         "hf://username/dataset/extra",
+        "hf://username//dataset",
         "s3://bucket/dataset",
         "username/dataset",
     ],
@@ -49,7 +50,8 @@ def test_parse_huggingface_storage_uri_valid(storage_uri, expected):
 def test_parse_huggingface_storage_uri_invalid(storage_uri):
     expected_message = (
         f"Invalid HuggingFace storage URI {storage_uri!r}: "
-        "expected format hf://<USER_NAME>/<DATASET_NAME>"
+        "expected format hf://<DATASET_NAME> or "
+        "hf://<USER_OR_ORG>/<DATASET_NAME>"
     )
 
     with pytest.raises(ValueError) as exc_info:
@@ -73,9 +75,9 @@ def test_parse_huggingface_storage_uri_invalid(storage_uri):
         ),
         (
             "Minimal config without token",
-            {"storage_uri": "hf://username/dataset-name"},
+            {"storage_uri": "hf://cnn_dailymail"},
             {
-                "storage_uri": "hf://username/dataset-name",
+                "storage_uri": "hf://cnn_dailymail",
                 "ignore_patterns": None,
                 "access_token": None,
             },
@@ -122,6 +124,18 @@ def test_load_config(test_name, test_config, expected):
                 "expected_repo_id": "org/dataset-v1",
             },
         ),
+        (
+            "Successful download without username",
+            {
+                "config": {
+                    "storage_uri": "hf://cnn_dailymail",
+                    "ignore_patterns": None,
+                    "access_token": None,
+                },
+                "should_login": False,
+                "expected_repo_id": "cnn_dailymail",
+            },
+        ),
     ],
 )
 def test_download_dataset(test_name, test_case):
@@ -153,4 +167,3 @@ def test_download_dataset(test_name, test_case):
             ignore_patterns=test_case["config"]["ignore_patterns"],
         )
     print("Test execution completed")
-    

--- a/pkg/initializers/dataset/huggingface_test.py
+++ b/pkg/initializers/dataset/huggingface_test.py
@@ -17,7 +17,45 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import pkg.initializers.utils.utils as utils
-from pkg.initializers.dataset.huggingface import HuggingFace
+from pkg.initializers.dataset.huggingface import (
+    HuggingFace,
+    parse_huggingface_storage_uri,
+)
+
+
+@pytest.mark.parametrize(
+    "storage_uri, expected",
+    [
+        ("hf://username/dataset-name", "username/dataset-name"),
+        ("hf://org/dataset-v1", "org/dataset-v1"),
+    ],
+)
+def test_parse_huggingface_storage_uri_valid(storage_uri, expected):
+    assert parse_huggingface_storage_uri(storage_uri) == expected
+
+
+@pytest.mark.parametrize(
+    "storage_uri",
+    [
+        "hf://",
+        "hf://username",
+        "hf:///dataset",
+        "hf://username/",
+        "hf://username/dataset/extra",
+        "s3://bucket/dataset",
+        "username/dataset",
+    ],
+)
+def test_parse_huggingface_storage_uri_invalid(storage_uri):
+    expected_message = (
+        f"Invalid HuggingFace storage URI {storage_uri!r}: "
+        "expected format hf://<USER_NAME>/<DATASET_NAME>"
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        parse_huggingface_storage_uri(storage_uri)
+
+    assert str(exc_info.value) == expected_message
 
 
 # Test cases for config loading
@@ -26,18 +64,18 @@ from pkg.initializers.dataset.huggingface import HuggingFace
     [
         (
             "Full config with token",
-            {"storage_uri": "hf://dataset/path", "access_token": "test_token"},
+            {"storage_uri": "hf://username/dataset-name", "access_token": "test_token"},
             {
-                "storage_uri": "hf://dataset/path",
+                "storage_uri": "hf://username/dataset-name",
                 "ignore_patterns": None,
                 "access_token": "test_token",
             },
         ),
         (
             "Minimal config without token",
-            {"storage_uri": "hf://dataset/path"},
+            {"storage_uri": "hf://username/dataset-name"},
             {
-                "storage_uri": "hf://dataset/path",
+                "storage_uri": "hf://username/dataset-name",
                 "ignore_patterns": None,
                 "access_token": None,
             },
@@ -115,3 +153,4 @@ def test_download_dataset(test_name, test_case):
             ignore_patterns=test_case["config"]["ignore_patterns"],
         )
     print("Test execution completed")
+    


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds validation for the HuggingFace dataset initializer `storage_uri` before parsing the HuggingFace dataset repository ID.

Previously, `pkg/initializers/dataset/huggingface.py` parsed the URI using direct URL parsing and path indexing:

```python
storage_uri_parsed = urlparse(self.config.storage_uri)
dataset_uri = (
    storage_uri_parsed.netloc + "/" + storage_uri_parsed.path.split("/")[1]
)
```
This assumes the URI always follows the expected format: `hf: //<USER_NAME>/<DATASET_NAME>`

If a malformed value was provided, such as:
```
hf://
hf://username
hf:///dataset
hf://username/
hf://username/dataset/extra
s3://bucket/dataset
username/dataset
```
the initializer could fail with an unclear Python error or construct an invalid HuggingFace repository ID.

This PR adds a dedicated **parse_huggingface_storage_uri** helper that validates the URI format and returns a clear **ValueErro**r when the value is invalid.

The expected format is:` hf://<USER_NAME>/<DATASET_NAME>`

This improves the user experience by failing early with an actionable error message.

Testing performed:
```python
python -m py_compile pkg/initializers/dataset/huggingface.py
python -m py_compile pkg/initializers/dataset/huggingface_test.py
$env:PYTHONPATH="."
uv run --with pytest --with huggingface-hub pytest pkg/initializers/dataset/huggingface_test.py
```

Fixes #3745

- [ ]  [Docs ](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing