### PR TITLE
fix(ci): Remove concurrency from Helm publish action

### DIFF
--- a/.github/workflows/publish-helm-charts.yaml
+++ b/.github/workflows/publish-helm-charts.yaml
@@ -29,10 +29,6 @@ on:
         type: string
         default: ""
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
-
 env:
   CHART_PATH: charts/kubeflow-trainer
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -190,7 +190,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [prepare, build, create-tag, publish-images]
+    needs: [prepare, build, create-tag, publish-images, publish-charts]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -209,6 +209,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
         with:
           print-hash: true
+          skip-existing: true
 
   github-release:
     name: Create GitHub release


### PR DESCRIPTION
This causes deadlock in the release workflow.

```
Canceling since a deadlock was detected for concurrency group: 'Release-refs/heads/master' between a top level workflow and 'Publish Helm Charts'
```

cc @robert-bell @Sridhar1030 @tenzen-y @astefanutti @abhijeet-dhumal @h0pers 