### PR TITLE
feat(runtimes): make MPI launcher depend on worker readiness

### DIFF
--- a/charts/kubeflow-trainer/files/runtimes/deepspeed-distributed.yaml
+++ b/charts/kubeflow-trainer/files/runtimes/deepspeed-distributed.yaml
@@ -38,19 +38,6 @@ spec:
         targetReplicatedJobs:
           - launcher
       replicatedJobs:
-        - name: launcher
-          template:
-            metadata:
-              labels:
-                trainer.kubeflow.org/trainjob-ancestor-step: trainer
-            spec:
-              template:
-                spec:
-                  containers:
-                    - name: node
-                      image: {{ include "trainer.runtimeImage" (list .Values.runtimes.deepspeedDistributed.image .) }}
-                      securityContext:
-                        runAsUser: 1000
         - name: node
           template:
             spec:
@@ -71,3 +58,19 @@ spec:
                         tcpSocket:
                           port: 2222
                         initialDelaySeconds: 5
+        - name: launcher
+          dependsOn:
+            - name: node
+              status: Ready
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: trainer
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: node
+                      image: {{ include "trainer.runtimeImage" (list .Values.runtimes.deepspeedDistributed.image .) }}
+                      securityContext:
+                        runAsUser: 1000

--- a/charts/kubeflow-trainer/files/runtimes/deepspeed-distributed.yaml
+++ b/charts/kubeflow-trainer/files/runtimes/deepspeed-distributed.yaml
@@ -43,6 +43,8 @@ spec:
             spec:
               template:
                 spec:
+                  securityContext:
+                    fsGroup: 1000
                   containers:
                     - name: node
                       image: {{ include "trainer.runtimeImage" (list .Values.runtimes.deepspeedDistributed.image .) }}
@@ -69,6 +71,8 @@ spec:
             spec:
               template:
                 spec:
+                  securityContext:
+                    fsGroup: 1000
                   containers:
                     - name: node
                       image: {{ include "trainer.runtimeImage" (list .Values.runtimes.deepspeedDistributed.image .) }}

--- a/charts/kubeflow-trainer/files/runtimes/mlx-distributed.yaml
+++ b/charts/kubeflow-trainer/files/runtimes/mlx-distributed.yaml
@@ -38,19 +38,6 @@ spec:
         targetReplicatedJobs:
           - launcher
       replicatedJobs:
-        - name: launcher
-          template:
-            metadata:
-              labels:
-                trainer.kubeflow.org/trainjob-ancestor-step: trainer
-            spec:
-              template:
-                spec:
-                  containers:
-                    - name: node
-                      image: {{ include "trainer.runtimeImage" (list .Values.runtimes.mlxDistributed.image .) }}
-                      securityContext:
-                        runAsUser: 1000
         - name: node
           template:
             spec:
@@ -71,3 +58,19 @@ spec:
                         tcpSocket:
                           port: 2222
                         initialDelaySeconds: 5
+        - name: launcher
+          dependsOn:
+            - name: node
+              status: Ready
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: trainer
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: node
+                      image: {{ include "trainer.runtimeImage" (list .Values.runtimes.mlxDistributed.image .) }}
+                      securityContext:
+                        runAsUser: 1000

--- a/charts/kubeflow-trainer/files/runtimes/mlx-distributed.yaml
+++ b/charts/kubeflow-trainer/files/runtimes/mlx-distributed.yaml
@@ -43,6 +43,8 @@ spec:
             spec:
               template:
                 spec:
+                  securityContext:
+                    fsGroup: 1000
                   containers:
                     - name: node
                       image: {{ include "trainer.runtimeImage" (list .Values.runtimes.mlxDistributed.image .) }}
@@ -69,6 +71,8 @@ spec:
             spec:
               template:
                 spec:
+                  securityContext:
+                    fsGroup: 1000
                   containers:
                     - name: node
                       image: {{ include "trainer.runtimeImage" (list .Values.runtimes.mlxDistributed.image .) }}

--- a/manifests/base/runtimes/deepspeed_distributed.yaml
+++ b/manifests/base/runtimes/deepspeed_distributed.yaml
@@ -40,6 +40,8 @@ spec:
             spec:
               template:
                 spec:
+                  securityContext:
+                    fsGroup: 1000
                   containers:
                     - name: node
                       image: ghcr.io/kubeflow/trainer/deepspeed-runtime
@@ -66,6 +68,8 @@ spec:
             spec:
               template:
                 spec:
+                  securityContext:
+                    fsGroup: 1000
                   containers:
                     - name: node
                       image: ghcr.io/kubeflow/trainer/deepspeed-runtime

--- a/manifests/base/runtimes/deepspeed_distributed.yaml
+++ b/manifests/base/runtimes/deepspeed_distributed.yaml
@@ -35,19 +35,6 @@ spec:
         targetReplicatedJobs:
           - launcher
       replicatedJobs:
-        - name: launcher
-          template:
-            metadata:
-              labels:
-                trainer.kubeflow.org/trainjob-ancestor-step: trainer
-            spec:
-              template:
-                spec:
-                  containers:
-                    - name: node
-                      image: ghcr.io/kubeflow/trainer/deepspeed-runtime
-                      securityContext:
-                        runAsUser: 1000
         - name: node
           template:
             spec:
@@ -68,3 +55,19 @@ spec:
                         tcpSocket:
                           port: 2222
                         initialDelaySeconds: 5
+        - name: launcher
+          dependsOn:
+            - name: node
+              status: Ready
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: trainer
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: node
+                      image: ghcr.io/kubeflow/trainer/deepspeed-runtime
+                      securityContext:
+                        runAsUser: 1000

--- a/manifests/base/runtimes/mlx_distributed.yaml
+++ b/manifests/base/runtimes/mlx_distributed.yaml
@@ -35,19 +35,6 @@ spec:
         targetReplicatedJobs:
           - launcher
       replicatedJobs:
-        - name: launcher
-          template:
-            metadata:
-              labels:
-                trainer.kubeflow.org/trainjob-ancestor-step: trainer
-            spec:
-              template:
-                spec:
-                  containers:
-                    - name: node
-                      image: ghcr.io/kubeflow/trainer/mlx-runtime
-                      securityContext:
-                        runAsUser: 1000
         - name: node
           template:
             spec:
@@ -68,3 +55,19 @@ spec:
                         tcpSocket:
                           port: 2222
                         initialDelaySeconds: 5
+        - name: launcher
+          dependsOn:
+            - name: node
+              status: Ready
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: trainer
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: node
+                      image: ghcr.io/kubeflow/trainer/mlx-runtime
+                      securityContext:
+                        runAsUser: 1000

--- a/manifests/base/runtimes/mlx_distributed.yaml
+++ b/manifests/base/runtimes/mlx_distributed.yaml
@@ -40,6 +40,8 @@ spec:
             spec:
               template:
                 spec:
+                  securityContext:
+                    fsGroup: 1000
                   containers:
                     - name: node
                       image: ghcr.io/kubeflow/trainer/mlx-runtime
@@ -66,6 +68,8 @@ spec:
             spec:
               template:
                 spec:
+                  securityContext:
+                    fsGroup: 1000
                   containers:
                     - name: node
                       image: ghcr.io/kubeflow/trainer/mlx-runtime

--- a/pkg/util/testing/wrapper.go
+++ b/pkg/util/testing/wrapper.go
@@ -1139,6 +1139,18 @@ func (s *TrainingRuntimeSpecWrapper) LauncherReplica() *TrainingRuntimeSpecWrapp
 	return s
 }
 
+func (s *TrainingRuntimeSpecWrapper) DependsOn(
+	rJobName string,
+	dependsOn ...jobsetv1alpha2.DependsOn,
+) *TrainingRuntimeSpecWrapper {
+	for i, rJob := range s.Template.Spec.ReplicatedJobs {
+		if rJob.Name == rJobName {
+			s.Template.Spec.ReplicatedJobs[i].DependsOn = dependsOn
+		}
+	}
+	return s
+}
+
 func (s *TrainingRuntimeSpecWrapper) Replicas(replicas int32, rJobNames ...string) *TrainingRuntimeSpecWrapper {
 	for i, rJob := range s.Template.Spec.ReplicatedJobs {
 		if slices.Contains(rJobNames, rJob.Name) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -135,9 +135,13 @@ var _ = ginkgo.Describe("TrainJob e2e", func() {
 	ginkgo.When("Creating TrainJob to perform OpenMPI workload", func() {
 		// Verify the `deepspeed-distributed` ClusterTrainingRuntime.
 		ginkgo.It("should create TrainJob with DeepSpeed runtime reference", func() {
-			// Create a TrainJob.
+			// Create a multi-node MPI TrainJob.
 			trainJob := testingutil.MakeTrainJobWrapper(ns.Name, "e2e-test-deepspeed").
 				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), deepSpeedRuntime).
+				Trainer(&trainer.Trainer{
+					NumNodes: ptr.To(int32(2)),
+					Command:  []string{"mpirun", "sleep", "10"},
+				}).
 				Obj()
 
 			ginkgo.By("Create a TrainJob with deepspeed-distributed runtime reference", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -149,24 +149,10 @@ var _ = ginkgo.Describe("TrainJob e2e", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					gotTrainJob := &trainer.TrainJob{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainJob), gotTrainJob)).Should(gomega.Succeed())
-					g.Expect(gotTrainJob.Status.JobsStatus).Should(gomega.BeComparableTo([]trainer.JobStatus{
-						{
-							Name:      constants.Launcher,
-							Ready:     ptr.To(int32(0)),
-							Succeeded: ptr.To(int32(0)),
-							Failed:    ptr.To(int32(0)),
-							Active:    ptr.To(int32(1)),
-							Suspended: ptr.To(int32(0)),
-						},
-						{
-							Name:      constants.Node,
-							Ready:     ptr.To(int32(0)),
-							Succeeded: ptr.To(int32(0)),
-							Failed:    ptr.To(int32(0)),
-							Active:    ptr.To(int32(1)),
-							Suspended: ptr.To(int32(0)),
-						},
-					}, util.SortJobsStatus))
+					nodeStatus, ok := jobStatusByName(gotTrainJob.Status.JobsStatus, constants.Node)
+					g.Expect(ok).Should(gomega.BeTrue())
+					g.Expect(nodeStatus.Active).Should(gomega.Equal(ptr.To(int32(1))))
+					g.Expect(nodeStatus.Failed).Should(gomega.Equal(ptr.To(int32(0))))
 				}, util.TimeoutE2E, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -183,24 +169,14 @@ var _ = ginkgo.Describe("TrainJob e2e", func() {
 							Message: jobsetconsts.AllJobsCompletedMessage,
 						},
 					}, util.IgnoreConditions))
-					g.Expect(gotTrainJob.Status.JobsStatus).Should(gomega.BeComparableTo([]trainer.JobStatus{
-						{
-							Name:      constants.Launcher,
-							Ready:     ptr.To(int32(0)),
-							Succeeded: ptr.To(int32(1)),
-							Failed:    ptr.To(int32(0)),
-							Active:    ptr.To(int32(0)),
-							Suspended: ptr.To(int32(0)),
-						},
-						{
-							Name:      constants.Node,
-							Ready:     ptr.To(int32(0)),
-							Succeeded: ptr.To(int32(0)),
-							Failed:    ptr.To(int32(0)),
-							Active:    ptr.To(int32(0)),
-							Suspended: ptr.To(int32(0)),
-						},
-					}, util.SortJobsStatus))
+					launcherStatus, ok := jobStatusByName(gotTrainJob.Status.JobsStatus, constants.Launcher)
+					g.Expect(ok).Should(gomega.BeTrue())
+					g.Expect(launcherStatus.Succeeded).Should(gomega.Equal(ptr.To(int32(1))))
+					g.Expect(launcherStatus.Failed).Should(gomega.Equal(ptr.To(int32(0))))
+
+					nodeStatus, ok := jobStatusByName(gotTrainJob.Status.JobsStatus, constants.Node)
+					g.Expect(ok).Should(gomega.BeTrue())
+					g.Expect(nodeStatus.Failed).Should(gomega.Equal(ptr.To(int32(0))))
 				}, util.TimeoutE2E, util.Interval).Should(gomega.Succeed())
 			})
 		})
@@ -880,3 +856,12 @@ var _ = ginkgo.Describe("TrainJob e2e", func() {
 		)
 	})
 })
+
+func jobStatusByName(statuses []trainer.JobStatus, name string) (trainer.JobStatus, bool) {
+	for _, status := range statuses {
+		if status.Name == name {
+			return status, true
+		}
+	}
+	return trainer.JobStatus{}, false
+}

--- a/test/integration/controller/trainjob_controller_test.go
+++ b/test/integration/controller/trainjob_controller_test.go
@@ -1078,6 +1078,13 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 					RuntimeSpec(
 						testingutil.MakeTrainingRuntimeSpecWrapper(testingutil.MakeTrainingRuntimeWrapper(ns.Name, "alpha").Spec).
 							LauncherReplica().
+							DependsOn(
+								constants.Launcher,
+								jobsetv1alpha2.DependsOn{
+									Name:   constants.Node,
+									Status: jobsetv1alpha2.DependencyReady,
+								},
+							).
 							Replicas(1, constants.Launcher).
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
@@ -1106,6 +1113,13 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 							ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), trainJobKey.Name, string(trainJob.UID)).
 							Suspend(false).
 							LauncherReplica().
+							DependsOn(
+								constants.Launcher,
+								jobsetv1alpha2.DependsOn{
+									Name:   constants.Node,
+									Status: jobsetv1alpha2.DependencyReady,
+								},
+							).
 							Replicas(1, constants.Node, constants.DatasetInitializer, constants.ModelInitializer, constants.Launcher).
 							Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Launcher).
 							Completions(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Launcher).


### PR DESCRIPTION
The DeepSpeed and MLX ClusterTrainingRuntimes are MPI-based, so the launcher SSHes into the worker pods to run `mpirun` and could fail its initial connections when it started before the workers' sshd was ready. This makes the launcher depend on the node replicated job reaching `Ready` via JobSet's `dependsOn` API, which also requires listing the node job ahead of the launcher (JobSet forbids `dependsOn` on the first replicated job) across both runtimes; integration and e2e tests are updated to cover the ordering and dependency.

Fixes: #2751

_This PR was created using AI tools._