### PR TITLE
chore(docs): update helm install VERSION to v2.2.1

### DIFF
--- a/charts/kubeflow-trainer/README.md
+++ b/charts/kubeflow-trainer/README.md
@@ -22,7 +22,7 @@ This chart bootstraps a [Kubernetes Trainer](https://github.com/kubeflow/trainer
 Install the released version:
 
 ```bash
-export VERSION=v2.1.0
+export VERSION=v2.2.1
 helm install kubeflow-trainer oci://ghcr.io/kubeflow/charts/kubeflow-trainer \
     --namespace kubeflow-system \
     --create-namespace \


### PR DESCRIPTION
**What this PR does / why we need it**

The Helm chart README install example still pointed at v2.1.0. I updated it to v2.2.1 so it matches the latest stable release. This way people following the install steps get the version they actually expect.

Fixes #3807

**Checklist:**

- [x] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing
