### PR TITLE
fix(ci): Publish Helm Charts in the release workflow

### DIFF
--- a/.github/workflows/publish-helm-charts.yaml
+++ b/.github/workflows/publish-helm-charts.yaml
@@ -21,6 +21,13 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: git ref (tag) to check out and publish the chart from
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -39,6 +46,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Checkout to the release tag when called from the release workflow.
+          ref: ${{ inputs.ref }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
@@ -49,7 +59,7 @@ jobs:
 
       - name: Build, package, and push Helm chart
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "${{ github.ref }}" == refs/tags/* || -n "${{ inputs.ref }}" ]]; then
             VERSION=$(grep '^version:' ${{ env.CHART_PATH }}/Chart.yaml | awk '{print $2}')
           else
             VERSION="0.0.0-sha-$(git rev-parse --short=7 HEAD)"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,14 +26,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   prepare:
     name: Prepare release branch
     runs-on: ubuntu-latest
     environment:
       name: release
-    permissions:
-      contents: write
     outputs:
       version: ${{ steps.vars.outputs.version }}
       branch: ${{ steps.vars.outputs.branch }}
@@ -149,8 +151,6 @@ jobs:
   create-tag:
     name: Create and push tag
     needs: [prepare, build]
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
 
     steps:
@@ -173,14 +173,19 @@ jobs:
   publish-images:
     name: Build and Publish Images
     needs: [prepare, build, create-tag]
-    permissions:
-      contents: read
-      packages: write
     uses: ./.github/workflows/build-and-push-images.yaml
     with:
       ref: ${{ needs.prepare.outputs.version }}
       version: ${{ needs.prepare.outputs.version }}
       publish: true
+    secrets: inherit
+
+  publish-charts:
+    name: Publish Helm Charts
+    needs: [prepare, publish-images]
+    uses: ./.github/workflows/publish-helm-charts.yaml
+    with:
+      ref: ${{ needs.prepare.outputs.version }}
     secrets: inherit
 
   publish-pypi:
@@ -207,13 +212,9 @@ jobs:
 
   github-release:
     name: Create GitHub release
-    needs: [prepare, build, create-tag, publish-images, publish-pypi]
-    permissions:
-      contents: write
+    needs:
+      [prepare, build, create-tag, publish-images, publish-charts, publish-pypi]
     runs-on: ubuntu-latest
-    environment:
-      name: release
-      url: https://github.com/kubeflow/trainer/releases
 
     steps:
       - name: Checkout release branch


### PR DESCRIPTION
We should also publish Helm Charts in the release workflow.


/assign @Sridhar1030 @robert-bell @astefanutti @tenzen-y @akshaychitneni @VassilisVassiliadis @abhijeet-dhumal @jaiakash
