### PR TITLE
fix(cache): propagate Kubernetes API errors from the cache initializer

### DIFF
--- a/pkg/initializers/dataset/cache.py
+++ b/pkg/initializers/dataset/cache.py
@@ -14,6 +14,7 @@
 
 import logging
 import time
+from collections.abc import Callable
 from urllib.parse import urlparse
 
 from kubernetes import client, config
@@ -57,6 +58,41 @@ def parse_cache_storage_uri(storage_uri: str) -> tuple[str, str]:
         )
 
     return schema_name, table_name
+
+
+class CreatedResources:
+    """Kubernetes resources created by one invocation, undoable as a group."""
+
+    def __init__(self) -> None:
+        self._resources: list[tuple[str, Callable[[], object]]] = []
+
+    def create(
+        self,
+        description: str,
+        create: Callable[[], object],
+        delete: Callable[[], object],
+    ) -> None:
+        """Create a resource unless it already exists, tracking it for rollback."""
+        try:
+            create()
+        except ApiException as e:
+            # 409 means someone else owns it — usually this same initializer on an
+            # earlier attempt — so it must survive our rollback.
+            if e.status == 409:
+                logging.info(f"{description} already exists, skipping creation")
+                return
+            raise
+        logging.info(f"Created {description}")
+        self._resources.append((description, delete))
+
+    def roll_back(self) -> None:
+        """Delete what this invocation created, newest first, without masking the failure."""
+        for description, delete in reversed(self._resources):
+            try:
+                delete()
+                logging.info(f"Cleaned up {description}")
+            except Exception as cleanup_error:
+                logging.error(f"Error cleaning up {description}: {cleanup_error}")
 
 
 class CacheInitializer(utils.DatasetProvider):
@@ -132,7 +168,9 @@ class CacheInitializer(utils.DatasetProvider):
             )
         except ApiException as e:
             logging.error(f"Failed to get TrainJob {train_job_name}: {e}")
-            return
+            raise
+
+        resources = CreatedResources()
 
         try:
             # Create ServiceAccount
@@ -148,19 +186,16 @@ class CacheInitializer(utils.DatasetProvider):
                 )
             )
 
-            try:
-                core_v1.create_namespaced_service_account(
+            service_account_name = service_account.metadata.name
+            resources.create(
+                f"ServiceAccount {service_account_name}",
+                lambda: core_v1.create_namespaced_service_account(
                     namespace=namespace, body=service_account
-                )
-                logging.info(f"Created ServiceAccount {service_account.metadata.name}")
-            except ApiException as e:
-                if e.status == 409:
-                    logging.info(
-                        f"ServiceAccount {service_account.metadata.name} "
-                        f"already exists, skipping creation"
-                    )
-                else:
-                    raise e
+                ),
+                lambda: core_v1.delete_namespaced_service_account(
+                    name=service_account_name, namespace=namespace
+                ),
+            )
 
             # Prepare environment variables
             env_vars = []
@@ -268,14 +303,24 @@ class CacheInitializer(utils.DatasetProvider):
             }
 
             # Create LeaderWorkerSet
-            custom_api.create_namespaced_custom_object(
-                group="leaderworkerset.x-k8s.io",
-                version="v1",
-                namespace=namespace,
-                plural="leaderworkersets",
-                body=lws_body,
+            lws_name = lws_body["metadata"]["name"]
+            resources.create(
+                f"LeaderWorkerSet {lws_name}",
+                lambda: custom_api.create_namespaced_custom_object(
+                    group="leaderworkerset.x-k8s.io",
+                    version="v1",
+                    namespace=namespace,
+                    plural="leaderworkersets",
+                    body=lws_body,
+                ),
+                lambda: custom_api.delete_namespaced_custom_object(
+                    group="leaderworkerset.x-k8s.io",
+                    version="v1",
+                    namespace=namespace,
+                    plural="leaderworkersets",
+                    name=lws_name,
+                ),
             )
-            logging.info(f"Created LeaderWorkerSet {lws_body['metadata']['name']}")
 
             # Create Service
             service = client.V1Service(
@@ -294,17 +339,16 @@ class CacheInitializer(utils.DatasetProvider):
                 ),
             )
 
-            try:
-                core_v1.create_namespaced_service(namespace=namespace, body=service)
-                logging.info(f"Created Service {service.metadata.name}")
-            except ApiException as e:
-                if e.status == 409:
-                    logging.info(
-                        f"Service {service.metadata.name} already exists, "
-                        f"skipping creation"
-                    )
-                else:
-                    raise e
+            service_name = service.metadata.name
+            resources.create(
+                f"Service {service_name}",
+                lambda: core_v1.create_namespaced_service(
+                    namespace=namespace, body=service
+                ),
+                lambda: core_v1.delete_namespaced_service(
+                    name=service_name, namespace=namespace
+                ),
+            )
 
             # Wait for LeaderWorkerSet to become ready
             # TODO:// refactor to use watch API
@@ -332,15 +376,11 @@ class CacheInitializer(utils.DatasetProvider):
                 except ApiException as e:
                     raise e
 
-        except ApiException as e:
+        # Not just ApiException: a connection error or a malformed response leaves the
+        # same half-built cluster behind, and it has to be rolled back too.
+        except Exception as e:
             logging.error(f"Cache cluster creation failed: {e}")
-            # Cleanup on failure
-            try:
-                core_v1.delete_namespaced_service_account(
-                    name=f"{train_job_name}-cache", namespace=namespace
-                )
-            except Exception as cleanup_error:
-                logging.error(f"Error cleaning up ServiceAccount: {cleanup_error}")
-            return
+            resources.roll_back()
+            raise
 
         logging.info("Cache cluster creation completed")

--- a/pkg/initializers/dataset/cache_test.py
+++ b/pkg/initializers/dataset/cache_test.py
@@ -327,3 +327,143 @@ def test_download_dataset_service_already_exists():
 
         # Must not trigger cleanup of the ServiceAccount.
         mock_core_v1.delete_namespaced_service_account.assert_not_called()
+
+
+TRAIN_JOB = {
+    "apiVersion": "trainer.kubeflow.org/v1alpha1",
+    "kind": "TrainJob",
+    "metadata": {"name": "cache-job", "uid": "test-uid"},
+}
+
+LWS_READY = {"status": {"conditions": [{"type": "Available", "status": "True"}]}}
+
+
+def build_initializer() -> CacheInitializer:
+    """Build a CacheInitializer with a minimal valid config."""
+    initializer = CacheInitializer()
+    config = {
+        "storage_uri": "cache://test_schema/test_table",
+        "train_job_name": "cache-job",
+        "cache_image": "test-image:latest",
+        "iam_role": "arn:aws:iam::123456789012:role/test-role",
+        "metadata_loc": "s3://test-bucket/metadata",
+    }
+    with patch.object(utils, "get_config_from_env", return_value=config):
+        initializer.load_config()
+    return initializer
+
+
+@pytest.fixture
+def k8s_mocks():
+    """Patch the Kubernetes clients the cache initializer builds."""
+    with patch(
+        "pkg.initializers.dataset.cache.get_namespace", return_value="test-namespace"
+    ), patch("pkg.initializers.dataset.cache.config"), patch(
+        "pkg.initializers.dataset.cache.client"
+    ) as mock_client:
+        core_v1 = MagicMock()
+        custom_api = MagicMock()
+        mock_client.ApiClient.return_value = MagicMock()
+        mock_client.CoreV1Api.return_value = core_v1
+        mock_client.CustomObjectsApi.return_value = custom_api
+        # The real client echoes back the name given to V1ObjectMeta, and the
+        # initializer reads it off the object to address deletes.
+        mock_client.V1ServiceAccount.return_value.metadata.name = "cache-job-cache"
+        mock_client.V1Service.return_value.metadata.name = "cache-job-cache-service"
+        yield core_v1, custom_api
+
+
+def test_download_dataset_raises_when_trainjob_lookup_fails(k8s_mocks):
+    core_v1, custom_api = k8s_mocks
+    custom_api.get_namespaced_custom_object.side_effect = ApiException(status=500)
+
+    with pytest.raises(ApiException):
+        build_initializer().download_dataset()
+
+    core_v1.create_namespaced_service_account.assert_not_called()
+
+
+def test_download_dataset_keeps_preexisting_service_account_on_failure(k8s_mocks):
+    """A retry must not delete a ServiceAccount an earlier attempt left behind."""
+    core_v1, custom_api = k8s_mocks
+    core_v1.create_namespaced_service_account.side_effect = ApiException(
+        status=409, reason="AlreadyExists"
+    )
+    # A single-element side_effect turns an unexpected entry into the readiness
+    # loop into StopIteration rather than an endless hang.
+    custom_api.get_namespaced_custom_object.side_effect = [TRAIN_JOB]
+    custom_api.create_namespaced_custom_object.side_effect = ApiException(status=500)
+
+    with pytest.raises(ApiException):
+        build_initializer().download_dataset()
+
+    core_v1.delete_namespaced_service_account.assert_not_called()
+
+
+def test_download_dataset_leader_worker_set_already_exists(k8s_mocks):
+    core_v1, custom_api = k8s_mocks
+    custom_api.create_namespaced_custom_object.side_effect = ApiException(
+        status=409, reason="AlreadyExists"
+    )
+    custom_api.get_namespaced_custom_object.side_effect = [TRAIN_JOB, LWS_READY]
+
+    build_initializer().download_dataset()
+
+    core_v1.delete_namespaced_service_account.assert_not_called()
+
+
+def test_download_dataset_rolls_back_resources_it_created(k8s_mocks):
+    core_v1, custom_api = k8s_mocks
+    manager = MagicMock()
+    manager.attach_mock(core_v1, "core")
+    manager.attach_mock(custom_api, "custom")
+    custom_api.get_namespaced_custom_object.side_effect = [TRAIN_JOB]
+    core_v1.create_namespaced_service.side_effect = ApiException(status=500)
+
+    with pytest.raises(ApiException):
+        build_initializer().download_dataset()
+
+    core_v1.delete_namespaced_service_account.assert_called_once_with(
+        name="cache-job-cache", namespace="test-namespace"
+    )
+    custom_api.delete_namespaced_custom_object.assert_called_once_with(
+        group="leaderworkerset.x-k8s.io",
+        version="v1",
+        namespace="test-namespace",
+        plural="leaderworkersets",
+        name="cache-job-cache",
+    )
+    # The Service is what failed, so it was never ours to delete.
+    core_v1.delete_namespaced_service.assert_not_called()
+    # Newest first, so nothing is deleted while something still depends on it.
+    assert [name for name, _, _ in manager.mock_calls if ".delete_" in name] == [
+        "custom.delete_namespaced_custom_object",
+        "core.delete_namespaced_service_account",
+    ]
+
+
+def test_download_dataset_rolls_back_on_non_api_errors(k8s_mocks):
+    """A connection error is as half-built as a 500, and must roll back too."""
+    core_v1, custom_api = k8s_mocks
+    custom_api.get_namespaced_custom_object.side_effect = [TRAIN_JOB]
+    core_v1.create_namespaced_service.side_effect = ConnectionError("connection reset")
+
+    with pytest.raises(ConnectionError):
+        build_initializer().download_dataset()
+
+    core_v1.delete_namespaced_service_account.assert_called_once()
+    custom_api.delete_namespaced_custom_object.assert_called_once()
+
+
+def test_download_dataset_cleanup_failure_does_not_mask_original_error(k8s_mocks):
+    core_v1, custom_api = k8s_mocks
+    custom_api.get_namespaced_custom_object.side_effect = [TRAIN_JOB]
+    core_v1.create_namespaced_service.side_effect = ApiException(status=500)
+    custom_api.delete_namespaced_custom_object.side_effect = ApiException(status=403)
+
+    with pytest.raises(ApiException) as excinfo:
+        build_initializer().download_dataset()
+
+    assert excinfo.value.status == 500
+    # Best effort: one failed delete must not strand the rest of the rollback.
+    core_v1.delete_namespaced_service_account.assert_called_once()


### PR DESCRIPTION
**What this PR does / why we need it**:

The cache initializer logged Kubernetes API failures and returned normally, so the container exited 0 with no cache cluster created and the failure surfaced later as a missing table. Retries were worse: cleanup deleted the ServiceAccount by name regardless of who created it, so an attempt that found a pre-existing ServiceAccount and then conflicted on the LeaderWorkerSet deleted a resource it did not own and still reported success. That conflict was itself avoidable — LeaderWorkerSet creation lacked the `AlreadyExists` handling ServiceAccount and Service already had.

Creation now records only the resources it actually created, rolls those back newest-first on failure, and re-raises the original error so the container fails visibly. Rollback catches `Exception` rather than `ApiException` alone, since a connection error strands the same half-built cluster.

Behavior change: rollback now removes the LeaderWorkerSet and Service as well as the ServiceAccount, so a failed readiness wait tears the cluster down instead of leaving it in place.

Six regression tests cover the TrainJob lookup failure, the pre-existing-ServiceAccount retry, `LeaderWorkerSet` `AlreadyExists`, rollback ordering and ownership, non-`ApiException` failure, and a failing delete not masking the original error. All six fail on master.

**Which issue(s) this PR fixes**:
Fixes #3835

**Checklist:**

- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing

---

AI assistance disclosure: drafted with Claude Code (Opus 5); I reviewed the change and verified the tests locally.