### PR TITLE
fix(operator): improve status server bearer token parsing and add helper tests

### DIFF
--- a/pkg/statusserver/auth.go
+++ b/pkg/statusserver/auth.go
@@ -113,10 +113,14 @@ func (p *projectedServiceAccountTokenAuthorizer) Authorize(ctx context.Context, 
 	return true, nil
 }
 
+// extractRawToken returns the credentials of an RFC 7235 "Bearer" Authorization header.
+// The scheme is matched case-insensitively, and any amount of surrounding or separating
+// whitespace is tolerated. An empty string is returned when the header does not carry
+// exactly one bearer credential.
 func extractRawToken(authHeader string) string {
-	parts := strings.Split(authHeader, " ")
+	parts := strings.Fields(authHeader)
 
-	if len(parts) != 2 || parts[0] != "Bearer" {
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
 		return ""
 	}
 

--- a/pkg/statusserver/auth_test.go
+++ b/pkg/statusserver/auth_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statusserver
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestExtractRawToken(t *testing.T) {
+	testcases := map[string]struct {
+		authHeader string
+		wantToken  string
+	}{
+		"bearer token is extracted": {
+			authHeader: "Bearer token",
+			wantToken:  "token",
+		},
+		"scheme is matched case-insensitively": {
+			authHeader: "bearer token",
+			wantToken:  "token",
+		},
+		"repeated whitespace between scheme and credentials is tolerated": {
+			authHeader: "Bearer \t token",
+			wantToken:  "token",
+		},
+		"surrounding whitespace is tolerated": {
+			authHeader: "  Bearer token  ",
+			wantToken:  "token",
+		},
+		"empty header yields no token": {
+			authHeader: "",
+			wantToken:  "",
+		},
+		"whitespace-only header yields no token": {
+			authHeader: "   ",
+			wantToken:  "",
+		},
+		"missing credentials yield no token": {
+			authHeader: "Bearer",
+			wantToken:  "",
+		},
+		"missing scheme yields no token": {
+			authHeader: "token",
+			wantToken:  "",
+		},
+		"other authorization schemes yield no token": {
+			authHeader: "Basic dXNlcjpwYXNz",
+			wantToken:  "",
+		},
+		"scheme substring is not accepted": {
+			authHeader: "Bearerx token",
+			wantToken:  "",
+		},
+		"multiple credentials yield no token": {
+			authHeader: "Bearer token another",
+			wantToken:  "",
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			got := extractRawToken(tc.authHeader)
+
+			if diff := cmp.Diff(tc.wantToken, got); len(diff) != 0 {
+				t.Errorf("Unexpected token (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/statusserver/utils_test.go
+++ b/pkg/statusserver/utils_test.go
@@ -38,11 +38,6 @@ func TestTokenAudience(t *testing.T) {
 			name:         "test-job",
 			wantAudience: "trainer.kubeflow.org/v1alpha1/namespaces/kubeflow-system/trainjobs/test-job/status",
 		},
-		"empty namespace and name are not rejected": {
-			namespace:    "",
-			name:         "",
-			wantAudience: "trainer.kubeflow.org/v1alpha1/namespaces//trainjobs//status",
-		},
 	}
 
 	for name, tc := range testcases {
@@ -71,11 +66,6 @@ func TestStatusUrl(t *testing.T) {
 			namespace: "kubeflow-system",
 			name:      "test-job",
 			wantUrl:   "/apis/trainer.kubeflow.org/v1alpha1/namespaces/kubeflow-system/trainjobs/test-job/status",
-		},
-		"empty namespace and name are not rejected": {
-			namespace: "",
-			name:      "",
-			wantUrl:   "/apis/trainer.kubeflow.org/v1alpha1/namespaces//trainjobs//status",
 		},
 	}
 

--- a/pkg/statusserver/utils_test.go
+++ b/pkg/statusserver/utils_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statusserver
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestTokenAudience(t *testing.T) {
+	testcases := map[string]struct {
+		namespace    string
+		name         string
+		wantAudience string
+	}{
+		"audience is scoped to the TrainJob status endpoint": {
+			namespace:    "default",
+			name:         "test-job",
+			wantAudience: "trainer.kubeflow.org/v1alpha1/namespaces/default/trainjobs/test-job/status",
+		},
+		"audience is scoped to the TrainJob namespace": {
+			namespace:    "kubeflow-system",
+			name:         "test-job",
+			wantAudience: "trainer.kubeflow.org/v1alpha1/namespaces/kubeflow-system/trainjobs/test-job/status",
+		},
+		"empty namespace and name are not rejected": {
+			namespace:    "",
+			name:         "",
+			wantAudience: "trainer.kubeflow.org/v1alpha1/namespaces//trainjobs//status",
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			got := TokenAudience(tc.namespace, tc.name)
+
+			if diff := cmp.Diff(tc.wantAudience, got); len(diff) != 0 {
+				t.Errorf("Unexpected audience (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestStatusUrl(t *testing.T) {
+	testcases := map[string]struct {
+		namespace string
+		name      string
+		wantUrl   string
+	}{
+		"URL points at the TrainJob status endpoint": {
+			namespace: "default",
+			name:      "test-job",
+			wantUrl:   "/apis/trainer.kubeflow.org/v1alpha1/namespaces/default/trainjobs/test-job/status",
+		},
+		"URL is scoped to the TrainJob namespace": {
+			namespace: "kubeflow-system",
+			name:      "test-job",
+			wantUrl:   "/apis/trainer.kubeflow.org/v1alpha1/namespaces/kubeflow-system/trainjobs/test-job/status",
+		},
+		"empty namespace and name are not rejected": {
+			namespace: "",
+			name:      "",
+			wantUrl:   "/apis/trainer.kubeflow.org/v1alpha1/namespaces//trainjobs//status",
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			got := StatusUrl(tc.namespace, tc.name)
+
+			if diff := cmp.Diff(tc.wantUrl, got); len(diff) != 0 {
+				t.Errorf("Unexpected URL (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This picks up the work started in #3405, which went stale before it could be merged.

`pkg/statusserver` has three small helpers that sit directly on the auth and routing path but had no direct unit coverage: `extractRawToken`, `TokenAudience` and `StatusUrl`. This PR adds tests for all three, and fixes a real parsing bug that the tests made obvious.

`extractRawToken` split the `Authorization` header on a literal `" "` and compared the scheme with `==`. RFC 7235 makes the auth-scheme case-insensitive, and clients can put more than one space between the scheme and the credentials, so `bearer <token>` or `Bearer  <token>` produced an empty token and a `403 Forbidden` that is hard to diagnose from the trainer side. Parsing with `strings.Fields` and comparing with `strings.EqualFold` tolerates case and surrounding/repeated whitespace, while still rejecting anything that is not exactly one bearer credential — `strings.Fields` also can never yield an empty token, so `Bearer` on its own is still rejected.

Changes:

- `pkg/statusserver/auth.go`: parse the bearer header with `strings.Fields` + `strings.EqualFold`, and document the accepted forms on the function.
- `pkg/statusserver/auth_test.go` (new): 11 cases for `extractRawToken`, covering scheme casing, whitespace handling, missing scheme/credentials, other schemes, `Bearerx` as a near-miss scheme, and multiple credentials.
- `pkg/statusserver/utils_test.go` (new): cases for `TokenAudience` and `StatusUrl`.

Test cases are defined as maps keyed by the case name and compared with `cmp.Diff`, per the Go testing conventions in `CONTRIBUTING.md` and @robert-bell's review comment on #3405. Both new files carry the standard boilerplate header so `make verify-boilerplate` stays green.

Verified locally with `go test ./pkg/statusserver/...`, `go vet ./pkg/statusserver/...`, `gofmt -l` and `golangci-lint run ./pkg/statusserver/...` (0 issues).

**Which issue(s) this PR fixes**:
Fixes #3404

**Checklist:**

- [x] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing

_This PR was created using AI tools._
