### PR TITLE
fix(api): add missing lower bounds to numeric API fields

### DIFF
--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_clustertrainingruntimes.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_clustertrainingruntimes.yaml
@@ -100,6 +100,9 @@ spec:
                           Defaults to 1.
                         format: int32
                         type: integer
+                        x-kubernetes-validations:
+                        - message: NumProcPerNode in mpiPolicy must be >= 1
+                          rule: self >= 1
                       runLauncherAsNode:
                         default: false
                         description: |-
@@ -120,6 +123,9 @@ spec:
                       Defaults to 1.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: NumNodes in mlPolicy must be >= 1
+                      rule: self >= 1
                   torch:
                     description: torch defines the configuration for the PyTorch runtime.
                     properties:
@@ -204,6 +210,7 @@ spec:
                           If the scheduling timeout is equal to 0, the default value is used.
                           Defaults to 60 seconds.
                         format: int32
+                        minimum: 0
                         type: integer
                     type: object
                   volcano:

--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainingruntimes.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainingruntimes.yaml
@@ -100,6 +100,9 @@ spec:
                           Defaults to 1.
                         format: int32
                         type: integer
+                        x-kubernetes-validations:
+                        - message: NumProcPerNode in mpiPolicy must be >= 1
+                          rule: self >= 1
                       runLauncherAsNode:
                         default: false
                         description: |-
@@ -120,6 +123,9 @@ spec:
                       Defaults to 1.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: NumNodes in mlPolicy must be >= 1
+                      rule: self >= 1
                   torch:
                     description: torch defines the configuration for the PyTorch runtime.
                     properties:
@@ -204,6 +210,7 @@ spec:
                           If the scheduling timeout is equal to 0, the default value is used.
                           Defaults to 60 seconds.
                         format: int32
+                        minimum: 0
                         type: integer
                     type: object
                   volcano:

--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
@@ -5795,6 +5795,9 @@ spec:
                     description: numNodes is the number of training nodes.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: NumNodes in trainer must be >= 1
+                      rule: self >= 1
                   numProcPerNode:
                     description: |-
                       numProcPerNode is the number of processes/workers/slots on every training node.
@@ -5802,6 +5805,9 @@ spec:
                       For the Torch runtime the value defaults to `auto` and can be overridden with an int.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: NumProcPerNode in trainer must be >= 1
+                      rule: self >= 1
                   resourcesPerNode:
                     description: resourcesPerNode defines the compute resources for
                       each training node.

--- a/manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
@@ -97,6 +97,9 @@ spec:
                           Defaults to 1.
                         format: int32
                         type: integer
+                        x-kubernetes-validations:
+                        - message: NumProcPerNode in mpiPolicy must be >= 1
+                          rule: self >= 1
                       runLauncherAsNode:
                         default: false
                         description: |-
@@ -117,6 +120,9 @@ spec:
                       Defaults to 1.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: NumNodes in mlPolicy must be >= 1
+                      rule: self >= 1
                   torch:
                     description: torch defines the configuration for the PyTorch runtime.
                     properties:
@@ -201,6 +207,7 @@ spec:
                           If the scheduling timeout is equal to 0, the default value is used.
                           Defaults to 60 seconds.
                         format: int32
+                        minimum: 0
                         type: integer
                     type: object
                   volcano:

--- a/manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
@@ -97,6 +97,9 @@ spec:
                           Defaults to 1.
                         format: int32
                         type: integer
+                        x-kubernetes-validations:
+                        - message: NumProcPerNode in mpiPolicy must be >= 1
+                          rule: self >= 1
                       runLauncherAsNode:
                         default: false
                         description: |-
@@ -117,6 +120,9 @@ spec:
                       Defaults to 1.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: NumNodes in mlPolicy must be >= 1
+                      rule: self >= 1
                   torch:
                     description: torch defines the configuration for the PyTorch runtime.
                     properties:
@@ -201,6 +207,7 @@ spec:
                           If the scheduling timeout is equal to 0, the default value is used.
                           Defaults to 60 seconds.
                         format: int32
+                        minimum: 0
                         type: integer
                     type: object
                   volcano:

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -5792,6 +5792,9 @@ spec:
                     description: numNodes is the number of training nodes.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: NumNodes in trainer must be >= 1
+                      rule: self >= 1
                   numProcPerNode:
                     description: |-
                       numProcPerNode is the number of processes/workers/slots on every training node.
@@ -5799,6 +5802,9 @@ spec:
                       For the Torch runtime the value defaults to `auto` and can be overridden with an int.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: NumProcPerNode in trainer must be >= 1
+                      rule: self >= 1
                   resourcesPerNode:
                     description: resourcesPerNode defines the compute resources for
                       each training node.

--- a/pkg/apis/trainer/v1alpha1/trainingruntime_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainingruntime_types.go
@@ -157,6 +157,7 @@ type CoschedulingPodGroupPolicySource struct {
 	// If the scheduling timeout is equal to 0, the default value is used.
 	// Defaults to 60 seconds.
 	// +kubebuilder:default=60
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	ScheduleTimeoutSeconds *int32 `json:"scheduleTimeoutSeconds,omitempty"`
 }
@@ -173,6 +174,7 @@ type VolcanoPodGroupPolicySource struct {
 type MLPolicy struct {
 	// numNodes is the number of training nodes.
 	// Defaults to 1.
+	// +kubebuilder:validation:XValidation:rule="self >= 1",message="NumNodes in mlPolicy must be >= 1"
 	// +optional
 	NumNodes *int32 `json:"numNodes,omitempty"`
 
@@ -274,6 +276,7 @@ type MPIMLPolicySource struct {
 	// This value is equal to the number of slots for each node in the hostfile.
 	// Defaults to 1.
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:XValidation:rule="self >= 1",message="NumProcPerNode in mpiPolicy must be >= 1"
 	// +optional
 	NumProcPerNode *int32 `json:"numProcPerNode,omitempty"`
 

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -274,6 +274,7 @@ type Trainer struct {
 
 	// numNodes is the number of training nodes.
 	// TODO (andreyvelich): Do we want to support dynamic num of nodes in TrainJob for PyTorch elastic: `--nnodes=1:4` ?
+	// +kubebuilder:validation:XValidation:rule="self >= 1",message="NumNodes in trainer must be >= 1"
 	// +optional
 	NumNodes *int32 `json:"numNodes,omitempty"`
 
@@ -284,6 +285,7 @@ type Trainer struct {
 	// numProcPerNode is the number of processes/workers/slots on every training node.
 	// For the MPI runtime only int value can be set to represent number of slots per node.
 	// For the Torch runtime the value defaults to `auto` and can be overridden with an int.
+	// +kubebuilder:validation:XValidation:rule="self >= 1",message="NumProcPerNode in trainer must be >= 1"
 	// +optional
 	NumProcPerNode *int32 `json:"numProcPerNode,omitempty"`
 }

--- a/test/integration/webhooks/trainingruntime_webhook_test.go
+++ b/test/integration/webhooks/trainingruntime_webhook_test.go
@@ -222,6 +222,52 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 				},
 				testingutil.BeInvalidError(),
 			),
+			ginkgo.Entry("Should succeed to create trainingRuntime with mlPolicy.numNodes=1",
+				func() *trainer.TrainingRuntime {
+					return makeRuntimeWithNumNodes(ns.Name, 1)
+				},
+				gomega.Succeed()),
+			ginkgo.Entry("Should fail to create trainingRuntime with mlPolicy.numNodes=0",
+				func() *trainer.TrainingRuntime {
+					return makeRuntimeWithNumNodes(ns.Name, 0)
+				},
+				testingutil.BeInvalidError()),
+			ginkgo.Entry("Should fail to create trainingRuntime with negative mlPolicy.numNodes",
+				func() *trainer.TrainingRuntime {
+					return makeRuntimeWithNumNodes(ns.Name, -1)
+				},
+				testingutil.BeInvalidError()),
+			ginkgo.Entry("Should succeed to create trainingRuntime with mpi.numProcPerNode=1",
+				func() *trainer.TrainingRuntime {
+					return makeRuntimeWithMPINumProcPerNode(ns.Name, 1)
+				},
+				gomega.Succeed()),
+			ginkgo.Entry("Should fail to create trainingRuntime with mpi.numProcPerNode=0",
+				func() *trainer.TrainingRuntime {
+					return makeRuntimeWithMPINumProcPerNode(ns.Name, 0)
+				},
+				testingutil.BeInvalidError()),
+			ginkgo.Entry("Should fail to create trainingRuntime with negative mpi.numProcPerNode",
+				func() *trainer.TrainingRuntime {
+					return makeRuntimeWithMPINumProcPerNode(ns.Name, -1)
+				},
+				testingutil.BeInvalidError()),
+			ginkgo.Entry("Should succeed to create trainingRuntime with positive coscheduling.scheduleTimeoutSeconds",
+				func() *trainer.TrainingRuntime {
+					return makeRuntimeWithScheduleTimeout(ns.Name, 120)
+				},
+				gomega.Succeed()),
+			// Zero stays valid because it is documented to select the default timeout.
+			ginkgo.Entry("Should succeed to create trainingRuntime with coscheduling.scheduleTimeoutSeconds=0",
+				func() *trainer.TrainingRuntime {
+					return makeRuntimeWithScheduleTimeout(ns.Name, 0)
+				},
+				gomega.Succeed()),
+			ginkgo.Entry("Should fail to create trainingRuntime with negative coscheduling.scheduleTimeoutSeconds",
+				func() *trainer.TrainingRuntime {
+					return makeRuntimeWithScheduleTimeout(ns.Name, -1)
+				},
+				testingutil.BeInvalidError()),
 		)
 		ginkgo.DescribeTable("Defaulting TrainingRuntime on creation", func(trainingRuntime func() *trainer.TrainingRuntime, wantTrainingRuntime func() *trainer.TrainingRuntime) {
 			created := trainingRuntime()
@@ -412,3 +458,35 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 		)
 	})
 })
+
+func makeRuntimeWithMLPolicy(nsName string, policy *trainer.MLPolicy) *trainer.TrainingRuntime {
+	base := testingutil.MakeTrainingRuntimeWrapper(nsName, "runtime")
+	return base.
+		RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(base.Obj().Spec).
+			WithMLPolicy(policy).
+			Obj()).
+		Obj()
+}
+
+func makeRuntimeWithNumNodes(nsName string, numNodes int32) *trainer.TrainingRuntime {
+	return makeRuntimeWithMLPolicy(nsName, testingutil.MakeMLPolicyWrapper().
+		WithNumNodes(numNodes).
+		Obj())
+}
+
+func makeRuntimeWithMPINumProcPerNode(nsName string, numProcPerNode int32) *trainer.TrainingRuntime {
+	return makeRuntimeWithMLPolicy(nsName, testingutil.MakeMLPolicyWrapper().
+		WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+			MPIPolicy(ptr.To(numProcPerNode), trainer.MPIImplementationOpenMPI, nil, nil).
+			Obj()).
+		Obj())
+}
+
+func makeRuntimeWithScheduleTimeout(nsName string, timeout int32) *trainer.TrainingRuntime {
+	base := testingutil.MakeTrainingRuntimeWrapper(nsName, "runtime")
+	return base.
+		RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(base.Obj().Spec).
+			PodGroupPolicyCoschedulingSchedulingTimeout(timeout).
+			Obj()).
+		Obj()
+}

--- a/test/integration/webhooks/trainjob_test.go
+++ b/test/integration/webhooks/trainjob_test.go
@@ -199,6 +199,8 @@ var _ = ginkgo.Describe("TrainJob Webhook", ginkgo.Ordered, func() {
 				},
 				testingutil.BeForbiddenError()),
 
+			// The spec.trainer.numProcPerNode marker now rejects this at schema validation,
+			// before the Flux plugin's own check can return a Forbidden error.
 			ginkgo.Entry("Should fail in creating TrainJob with Flux numProcPerNode < 1",
 				func() *trainer.TrainJob {
 					trainingRuntime.Spec.MLPolicy = &trainer.MLPolicy{
@@ -218,7 +220,7 @@ var _ = ginkgo.Describe("TrainJob Webhook", ginkgo.Ordered, func() {
 						}).
 						Obj()
 				},
-				testingutil.BeForbiddenError(),
+				testingutil.BeInvalidError(),
 			),
 			ginkgo.Entry("Should fail in creating TrainJob with reserved flux-installer init container",
 				func() *trainer.TrainJob {
@@ -688,6 +690,36 @@ var _ = ginkgo.Describe("TrainJob marker validations and defaulting", ginkgo.Ord
 						Obj()
 				},
 				gomega.Succeed()),
+			ginkgo.Entry("Should succeed to create TrainJob with trainer.numNodes=1",
+				func() *trainer.TrainJob {
+					return makeTrainJobWithTrainer(ns.Name, testingutil.MakeTrainJobTrainerWrapper().NumNodes(1).Obj())
+				},
+				gomega.Succeed()),
+			ginkgo.Entry("Should fail to create TrainJob with trainer.numNodes=0",
+				func() *trainer.TrainJob {
+					return makeTrainJobWithTrainer(ns.Name, testingutil.MakeTrainJobTrainerWrapper().NumNodes(0).Obj())
+				},
+				testingutil.BeInvalidError()),
+			ginkgo.Entry("Should fail to create TrainJob with negative trainer.numNodes",
+				func() *trainer.TrainJob {
+					return makeTrainJobWithTrainer(ns.Name, testingutil.MakeTrainJobTrainerWrapper().NumNodes(-1).Obj())
+				},
+				testingutil.BeInvalidError()),
+			ginkgo.Entry("Should succeed to create TrainJob with trainer.numProcPerNode=1",
+				func() *trainer.TrainJob {
+					return makeTrainJobWithTrainer(ns.Name, testingutil.MakeTrainJobTrainerWrapper().NumProcPerNode(1).Obj())
+				},
+				gomega.Succeed()),
+			ginkgo.Entry("Should fail to create TrainJob with trainer.numProcPerNode=0",
+				func() *trainer.TrainJob {
+					return makeTrainJobWithTrainer(ns.Name, testingutil.MakeTrainJobTrainerWrapper().NumProcPerNode(0).Obj())
+				},
+				testingutil.BeInvalidError()),
+			ginkgo.Entry("Should fail to create TrainJob with negative trainer.numProcPerNode",
+				func() *trainer.TrainJob {
+					return makeTrainJobWithTrainer(ns.Name, testingutil.MakeTrainJobTrainerWrapper().NumProcPerNode(-1).Obj())
+				},
+				testingutil.BeInvalidError()),
 		)
 		ginkgo.DescribeTable("Defaulting TrainJob on creation", func(trainJob func() *trainer.TrainJob, wantTrainJob func() *trainer.TrainJob) {
 			created := trainJob()
@@ -905,3 +937,10 @@ var _ = ginkgo.Describe("TrainJob marker validations and defaulting", ginkgo.Ord
 		)
 	})
 })
+
+func makeTrainJobWithTrainer(nsName string, tr *trainer.Trainer) *trainer.TrainJob {
+	return testingutil.MakeTrainJobWrapper(nsName, "trainer-numeric-markers").
+		RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), "testing").
+		Trainer(tr).
+		Obj()
+}


### PR DESCRIPTION
## Summary

Several v1alpha1 numeric fields carry a documented default but no lower bound. `scheduleTimeoutSeconds` reaches the scheduler-plugins `PodGroup` unchanged, so a negative timeout expires the group the moment it is created. `numNodes` becomes the JobSet's `Parallelism` and `Completions`, so a non-positive value surfaces only when the Job API rejects it, with an error that never names the TrainJob field responsible.

#3836 reports the coscheduling field. It is one of five — the same gap exists on `mlPolicy.numNodes`, `mlPolicy.mpi.numProcPerNode`, `trainer.numNodes` and `trainer.numProcPerNode`. `FluxMLPolicySource.numProcPerNode` already carried `self >= 1`, so this extends that bound rather than introducing a second convention. Zero stays valid for `scheduleTimeoutSeconds`, which is documented to select the default.

## Change

Two decisions the diff doesn't explain. The count fields use CEL rather than `Minimum=1` because `kubeapilinter`'s `optionalfields` rule rejects `Minimum=1` on an optional pointer — once zero is invalid, it argues the pointer is unnecessary. These fields rely on `nil` meaning "unset, use the default" throughout the runtime, so dropping the pointer isn't available; `scheduleTimeoutSeconds` keeps `Minimum=0`.

The Flux plugin's own `numProcPerNode` check can no longer see a value below 1, now that both its inputs are bounded at the schema. I left it as defence in depth rather than widen this PR into plugin logic, but am happy to remove it instead.

## Behavior change

An object already stored with one of these values now fails admission when that field is updated. Ratcheting covers updates that leave it untouched.

## Tests

Admission coverage for negative, zero and positive values on each field. The one existing test that reached the Flux check now asserts `Invalid` rather than `Forbidden`, since the schema rejects the object first.

**Which issue(s) this PR fixes**:
Fixes #3836

**Checklist:**

- [x] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing — the field descriptions are generated from the API markers, so the regenerated CRDs carry the change.

---

_AI assistance disclosure: written with Claude Code (Opus 5). I reviewed the diff and verified the validation gap and the `Parallelism`/`Completions` path against the current source before submitting._
