### PR TITLE
fix: correct typos in AGENTS.md and deepspeed example notebook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ kubeflow/trainer/
 │   │       │   ├── jobset/                # JobSet plugin
 │   │       │   └── ...
 │   │       └── interface.go           # Framework interface definitions
-│   │       └── runtime.go             # Implementation of Info object which carries information trough the plugin chain.
+│   │       └── runtime.go             # Implementation of Info object which carries information through the plugin chain.
 │   ├── statusserver/                  # TrainJob status collection HTTPS server
 │   ├── webhooks/                    # Kubernetes validation/mutation webhooks for Trainer
 │   ├── data_cache/                  # Distributed in-memory cache (Rust)

--- a/examples/deepspeed/text-summarization/T5-Fine-Tuning.ipynb
+++ b/examples/deepspeed/text-summarization/T5-Fine-Tuning.ipynb
@@ -457,7 +457,7 @@
     "\n",
     "Use the `get_job_logs()` API to retrieve the TrainJob logs.\n",
     "\n",
-    "Since we distribute the dataset accross 8 GPUs (2 nodes x 4 GPUs), each rank processes `round(2000 / 8) = 250` samples."
+    "Since we distribute the dataset across 8 GPUs (2 nodes x 4 GPUs), each rank processes `round(2000 / 8) = 250` samples."
    ]
   },
   {


### PR DESCRIPTION
Fix two typos:
- AGENTS.md: trough -> through
- examples/deepspeed: accross -> across

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing
