### PR TITLE
fix(api): CEL validation fix to restore CI pipeline

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14409,7 +14409,7 @@
             "type": "string"
           },
           "metric": {
-            "description": "metric specifies the name of the objective metric to track. Defaults to \"loss\".",
+            "description": "metric specifies the name of the objective metric to track.",
             "type": "string"
           }
         }

--- a/api/python_api/kubeflow_trainer_api/models/trainer_v1alpha1_objective.py
+++ b/api/python_api/kubeflow_trainer_api/models/trainer_v1alpha1_objective.py
@@ -41,7 +41,7 @@ class TrainerV1alpha1Objective(BaseModel):
     TrainerV1alpha1Objective
     """ # noqa: E501
     direction: Optional[StrictStr] = Field(default=None, description="direction specifies the optimization goal. Defaults to \"Minimize\".")
-    metric: StrictStr = Field(description="metric specifies the name of the objective metric to track. Defaults to \"loss\".")
+    metric: StrictStr = Field(description="metric specifies the name of the objective metric to track.")
     __properties: ClassVar[List[str]] = ["direction", "metric"]
 
     model_config = ConfigDict(

--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_optimizationjobs.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_optimizationjobs.yaml
@@ -72,7 +72,7 @@ spec:
                       type: string
                     metric:
                       description: metric specifies the name of the objective metric
-                        to track. Defaults to "loss".
+                        to track.
                       maxLength: 64
                       minLength: 1
                       type: string
@@ -6236,7 +6236,7 @@ spec:
               rule: self.parallelTrials <= self.numTrials
             - message: Grid search requires all parameters to be Categorical; Uniform
                 and LogUniform are not supported.
-              rule: '!has(self.searchAlgorithm.grid) || self.parameters.all(p, has(p.categorical))'
+              rule: '!has(self.searchAlgorithm.grid) || self.parameters.all(p, has(p.searchSpace.categorical))'
           status:
             description: status is the status for the optimization job.
             properties:

--- a/manifests/base/crds/trainer.kubeflow.org_optimizationjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_optimizationjobs.yaml
@@ -69,7 +69,7 @@ spec:
                       type: string
                     metric:
                       description: metric specifies the name of the objective metric
-                        to track. Defaults to "loss".
+                        to track.
                       maxLength: 64
                       minLength: 1
                       type: string
@@ -6233,7 +6233,7 @@ spec:
               rule: self.parallelTrials <= self.numTrials
             - message: Grid search requires all parameters to be Categorical; Uniform
                 and LogUniform are not supported.
-              rule: '!has(self.searchAlgorithm.grid) || self.parameters.all(p, has(p.categorical))'
+              rule: '!has(self.searchAlgorithm.grid) || self.parameters.all(p, has(p.searchSpace.categorical))'
           status:
             description: status is the status for the optimization job.
             properties:

--- a/pkg/apis/trainer/v1alpha1/optimizationjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/optimizationjob_types.go
@@ -66,7 +66,7 @@ type OptimizationJobList struct {
 // OptimizationJobSpec defines the desired state of OptimizationJob.
 // +kubebuilder:validation:XValidation:rule="self == oldSelf",message="OptimizationJobSpec is immutable and cannot be updated after creation"
 // +kubebuilder:validation:XValidation:rule="self.parallelTrials <= self.numTrials",message="parallelTrials cannot exceed numTrials"
-// +kubebuilder:validation:XValidation:rule="!has(self.searchAlgorithm.grid) || self.parameters.all(p, has(p.categorical))",message="Grid search requires all parameters to be Categorical; Uniform and LogUniform are not supported."
+// +kubebuilder:validation:XValidation:rule="!has(self.searchAlgorithm.grid) || self.parameters.all(p, has(p.searchSpace.categorical))",message="Grid search requires all parameters to be Categorical; Uniform and LogUniform are not supported."
 type OptimizationJobSpec struct {
 	// objectives is the list of objectives to optimize.
 	// +listType=map

--- a/pkg/apis/trainer/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/trainer/v1alpha1/zz_generated.openapi.go
@@ -1335,7 +1335,7 @@ func schema_pkg_apis_trainer_v1alpha1_Objective(ref common.ReferenceCallback) co
 				Properties: map[string]spec.Schema{
 					"metric": {
 						SchemaProps: spec.SchemaProps{
-							Description: "metric specifies the name of the objective metric to track. Defaults to \"loss\".",
+							Description: "metric specifies the name of the objective metric to track.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/client/applyconfiguration/trainer/v1alpha1/objective.go
+++ b/pkg/client/applyconfiguration/trainer/v1alpha1/objective.go
@@ -25,7 +25,7 @@ import (
 // ObjectiveApplyConfiguration represents a declarative configuration of the Objective type for use
 // with apply.
 type ObjectiveApplyConfiguration struct {
-	// metric specifies the name of the objective metric to track. Defaults to "loss".
+	// metric specifies the name of the objective metric to track.
 	Metric *string `json:"metric,omitempty"`
 	// direction specifies the optimization goal. Defaults to "Minimize".
 	Direction *trainerv1alpha1.ObjectiveDirection `json:"direction,omitempty"`


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Fixes a validation bug in the `OptimizationJob` CRD where the CEL rule for Grid search incorrectly checked for `p.categorical` instead of traversing the proper nested field (`p.searchSpace.categorical`).

Regenerated CRD manifests to correct validations and a comment message.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #3749 

**Checklist:**

- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing
