### PR TITLE
fix(ci): Publish images during the GitHub release workflow

### DIFF
--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -26,6 +26,18 @@ on:
       - 'docs/**'
       - 'proposals/**'
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      version:
+        description: explicit image tag (e.g. v2.3.0-rc.0) to publish
+        required: false
+        type: string
+        default: ""
+      publish:
+        description: whether to push the built images to registries
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-and-publish:
@@ -33,8 +45,12 @@ jobs:
     if: github.repository == 'kubeflow/trainer'
     runs-on: cncf-ubuntu-16-64-x86
 
+    permissions:
+      contents: read
+      packages: write
+
     env:
-      SHOULD_PUBLISH: ${{ github.event_name == 'push' }}
+      SHOULD_PUBLISH: ${{ inputs.publish || github.event_name == 'push' }}
 
     strategy:
       fail-fast: false
@@ -95,7 +111,7 @@ jobs:
             docker.io/kubeflow/${{ matrix.component-name }}
           dockerfile: ${{ matrix.dockerfile }}
           platforms: ${{ matrix.platforms }}
-          context: ${{ matrix.context }}
+          version: ${{ inputs.version }}
           push: true
 
       - name: Test Build For Component ${{ matrix.component-name }}
@@ -107,5 +123,5 @@ jobs:
             docker.io/kubeflow/${{ matrix.component-name }}
           dockerfile: ${{ matrix.dockerfile }}
           platforms: ${{ matrix.platforms }}
-          context: ${{ matrix.context }}
+          version: ${{ inputs.version }}
           push: false

--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -28,6 +28,11 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      ref:
+        description: git ref (tag, branch, or SHA) to check out and build the images from
+        required: false
+        type: string
+        default: ""
       version:
         description: explicit image tag (e.g. v2.3.0-rc.0) to publish
         required: false
@@ -84,6 +89,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Checkout to the release tag when called from the release workflow.
+          ref: ${{ inputs.ref }}
 
       - name: GHCR Login
         if: env.SHOULD_PUBLISH == 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -170,9 +170,21 @@ jobs:
           git tag "$TAG"
           git push origin "$TAG"
 
+  publish-images:
+    name: Build and Publish Images
+    needs: [prepare, build, create-tag]
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build-and-push-images.yaml
+    with:
+      version: ${{ needs.prepare.outputs.version }}
+      publish: true
+    secrets: inherit
+
   publish-pypi:
     name: Publish to PyPI
-    needs: [prepare, build, create-tag]
+    needs: [prepare, build, create-tag, publish-images]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -194,7 +206,7 @@ jobs:
 
   github-release:
     name: Create GitHub release
-    needs: [prepare, build, create-tag, publish-pypi]
+    needs: [prepare, build, create-tag, publish-images, publish-pypi]
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -246,8 +258,16 @@ jobs:
           tag_name: ${{ needs.prepare.outputs.version }}
           name: ${{ needs.prepare.outputs.version }}
           body: ${{ steps.changelog.outputs.changelog }}
-          draft: false
+          # Create the release as a draft so assets are uploaded before publication.
+          # With immutable releases enabled, a published release locks its assets, so
+          # they must be attached while the release is still a draft.
+          draft: true
           prerelease: ${{ needs.prepare.outputs.is-prerelease == 'true' }}
           generate_release_notes: false
           files: |
             dist/*
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ needs.prepare.outputs.version }}" --draft=false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -178,6 +178,7 @@ jobs:
       packages: write
     uses: ./.github/workflows/build-and-push-images.yaml
     with:
+      ref: ${{ needs.prepare.outputs.version }}
       version: ${{ needs.prepare.outputs.version }}
       publish: true
     secrets: inherit

--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -33,6 +33,10 @@ inputs:
   push:
     required: true
     description: whether to push container images or not
+  version:
+    required: false
+    default: ""
+    description: explicit image tag (e.g. v2.3.0-rc.0) for builds not triggered by a tag push
 
 runs:
   using: composite
@@ -95,6 +99,7 @@ runs:
         tags: |
           type=ref,event=tag
           type=sha
+          type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
 
     - name: Build and Push
       uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5

--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -98,7 +98,7 @@ runs:
         images: ${{ inputs.image }}
         tags: |
           type=ref,event=tag
-          type=sha
+          type=sha,enable=${{ inputs.version == '' }}
           type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
 
     - name: Build and Push


### PR DESCRIPTION
This should publish images during our release automation. Otherwise, it doesn't trigger push.

Also, this should fix this error in release publish:

```
Error: Cannot upload asset kubeflow_trainer_api-2.3.0rc0.tar.gz to an immutable release. GitHub only allows asset uploads before a release is published, but draft prereleases publish with the release.published event instead of release.prereleased. If you need prereleases with assets on an immutable-release repository, keep the release as a draft with draft: true, then publish it later from that draft and subscribe downstream workflows to release.published.
```

/assign @Sridhar1030 @robert-bell @astefanutti @tenzen-y @akshaychitneni @VassilisVassiliadis @abhijeet-dhumal @jaiakash 